### PR TITLE
Document hybrid training workflow and ignore bundles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ __pycache__/
 # Binary dataset and model artefacts
 *.parquet
 *.joblib
+*.zip
 *.pt
 *.pkl
 *.onnx

--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -8,9 +8,16 @@ reproduce el experimento y guarda la evidencia en `data/benchmarks/`.
 ## Cómo ejecutar los benchmarks
 
 1. Asegurá que los artefactos entrenados (`data/models/rexai_regressor.joblib`,
-   clasificadores y metadata) están disponibles. Podés generarlos con
-   `python -m app.modules.model_training` o descargar el bundle publicado en
-   los releases.
+   clasificadores y metadata) están disponibles. Podés regenerarlos con:
+
+   ```bash
+   python -m app.modules.model_training --gold datasets/gold --append-logs "data/logs/feedback_*.parquet"
+   ```
+
+   Si preferís evitar el entrenamiento local, descargá el bundle
+   `rexai_model_bundle_hybrid_v1.zip` desde la sección **Releases** (o el
+   artifact equivalente de CI), descomprimilo y copiá su contenido en
+   `data/models/` antes de continuar.
 2. Ejecutá el script:
 
    ```bash


### PR DESCRIPTION
## Summary
- document the hybrid training CLI that consumes curated gold datasets and feedback logs
- explain how to download the packaged bundle from Releases and load it into data/models for IA mode
- ensure binary bundles stay ignored in git by adding zip files to the ignore list

## Testing
- `python -m app.modules.model_training --gold datasets/gold --append-logs "data/logs/feedback_*.parquet"`
- `python -m scripts.verify_model_ready`
- `python scripts/run_benchmarks.py --format csv --with-ablation`
- `python -m scripts.package_model_bundle --output dist/rexai_model_bundle_hybrid_v1.zip`


------
https://chatgpt.com/codex/tasks/task_e_68d2f8fa45f083318de665f90c6021ff