### PR TITLE
Refine session state handling in generator page

### DIFF
--- a/app/pages/3_Generator.py
+++ b/app/pages/3_Generator.py
@@ -110,6 +110,7 @@ with layout:
             if overall:
                 st.caption(f"MAE promedio: {overall.get('mae', '—'):.3f} · RMSE: {overall.get('rmse', '—'):.3f} · R²: {overall.get('r2', '—'):.3f}")
 
+    result = None
     if run:
         result = generate_candidates(
             waste_df,
@@ -121,10 +122,15 @@ with layout:
         )
         if isinstance(result, tuple):
             cands, history = result
-    if isinstance(result, tuple):
-        cands, history = result
+        else:
+            cands, history = result, pd.DataFrame()
     else:
-        cands, history = result, pd.DataFrame()
+        cands = st.session_state.get("candidates")
+        history = st.session_state.get("optimizer_history")
+        if cands is None:
+            cands = []
+        if history is None:
+            history = pd.DataFrame()
     st.session_state["candidates"] = cands
     st.session_state["optimizer_history"] = history
 


### PR DESCRIPTION
## Summary
- initialize the generator result before running the button action
- reuse previously stored candidates and history from session state when the button isn't pressed

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d0e24f55c083319a8cfd5c30ef0003