### PR TITLE
Add training provenance tag to metadata

### DIFF
--- a/app/Home.py
+++ b/app/Home.py
@@ -127,7 +127,9 @@ st.markdown(
 
 # ──────────── Pila/estado del modelo ────────────
 st.markdown("### Estado del modelo Rex-AI")
-trained_label = trained_dt.strftime("%d %b %Y %H:%M UTC") if trained_dt else "sin metadata"
+trained_label = MODEL_REGISTRY.trained_label()
+if not trained_label or trained_label == "—":
+    trained_label = trained_dt.strftime("%d %b %Y %H:%M UTC") if trained_dt else "sin metadata"
 ready = "✅ Modelo listo" if MODEL_REGISTRY.ready else "⚠️ Entrená localmente"
 
 st.markdown(

--- a/app/modules/ml_models.py
+++ b/app/modules/ml_models.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import json
 import logging
 from dataclasses import dataclass
+from datetime import datetime
 from pathlib import Path
 from typing import Any, Mapping, Dict, List, Tuple
 
@@ -131,7 +132,26 @@ class ModelRegistry:
         return self.pipeline is not None
 
     def trained_label(self) -> str:
-        return str(self.metadata.get("trained_at", "—"))
+        trained_on = self.metadata.get("trained_on")
+        trained_at = self.metadata.get("trained_at")
+
+        label_parts: List[str] = []
+
+        if trained_on:
+            label_parts.append(str(trained_on))
+
+        if trained_at:
+            ts_label = str(trained_at)
+            if isinstance(trained_at, str):
+                try:
+                    dt = datetime.fromisoformat(trained_at)
+                except ValueError:
+                    pass
+                else:
+                    ts_label = dt.strftime("%d %b %Y %H:%M UTC")
+            label_parts.append(ts_label)
+
+        return " · ".join(label_parts) if label_parts else "—"
 
     def uncertainty_label(self) -> str:
         # Texto para Home; si hay residual_std lo indicamos

--- a/app/modules/model_training.py
+++ b/app/modules/model_training.py
@@ -1030,6 +1030,7 @@ def train_and_save(n_samples: int = 1600, seed: int | None = 21) -> Dict[str, An
 
     metadata = {
         "model_name": "rexai-rf-ensemble",
+        "trained_on": "synthetic_v0",
         "trained_at": datetime.now(tz=UTC).isoformat(),
         "n_samples": int(len(df)),
         "dataset": {


### PR DESCRIPTION
## Summary
- include the synthetic dataset tag in the metadata generated by the training pipeline
- surface the new `trained_on` information through `ModelRegistry.trained_label`
- adjust the home page status widget to display the richer training label while keeping the legacy fallback

## Testing
- python -m app.modules.model_training
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d21a188cf88331bbe0ca5aaa08e938