### PR TITLE
Add extra metadata column to impact and feedback logs

### DIFF
--- a/data/feedback_log.csv
+++ b/data/feedback_log.csv
@@ -1,0 +1,1 @@
+ts_iso,astronaut,scenario,target_name,option_idx,rigidity_ok,ease_ok,issues,notes,extra

--- a/data/impact_log.csv
+++ b/data/impact_log.csv
@@ -1,0 +1,1 @@
+ts_iso,scenario,target_name,materials,weights,process_id,process_name,mass_final_kg,energy_kwh,water_l,crew_min,score,extra


### PR DESCRIPTION
## Summary
- add an `extra` metadata field to impact and feedback entries and ensure the CSV log files stay aligned
- include empty `extra` columns in the bundled CSV templates for backwards compatibility
- surface parsed metadata in the feedback & impact dashboard while handling legacy records that lack extra data

## Testing
- python3 -m compileall app/modules/impact.py app/pages/8_Feedback_and_Impact.py

------
https://chatgpt.com/codex/tasks/task_e_68cf84040a848331820b7967d773f1c6