### PR TITLE
Add feedback retraining CLI and surface provenance metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,33 @@ corpus dorado y feedback humano cuando está disponible):
 python -m app.modules.model_training --gold datasets/gold --append-logs "data/logs/feedback_*.parquet"
 ```
 
+### Reentrenar desde feedback humano
+
+Cada sesión de la tripulación registrada en el panel "Feedback & Impact"
+genera archivos `data/logs/feedback_*.parquet` con las correcciones aplicadas
+al proceso (rigidez, estanqueidad, penalizaciones de energía/agua/crew). El
+comando dedicado `retrain_from_feedback` consume esos logs, convierte las
+señales en targets supervisados y re-ejecuta el pipeline principal con
+`--append-logs` ya configurado:
+
+```bash
+python -m app.modules.retrain_from_feedback
+```
+
+Opcionalmente podés especificar rutas alternativas:
+
+```bash
+python -m app.modules.retrain_from_feedback \
+  --gold datasets/gold \
+  --features datasets/gold/features.parquet \
+  --logs "data/logs/custom_feedback_*.parquet"
+```
+
+Al finalizar, `data/models/metadata.json` y `metadata_gold.json` se actualizan
+con la nueva fecha (`trained_at`) y el label de procedencia (`trained_on`, por
+ejemplo `hil_v1` o `hybrid_v2`). La pantalla principal de la app refleja la
+última fecha de reentrenamiento y la mezcla utilizada.
+
 > Nota: la optimización bayesiana con Ax/BoTorch es opcional. El entorno Streamlit
 > detecta automáticamente si `ax-platform` y `botorch` están instalados; en caso
 > contrario utiliza el optimizador heurístico integrado. Para habilitarla basta con

--- a/README_ML_GAMEPLAN.md
+++ b/README_ML_GAMEPLAN.md
@@ -101,7 +101,7 @@ Crear `notebooks/validate_model.ipynb` con:
 3. Publicar los artefactos y actualizar `MODEL_DIR` o la URL remota.
 4. Configurar la app para que `ModelRegistry.ready == True` y mostrar procedencia + CI; fallback solo si `predict()` devuelve `{}`.
 5. Elaborar notebook de validación con métricas y recetas demo.
-6. Consolidar `impact.jsonl`/`feedback.jsonl` en `datasets/raw/` y re-entrenar periódicamente.
+6. Consolidar `impact.jsonl`/`feedback.jsonl` en `datasets/raw/` y re-entrenar periódicamente (`python -m app.modules.retrain_from_feedback`).
 
 ---
 

--- a/app/modules/ml_models.py
+++ b/app/modules/ml_models.py
@@ -132,12 +132,15 @@ class ModelRegistry:
         return self.pipeline is not None
 
     def trained_label(self) -> str:
+        metadata_label = self.metadata.get("trained_label")
         trained_on = self.metadata.get("trained_on")
         trained_at = self.metadata.get("trained_at")
 
         label_parts: List[str] = []
 
-        if trained_on:
+        if metadata_label:
+            label_parts.append(str(metadata_label))
+        elif trained_on:
             label_parts.append(str(trained_on))
 
         if trained_at:

--- a/app/modules/model_training.py
+++ b/app/modules/model_training.py
@@ -1296,11 +1296,13 @@ def train_and_save(
     }
 
     trained_on = _infer_trained_on_label(df)
+    trained_at_iso = datetime.now(tz=UTC).isoformat()
 
     metadata = {
         "model_name": "rexai-rf-ensemble",
         "trained_on": trained_on,
-        "trained_at": datetime.now(tz=UTC).isoformat(),
+        "trained_at": trained_at_iso,
+        "trained_label": trained_on,
         "n_samples": int(len(df)),
         "dataset": {
             "path": _relative_path(DATASET_PATH),

--- a/app/modules/retrain_from_feedback.py
+++ b/app/modules/retrain_from_feedback.py
@@ -1,0 +1,123 @@
+"""Utility CLI to retrain Rex-AI models using captured astronaut feedback.
+
+The command scans ``data/logs/feedback_*.parquet`` by default, converts the
+recorded corrections into supervised targets (RandomForest regression +
+classification) and reuses the main training pipeline with ``--append-logs``.
+
+Usage
+-----
+``python -m app.modules.retrain_from_feedback``
+
+Optional arguments expose the same knobs as ``app.modules.model_training`` to
+control synthetic sampling, gold datasets and feedback glob patterns.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Iterable, Sequence
+
+from app.modules import model_training
+
+ROOT = Path(__file__).resolve().parents[2]
+DATA_DIR = ROOT / "data"
+LOGS_DIR = DATA_DIR / "logs"
+DEFAULT_PATTERN = LOGS_DIR / "feedback_*.parquet"
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Reentrena Rex-AI combinando datasets base con feedback humano. "
+            "Carga data/logs/feedback_*.parquet por defecto y reutiliza el "
+            "pipeline principal (train_and_save)."
+        )
+    )
+    parser.add_argument(
+        "--samples",
+        type=int,
+        default=1600,
+        help=(
+            "Número de muestras sintéticas a generar si faltan etiquetas doradas. "
+            "Se pasa directamente a train_and_save()."
+        ),
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=21,
+        help="Semilla global para generación y entrenamiento.",
+    )
+    parser.add_argument(
+        "--gold",
+        type=Path,
+        default=None,
+        help="Directorio con features.parquet/labels.parquet dorados.",
+    )
+    parser.add_argument(
+        "--features",
+        type=Path,
+        default=None,
+        help="Ruta alternativa a features.parquet si difiere del --gold.",
+    )
+    parser.add_argument(
+        "--logs",
+        nargs="*",
+        default=None,
+        help=(
+            "Globs o archivos Parquet con feedback humano. Si no se pasan se usa "
+            "data/logs/feedback_*.parquet."
+        ),
+    )
+    return parser
+
+
+def _resolve_gold_paths(args: argparse.Namespace) -> tuple[Path | None, Path | None]:
+    gold_features: Path | None = None
+    gold_labels: Path | None = None
+
+    if args.gold is not None:
+        gold_dir = Path(args.gold)
+        gold_features = gold_dir / "features.parquet"
+        gold_labels = gold_dir / "labels.parquet"
+
+    if args.features is not None:
+        features_path = Path(args.features)
+        if features_path.is_dir():
+            features_path = features_path / "features.parquet"
+        gold_features = features_path
+
+    return gold_features, gold_labels
+
+
+def _resolve_patterns(log_args: Iterable[str] | None) -> list[str]:
+    patterns: list[str] = []
+    if log_args:
+        patterns.extend(str(Path(p)) for p in log_args)
+    if not patterns:
+        patterns.append(str(DEFAULT_PATTERN))
+    return patterns
+
+
+def cli(argv: Sequence[str] | None = None) -> dict:
+    args = _build_arg_parser().parse_args(list(argv) if argv is not None else None)
+    gold_features_path, gold_labels_path = _resolve_gold_paths(args)
+    patterns = _resolve_patterns(args.logs)
+
+    feedback_df = model_training.load_feedback_logs(patterns)
+    metadata = model_training.train_and_save(
+        n_samples=args.samples,
+        seed=args.seed,
+        gold_features_path=gold_features_path,
+        gold_labels_path=gold_labels_path,
+        feedback_logs=feedback_df,
+    )
+
+    print(json.dumps(metadata, indent=2, ensure_ascii=False))
+    return metadata
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    cli()


### PR DESCRIPTION
## Summary
- add a dedicated `app.modules.retrain_from_feedback` CLI that loads `data/logs/feedback_*.parquet` and pipes the dataframe into the existing training pipeline
- store provenance fields (`trained_on`, `trained_label`, `trained_at`) when writing metadata and show the label/date combo in the home dashboard
- document the feedback retraining flow in README and the ML game plan for quick reference

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d3028add70833190a875de625cc75f