### PR TITLE
feat: download model bundle before loading registry

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ joblib==1.4.2
 xgboost==2.1.1
 # Fijamos rich compatible con Streamlit 1.38 para evitar conflictos en Cloud
 rich>=10.14.0,<14
+responses==0.25.3


### PR DESCRIPTION
## Summary
- add a helper that downloads and extracts the model bundle from MODEL_BUNDLE_URL/sha before loading the registry
- invoke the helper during registry bootstrap and extend the README with the new release workflow
- add a unit test that simulates the download and ensure bootstrap_demo_model is skipped, including the responses dependency

## Testing
- pytest tests/test_ml_models.py

------
https://chatgpt.com/codex/tasks/task_e_68d3354cbbd8833194c68d3ce6b575dd