### PR TITLE
chore: tidy app init after branding removal

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,1 +1,1 @@
-
+"""Streamlit app package."""


### PR DESCRIPTION
## Summary
- replace the placeholder newline in `app/__init__.py` with a minimal module docstring now that the branding helper is gone

## Testing
- streamlit run app/Home.py --server.headless true
- rg "inject_branding"


------
https://chatgpt.com/codex/tasks/task_e_68d5fd05045c83319fee08c2739dbe76