### PR TITLE
Add regression test covering legacy charts helper removal

### DIFF
--- a/tests/test_legacy_charts_cleanup.py
+++ b/tests/test_legacy_charts_cleanup.py
@@ -1,0 +1,19 @@
+"""Regression tests ensuring the legacy charts helper stays removed."""
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_no_legacy_charts_helper_references() -> None:
+    """Ensure the deprecated charts helper is not referenced anywhere."""
+    repo_root = Path(__file__).resolve().parents[1]
+    targets = ["predictions_ci_" + "chart", "modules." + "charts"]
+
+    offenders: list[tuple[Path, str]] = []
+    for path in repo_root.rglob("*.py"):
+        text = path.read_text(encoding="utf-8", errors="ignore")
+        for target in targets:
+            if target in text:
+                offenders.append((path, target))
+
+    assert not offenders, f"legacy helper references found: {offenders}"


### PR DESCRIPTION
## Summary
- add a regression test that scans the repository for any remaining references to the removed `app.modules.charts` helper

## Testing
- pytest tests/test_legacy_charts_cleanup.py

------
https://chatgpt.com/codex/tasks/task_e_68d5fd0bd5088331bb4d021963559248