### PR TITLE
Switch impact and feedback logging to parquet with extras

### DIFF
--- a/app/modules/impact.py
+++ b/app/modules/impact.py
@@ -1,11 +1,17 @@
 from __future__ import annotations
-from dataclasses import dataclass, asdict
+
+from dataclasses import dataclass, asdict, field
+from datetime import datetime
 from pathlib import Path
+from typing import Any
+import json
+import uuid
+
 import pandas as pd
 
 DATA_DIR = Path(__file__).resolve().parents[2] / "data"
-LOG_FILE = DATA_DIR / "impact_log.csv"
-FEEDBACK_FILE = DATA_DIR / "feedback_log.csv"
+LOGS_DIR = DATA_DIR / "logs"
+
 
 @dataclass
 class ImpactEntry:
@@ -21,7 +27,8 @@ class ImpactEntry:
     water_l: float
     crew_min: float
     score: float
-    extra: str = ""
+    extra: dict[str, Any] = field(default_factory=dict)
+
 
 @dataclass
 class FeedbackEntry:
@@ -34,74 +41,111 @@ class FeedbackEntry:
     ease_ok: bool
     issues: str
     notes: str
-    extra: str = ""
+    extra: dict[str, Any] = field(default_factory=dict)
 
-def _ensure_files():
-    DATA_DIR.mkdir(parents=True, exist_ok=True)
-    impact_columns = list(ImpactEntry.__annotations__.keys())
-    feedback_columns = list(FeedbackEntry.__annotations__.keys())
 
-    def _ensure_file(path: Path, columns: list[str]):
-        if not path.exists():
-            pd.DataFrame(columns=columns).to_csv(path, index=False)
-            return
-        df = pd.read_csv(path)
-        updated = False
-        missing = [col for col in columns if col not in df.columns]
-        if missing:
-            for col in missing:
-                df[col] = ""
-            updated = True
-        # Reordenamos columnas para mantener consistencia
-        ordered = df.reindex(columns=columns)
-        if not ordered.equals(df):
-            df = ordered
-            updated = True
-        if updated:
-            df.to_csv(path, index=False)
+def _ensure_dirs() -> None:
+    LOGS_DIR.mkdir(parents=True, exist_ok=True)
 
-    _ensure_file(LOG_FILE, impact_columns)
-    _ensure_file(FEEDBACK_FILE, feedback_columns)
 
-def append_impact(entry: ImpactEntry):
-    _ensure_files()
-    df = pd.read_csv(LOG_FILE)
-    if "extra" not in df.columns:
-        df["extra"] = ""
-    payload = asdict(entry)
-    df.loc[len(df)] = [payload.get(col, "") for col in df.columns]
-    df.to_csv(LOG_FILE, index=False)
+def _serialize_extra(extra: dict[str, Any]) -> tuple[str, dict[str, Any]]:
+    extras = extra or {}
+    return json.dumps(extras, ensure_ascii=False, sort_keys=True), {
+        f"extra_{key}": value for key, value in extras.items()
+    }
 
-def append_feedback(entry: FeedbackEntry):
-    _ensure_files()
-    df = pd.read_csv(FEEDBACK_FILE)
-    if "extra" not in df.columns:
-        df["extra"] = ""
-    payload = asdict(entry)
-    df.loc[len(df)] = [payload.get(col, "") for col in df.columns]
-    df.to_csv(FEEDBACK_FILE, index=False)
+
+def _prepare_payload(entry_dict: dict[str, Any]) -> dict[str, Any]:
+    extra_payload = entry_dict.pop("extra", {}) or {}
+    extra_serialized, extra_columns = _serialize_extra(extra_payload)
+    payload = {**entry_dict, **extra_columns}
+    payload["extra"] = extra_serialized
+    payload["run_id"] = uuid.uuid4().hex
+    return payload
+
+
+def _entry_date(ts_iso: str) -> str:
+    try:
+        dt = datetime.fromisoformat(ts_iso.replace("Z", "+00:00"))
+    except ValueError:
+        dt = datetime.utcnow()
+    return dt.strftime("%Y-%m-%d")
+
+
+def _append_record(filename: str, payload: dict[str, Any]) -> None:
+    _ensure_dirs()
+    path = LOGS_DIR / filename
+    row_df = pd.DataFrame([payload])
+    if path.exists():
+        existing = pd.read_parquet(path)
+        df = pd.concat([existing, row_df], ignore_index=True, sort=False)
+    else:
+        df = row_df
+    df.to_parquet(path, index=False)
+
+
+def append_impact(entry: ImpactEntry) -> str:
+    payload = _prepare_payload(asdict(entry))
+    date_str = _entry_date(entry.ts_iso)
+    _append_record(f"impact_{date_str}.parquet", payload)
+    return payload["run_id"]
+
+
+def append_feedback(entry: FeedbackEntry) -> str:
+    payload = _prepare_payload(asdict(entry))
+    date_str = _entry_date(entry.ts_iso)
+    _append_record(f"feedback_{date_str}.parquet", payload)
+    return payload["run_id"]
+
+
+def _parse_extra_column(value: Any) -> dict[str, Any]:
+    if isinstance(value, dict):
+        return value
+    if isinstance(value, str) and value:
+        try:
+            parsed = json.loads(value)
+            if isinstance(parsed, dict):
+                return parsed
+        except json.JSONDecodeError:
+            pass
+    return {}
+
+
+def _load_parquet(pattern: str) -> pd.DataFrame:
+    _ensure_dirs()
+    files = sorted(LOGS_DIR.glob(pattern))
+    if not files:
+        return pd.DataFrame()
+    frames = [pd.read_parquet(path) for path in files]
+    df = pd.concat(frames, ignore_index=True, sort=False)
+    if "extra" in df.columns:
+        df["extra"] = df["extra"].apply(_parse_extra_column)
+    else:
+        df["extra"] = [{} for _ in range(len(df))]
+    return df
+
 
 def load_impact_df() -> pd.DataFrame:
-    _ensure_files()
-    df = pd.read_csv(LOG_FILE)
-    if "extra" not in df.columns:
-        df["extra"] = ""
-    return df
+    return _load_parquet("impact_*.parquet")
+
 
 def load_feedback_df() -> pd.DataFrame:
-    _ensure_files()
-    df = pd.read_csv(FEEDBACK_FILE)
-    if "extra" not in df.columns:
-        df["extra"] = ""
-    return df
+    return _load_parquet("feedback_*.parquet")
+
 
 def summarize_impact(df: pd.DataFrame) -> dict:
     if df.empty:
         return {"runs":0, "kg":0.0, "kwh":0.0, "water_l":0.0, "crew_min":0.0}
+    metrics = {}
+    for column in ("mass_final_kg", "energy_kwh", "water_l", "crew_min"):
+        if column in df.columns:
+            metrics[column] = pd.to_numeric(df[column], errors="coerce")
+        else:
+            metrics[column] = pd.Series(dtype="float64")
     return {
         "runs": int(len(df)),
-        "kg": float(df["mass_final_kg"].sum()),
-        "kwh": float(df["energy_kwh"].sum()),
-        "water_l": float(df["water_l"].sum()),
-        "crew_min": float(df["crew_min"].sum())
+        "kg": float(metrics["mass_final_kg"].sum(skipna=True)),
+        "kwh": float(metrics["energy_kwh"].sum(skipna=True)),
+        "water_l": float(metrics["water_l"].sum(skipna=True)),
+        "crew_min": float(metrics["crew_min"].sum(skipna=True))
     }

--- a/tests/test_impact_logging.py
+++ b/tests/test_impact_logging.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+import pandas as pd
+
+from app.modules import impact
+
+
+def _setup_tmp_logs(monkeypatch, tmp_path):
+    logs_dir = tmp_path / "logs"
+    monkeypatch.setattr(impact, "DATA_DIR", tmp_path)
+    monkeypatch.setattr(impact, "LOGS_DIR", logs_dir)
+    return logs_dir
+
+
+def test_append_impact_preserves_extra_columns(tmp_path, monkeypatch):
+    logs_dir = _setup_tmp_logs(monkeypatch, tmp_path)
+    ts = datetime.utcnow().replace(microsecond=0).isoformat()
+    entry = impact.ImpactEntry(
+        ts_iso=ts,
+        scenario="moon_base",
+        target_name="panel",
+        materials="A|B",
+        weights="0.4|0.6",
+        process_id="proc-1",
+        process_name="Sintering",
+        mass_final_kg=10.5,
+        energy_kwh=3.2,
+        water_l=1.1,
+        crew_min=45.0,
+        score=0.87,
+        extra={"custom_metric": 123, "regolith_pct": 0.5},
+    )
+
+    run_id = impact.append_impact(entry)
+    assert isinstance(run_id, str) and run_id
+
+    files = list(logs_dir.glob("impact_*.parquet"))
+    assert len(files) == 1
+    df = pd.read_parquet(files[0])
+    assert "run_id" in df.columns
+    assert df.loc[0, "run_id"] == run_id
+    assert "extra_custom_metric" in df.columns
+    assert "extra_regolith_pct" in df.columns
+
+    loaded = impact.load_impact_df()
+    assert loaded.loc[0, "extra"]["custom_metric"] == 123
+    assert loaded.loc[0, "extra"]["regolith_pct"] == 0.5
+    assert "extra_custom_metric" in loaded.columns
+    assert "extra_regolith_pct" in loaded.columns
+
+
+def test_feedback_logging_concatenates_daily(tmp_path, monkeypatch):
+    logs_dir = _setup_tmp_logs(monkeypatch, tmp_path)
+    ts = datetime.utcnow().replace(microsecond=0)
+    entries = [
+        impact.FeedbackEntry(
+            ts_iso=ts.isoformat(),
+            astronaut="astro",
+            scenario="moon",
+            target_name="tile",
+            option_idx=1,
+            rigidity_ok=True,
+            ease_ok=False,
+            issues="cracks",
+            notes="",
+            extra={"overall": 9, "porosity": 2},
+        ),
+        impact.FeedbackEntry(
+            ts_iso=(ts + timedelta(days=1)).isoformat(),
+            astronaut="astro2",
+            scenario="moon",
+            target_name="tile",
+            option_idx=2,
+            rigidity_ok=False,
+            ease_ok=True,
+            issues="",
+            notes="note",
+            extra={"overall": 6, "unknown_field": "x"},
+        ),
+    ]
+
+    run_ids = [impact.append_feedback(entry) for entry in entries]
+    assert all(run_ids)
+
+    files = sorted(logs_dir.glob("feedback_*.parquet"))
+    assert len(files) == 2
+    df0 = pd.read_parquet(files[0])
+    assert "run_id" in df0.columns
+    assert "extra_overall" in df0.columns
+
+    loaded = impact.load_feedback_df()
+    assert len(loaded) == 2
+    assert set(loaded["run_id"]) == set(run_ids)
+    assert "extra_unknown_field" in loaded.columns
+    assert loaded.loc[1, "extra"]["unknown_field"] == "x"


### PR DESCRIPTION
## Summary
- persist impact and feedback entries as daily parquet files with JSON `extra` metadata and run identifiers
- ensure Streamlit page surfaces structured extras and handles new parquet-backed loaders
- add regression tests covering run ids, unknown extra fields, and column preservation

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d22bf9a5e88331b5d024a8987f2160