### PR TITLE
Add Pareto optimizer integration to candidate generator

### DIFF
--- a/app/modules/generator.py
+++ b/app/modules/generator.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 import random
 from dataclasses import dataclass
+
 import pandas as pd
 
 @dataclass
@@ -76,124 +77,156 @@ def _pick_materials(df: pd.DataFrame, n: int = 2) -> pd.DataFrame:
     return df.sample(n=min(n, len(df)), weights=w, replace=False, random_state=None)
 
 def generate_candidates(waste_df: pd.DataFrame, proc_df: pd.DataFrame,
-                        target: dict, n: int = 6, crew_time_low: bool = False):
+                        target: dict, n: int = 6, crew_time_low: bool = False,
+                        optimizer_evals: int = 0):
     """
     Genera candidatos priorizando:
     - Consumir masa de ítems 'problemáticos' definidos por NASA.
     - Elegir procesos coherentes: P02 (laminado multicapa), P03 (sinter + MGS-1), P04 (reuso CTB).
     - Insertar explícitamente **regolito MGS-1** cuando el proceso sea P03.
+
+    Devuelve una tupla con el listado de candidatos y, si se habilita el
+    optimizador, un DataFrame con el historial de convergencia.
     """
     if waste_df is None or proc_df is None or len(waste_df) == 0 or len(proc_df) == 0:
-        return []
+        return [], pd.DataFrame()
 
     df = _ensure_compat(waste_df)
+    def _sampler() -> dict | None:
+        picks = _pick_materials(df, n=random.choice([2, 3]))
+        return _build_candidate(picks, proc_df, target, crew_time_low)
+
     out = []
-
     for _ in range(n):
-        picks = _pick_materials(df, n=random.choice([2,3]))
-        total_kg = max(0.001, float(picks["kg"].sum()))
-        weights = (picks["kg"] / total_kg).round(2).tolist()
+        cand = _sampler()
+        if cand:
+            out.append(cand)
 
-        used_ids   = picks["_source_id"].tolist()
-        used_cats  = picks["_source_category"].tolist()
-        used_flags = picks["_source_flags"].tolist()
-        used_mats  = picks["material"].tolist()
+    history = pd.DataFrame()
 
-        # Heurística de proceso:
-        proc = proc_df.sample(1).iloc[0]
-        cats_join = " ".join([str(c).lower() for c in used_cats])
-        flags_join = " ".join([str(f).lower() for f in used_flags])
+    if optimizer_evals and optimizer_evals > 0:
+        try:
+            from app.modules.optimizer import optimize_candidates
 
-        # Multicapa/pouches → favorecer laminación
-        if ("pouches" in cats_join) or ("multilayer" in flags_join) or ("pe-pet-al" in " ".join(used_mats).lower()):
-            cand = proc_df[proc_df["process_id"]=="P02"]
-            if not cand.empty:
-                proc = cand.iloc[0]
-
-        # Espumas → laminar o sinterizar con MGS-1
-        if ("foam" in cats_join) or ("zotek" in " ".join(used_mats).lower()):
-            cand = proc_df[proc_df["process_id"].isin(["P03","P02"])]
-            if not cand.empty:
-                proc = cand.sample(1).iloc[0]
-
-        # EVA/CTB → reconfigurar kit (reuso)
-        if ("eva" in cats_join) or ("ctb" in flags_join):
-            cand = proc_df[proc_df["process_id"]=="P04"]
-            if not cand.empty:
-                proc = cand.iloc[0]
-
-        # Cálculo recursos base
-        mass_final = total_kg * 0.90  # pérdida por recorte/mermas
-        energy = float(proc["energy_kwh_per_kg"]) * mass_final
-        water  = float(proc["water_l_per_kg"]) * mass_final
-        crew   = float(proc["crew_min_per_batch"])
-
-        # Propiedades (demo razonable)
-        # - Si hay Al → sube rigidez
-        # - Si hay pouches multilayer → sube estanqueidad
-        mats_join = " ".join(used_mats).lower()
-        rigidity  = min(1.0, 0.5 + (0.2 if "al" in mats_join or "aluminum" in mats_join else 0.0))
-        tightness = min(1.0, 0.5 + (0.2 if "pouches" in cats_join or "pe-pet-al" in mats_join else 0.0))
-
-        regolith_pct = 0.0
-        materials_for_plan = used_mats.copy()
-        weights_for_plan = weights.copy()
-
-        # Si el proceso es P03, **inyectar regolito MGS-1** como carga mineral (10–30%)
-        if str(proc["process_id"]).upper() == "P03":
-            regolith_pct = 0.2  # 20% por defecto (podés hacer slider más adelante)
-            materials_for_plan.append("MGS-1_regolith")
-            weights_for_plan = [round(w*(1.0 - regolith_pct), 2) for w in weights_for_plan]
-            weights_for_plan.append(round(regolith_pct, 2))
-            # Re-normalizar por cualquier redondeo
-            s = sum(weights_for_plan)
-            if s > 0:
-                weights_for_plan = [round(w/s, 2) for w in weights_for_plan]
-
-            # Sutilezas: al sumar carga mineral, suele subir rigidez y bajar estanqueidad
-            rigidity = min(1.0, rigidity + 0.1)
-            tightness = max(0.0, tightness - 0.05)
-
-        props = PredProps(
-            rigidity=rigidity,
-            tightness=tightness,
-            mass_final_kg=mass_final,
-            energy_kwh=energy,
-            water_l=water,
-            crew_min=crew
-        )
-
-        # Scoring multi-objetivo (simple y transparente)
-        score = 0.0
-        score += 1.0 - abs(props.rigidity  - float(target["rigidity"]))
-        score += 1.0 - abs(props.tightness - float(target["tightness"]))
-        # Penalizaciones por recursos vs límites
-        def _pen(v, lim, eps):
-            return max(0.0, (v - float(lim)) / max(eps, float(lim)))
-        score -= _pen(props.energy_kwh, target["max_energy_kwh"], 0.1)
-        score -= _pen(props.water_l,     target["max_water_l"],   0.1)
-        score -= _pen(props.crew_min,    target["max_crew_min"],  1.0)
-
-        # Bono por **masa problemática** consumida
-        prob_mass = float((picks["_problematic"].astype(int) * picks["kg"]).sum())
-        score += 0.5 * (prob_mass / max(0.1, total_kg))
-
-        out.append({
-            "materials": materials_for_plan,
-            "weights": weights_for_plan,
-            "process_id": str(proc["process_id"]),
-            "process_name": str(proc["name"]),
-            "props": props,
-            "score": round(float(score), 3),
-
-            # Trazabilidad NASA
-            "source_ids": used_ids,
-            "source_categories": used_cats,
-            "source_flags": used_flags,
-
-            # Señal explícita de uso de regolito
-            "regolith_pct": regolith_pct
-        })
+            pareto, history = optimize_candidates(
+                initial_candidates=out,
+                sampler=_sampler,
+                target=target,
+                n_evals=int(optimizer_evals)
+            )
+            out = pareto
+        except Exception:
+            history = pd.DataFrame()
 
     out.sort(key=lambda x: x["score"], reverse=True)
-    return out
+    return out, history
+
+
+def _build_candidate(picks: pd.DataFrame, proc_df: pd.DataFrame, target: dict,
+                     crew_time_low: bool = False) -> dict | None:
+    if picks is None or picks.empty or proc_df is None or proc_df.empty:
+        return None
+
+    total_kg = max(0.001, float(picks["kg"].sum()))
+    weights = (picks["kg"] / total_kg).round(2).tolist()
+
+    used_ids = picks["_source_id"].tolist()
+    used_cats = picks["_source_category"].tolist()
+    used_flags = picks["_source_flags"].tolist()
+    used_mats = picks["material"].tolist()
+
+    proc = _select_process(proc_df, used_cats, used_flags, used_mats)
+
+    mass_final = total_kg * 0.90
+    energy = float(proc["energy_kwh_per_kg"]) * mass_final
+    water = float(proc["water_l_per_kg"]) * mass_final
+    crew = float(proc["crew_min_per_batch"])
+
+    mats_join = " ".join(used_mats).lower()
+    cats_join = " ".join([str(c).lower() for c in used_cats])
+    flags_join = " ".join([str(f).lower() for f in used_flags])
+    rigidity = min(1.0, 0.5 + (0.2 if "al" in mats_join or "aluminum" in mats_join else 0.0))
+    tightness = min(1.0, 0.5 + (0.2 if "pouches" in cats_join or "pe-pet-al" in mats_join else 0.0))
+
+    regolith_pct = 0.0
+    materials_for_plan = used_mats.copy()
+    weights_for_plan = weights.copy()
+
+    if str(proc["process_id"]).upper() == "P03":
+        regolith_pct = 0.2
+        materials_for_plan.append("MGS-1_regolith")
+        weights_for_plan = [round(w * (1.0 - regolith_pct), 2) for w in weights_for_plan]
+        weights_for_plan.append(round(regolith_pct, 2))
+        s = sum(weights_for_plan)
+        if s > 0:
+            weights_for_plan = [round(w / s, 2) for w in weights_for_plan]
+        rigidity = min(1.0, rigidity + 0.1)
+        tightness = max(0.0, tightness - 0.05)
+
+    props = PredProps(
+        rigidity=rigidity,
+        tightness=tightness,
+        mass_final_kg=mass_final,
+        energy_kwh=energy,
+        water_l=water,
+        crew_min=crew
+    )
+
+    score = _score_candidate(props, target, picks, total_kg, crew_time_low)
+
+    return {
+        "materials": materials_for_plan,
+        "weights": weights_for_plan,
+        "process_id": str(proc["process_id"]),
+        "process_name": str(proc["name"]),
+        "props": props,
+        "score": round(float(score), 3),
+        "source_ids": used_ids,
+        "source_categories": used_cats,
+        "source_flags": used_flags,
+        "regolith_pct": regolith_pct
+    }
+
+
+def _select_process(proc_df: pd.DataFrame, used_cats: list[str], used_flags: list[str],
+                    used_mats: list[str]) -> pd.Series:
+    proc = proc_df.sample(1).iloc[0]
+    cats_join = " ".join([str(c).lower() for c in used_cats])
+    flags_join = " ".join([str(f).lower() for f in used_flags])
+    mats_join = " ".join(used_mats).lower()
+
+    if ("pouches" in cats_join) or ("multilayer" in flags_join) or ("pe-pet-al" in mats_join):
+        cand = proc_df[proc_df["process_id"] == "P02"]
+        if not cand.empty:
+            proc = cand.iloc[0]
+
+    if ("foam" in cats_join) or ("zotek" in mats_join):
+        cand = proc_df[proc_df["process_id"].isin(["P03", "P02"])]
+        if not cand.empty:
+            proc = cand.sample(1).iloc[0]
+
+    if ("eva" in cats_join) or ("ctb" in flags_join):
+        cand = proc_df[proc_df["process_id"] == "P04"]
+        if not cand.empty:
+            proc = cand.iloc[0]
+
+    return proc
+
+
+def _score_candidate(props: PredProps, target: dict, picks: pd.DataFrame, total_kg: float,
+                     crew_time_low: bool = False) -> float:
+    score = 0.0
+    score += 1.0 - abs(props.rigidity - float(target["rigidity"]))
+    score += 1.0 - abs(props.tightness - float(target["tightness"]))
+
+    def _pen(v, lim, eps):
+        return max(0.0, (v - float(lim)) / max(eps, float(lim)))
+
+    crew_eps = 0.5 if crew_time_low else 1.0
+    score -= _pen(props.energy_kwh, target["max_energy_kwh"], 0.1)
+    score -= _pen(props.water_l, target["max_water_l"], 0.1)
+    score -= _pen(props.crew_min, target["max_crew_min"], crew_eps)
+
+    prob_mass = float((picks["_problematic"].astype(int) * picks["kg"]).sum())
+    score += 0.5 * (prob_mass / max(0.1, total_kg))
+    return score

--- a/app/modules/optimizer.py
+++ b/app/modules/optimizer.py
@@ -1,0 +1,208 @@
+"""Utilities para optimizar combinaciones multiobjetivo.
+
+Este módulo implementa una capa ligera de optimización inspirada en
+Bayesian Optimization/MILP. Trabaja con los candidatos generados y un
+sampler callable que produce nuevas combinaciones. El resultado es un
+conjunto Pareto y métricas de convergencia (hipervolumen y dominancia).
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Iterable
+
+import numpy as np
+import pandas as pd
+
+
+@dataclass
+class OptimizationSummary:
+    iteration: int
+    score: float
+    penalty: float
+    hypervolume: float
+    dominance_ratio: float
+    pareto_size: int
+
+
+Candidate = dict
+Sampler = Callable[[], Candidate | None]
+
+
+def optimize_candidates(
+    initial_candidates: Iterable[Candidate],
+    sampler: Sampler,
+    target: dict,
+    n_evals: int = 30,
+) -> tuple[list[Candidate], pd.DataFrame]:
+    """Ejecuta un barrido de optimización multiobjetivo.
+
+    Parameters
+    ----------
+    initial_candidates:
+        Colección inicial (semillas) generadas por heurística.
+    sampler:
+        Callable que devuelve nuevos candidatos a evaluar.
+    target:
+        Diccionario con restricciones y objetivos (rigidez, estanqueidad,
+        máximos de recursos, etc.).
+    n_evals:
+        Número de evaluaciones adicionales a ejecutar.
+
+    Returns
+    -------
+    tuple[list[Candidate], pd.DataFrame]
+        La lista de soluciones no dominadas y el historial de métricas
+        (hipervolumen, dominancia, etc.).
+    """
+
+    evaluated: list[Candidate] = [cand for cand in initial_candidates if cand]
+    history: list[OptimizationSummary] = []
+
+    pareto = _pareto_front(evaluated, target)
+    hv = _hypervolume(pareto, evaluated, target)
+    dom_ratio = _dominance_ratio(pareto, evaluated)
+    history.append(
+        OptimizationSummary(
+            iteration=0,
+            score=float("nan"),
+            penalty=float("nan"),
+            hypervolume=hv,
+            dominance_ratio=dom_ratio,
+            pareto_size=len(pareto),
+        )
+    )
+
+    for i in range(1, n_evals + 1):
+        candidate = sampler()
+        if candidate:
+            evaluated.append(candidate)
+        pareto = _pareto_front(evaluated, target)
+        hv = _hypervolume(pareto, evaluated, target)
+        dom_ratio = _dominance_ratio(pareto, evaluated)
+        score = float(candidate["score"]) if candidate else float("nan")
+        penalty = _penalty(candidate, target) if candidate else float("nan")
+        history.append(
+            OptimizationSummary(
+                iteration=i,
+                score=score,
+                penalty=penalty,
+                hypervolume=hv,
+                dominance_ratio=dom_ratio,
+                pareto_size=len(pareto),
+            )
+        )
+
+    pareto_sorted = sorted(pareto, key=lambda c: c.get("score", 0.0), reverse=True)
+    history_df = pd.DataFrame(history)
+    return pareto_sorted, history_df
+
+
+def _pareto_front(candidates: list[Candidate], target: dict) -> list[Candidate]:
+    if not candidates:
+        return []
+
+    front: list[Candidate] = []
+    for cand in candidates:
+        dominated = False
+        metrics_c = _metrics(cand, target)
+        remove: list[Candidate] = []
+        for other in front:
+            metrics_o = _metrics(other, target)
+            if _dominates(metrics_o, metrics_c):
+                dominated = True
+                break
+            if _dominates(metrics_c, metrics_o):
+                remove.append(other)
+        if not dominated:
+            front.append(cand)
+            for r in remove:
+                if r in front:
+                    front.remove(r)
+    return front
+
+
+def _metrics(candidate: Candidate, target: dict) -> dict[str, float]:
+    props = candidate.get("props")
+    energy = getattr(props, "energy_kwh", 0.0)
+    water = getattr(props, "water_l", 0.0)
+    crew = getattr(props, "crew_min", 0.0)
+    score = float(candidate.get("score", 0.0))
+
+    def _norm(value: float, limit: float, eps: float = 1e-6) -> float:
+        limit = max(limit, eps)
+        return max(0.0, value) / limit
+
+    energy_n = _norm(energy, float(target.get("max_energy_kwh", 1.0)))
+    water_n = _norm(water, float(target.get("max_water_l", 1.0)))
+    crew_n = _norm(crew, float(target.get("max_crew_min", 1.0)))
+    penalty = np.mean([energy_n, water_n, crew_n])
+    return {
+        "score": score,
+        "energy": energy_n,
+        "water": water_n,
+        "crew": crew_n,
+        "penalty": penalty,
+    }
+
+
+def _dominates(metrics_a: dict[str, float], metrics_b: dict[str, float]) -> bool:
+    better_or_equal = (
+        metrics_a["score"] >= metrics_b["score"]
+        and metrics_a["energy"] <= metrics_b["energy"]
+        and metrics_a["water"] <= metrics_b["water"]
+        and metrics_a["crew"] <= metrics_b["crew"]
+    )
+    strictly_better = (
+        metrics_a["score"] > metrics_b["score"]
+        or metrics_a["energy"] < metrics_b["energy"]
+        or metrics_a["water"] < metrics_b["water"]
+        or metrics_a["crew"] < metrics_b["crew"]
+    )
+    return better_or_equal and strictly_better
+
+
+def _hypervolume(
+    pareto: list[Candidate],
+    evaluated: list[Candidate],
+    target: dict,
+) -> float:
+    if not pareto:
+        return 0.0
+
+    scores = [float(c.get("score", 0.0)) for c in evaluated]
+    score_min = min(scores)
+    score_max = max(scores)
+    span = max(score_max - score_min, 1e-6)
+
+    points = []
+    for cand in pareto:
+        metrics = _metrics(cand, target)
+        score_norm = (metrics["score"] - score_min) / span
+        quality = max(0.0, 1.0 - metrics["penalty"])
+        points.append((np.clip(score_norm, 0.0, 1.0), np.clip(quality, 0.0, 1.0)))
+
+    points.sort(key=lambda p: p[0])
+    hv = 0.0
+    prev_score = 0.0
+    prev_height = 0.0
+    for score_norm, height in points:
+        width = max(0.0, score_norm - prev_score)
+        prev_height = max(prev_height, height)
+        hv += width * prev_height
+        prev_score = score_norm
+    hv += max(0.0, 1.0 - prev_score) * prev_height
+    return float(np.clip(hv, 0.0, 1.0))
+
+
+def _dominance_ratio(pareto: list[Candidate], evaluated: list[Candidate]) -> float:
+    if not evaluated:
+        return 0.0
+    dominated = max(len(evaluated) - len(pareto), 0)
+    return dominated / len(evaluated)
+
+
+def _penalty(candidate: Candidate, target: dict) -> float:
+    if not candidate:
+        return float("nan")
+    metrics = _metrics(candidate, target)
+    return float(metrics["penalty"])


### PR DESCRIPTION
## Summary
- add an optimizer module that builds a Pareto front from sampled candidates and tracks convergence metrics
- refactor the generator to expose reusable candidate builders and hook the optimizer behind an evaluations slider
- surface optimizer controls and convergence charts in the generator UI while preserving the existing candidates structure

## Testing
- python3 -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68cf84f18a088331abe16e0d473759c8