### PR TITLE
Add Plotly graph objects import to results page

### DIFF
--- a/app/pages/4_Results_and_Tradeoffs.py
+++ b/app/pages/4_Results_and_Tradeoffs.py
@@ -7,6 +7,7 @@ if str(ROOT) not in sys.path:
 
 import altair as alt
 import pandas as pd
+import plotly.graph_objects as go
 import streamlit as st
 
 from app.modules.explain import score_breakdown


### PR DESCRIPTION
## Summary
- import Plotly graph objects in the results and tradeoffs page
- ensure go alias is available for Sankey and bar chart figures

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d0e5a1d1c4833182fd3c07350bb2a4