### PR TITLE
Clarify docs after removing legacy embeddings helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,10 @@ datasets con el catálogo de procesos y genera:
 - Ensemble de modelos de "wow effect":
   - `data/models/rexai_xgboost.joblib` (boosting por target).
   - `data/models/rexai_tabtransformer.pt` (transformer tabular ligero, opcional si PyTorch está disponible).
-- Autoencoder tabular opcional (`data/models/rexai_autoencoder.pt`, requiere PyTorch).
+- Autoencoder tabular opcional (`data/models/rexai_autoencoder.pt`, requiere PyTorch). Las
+  incrustaciones latentes expuestas en la app provienen exclusivamente de este
+  autoencoder entrenado; ya no existe ningún helper heurístico para fabricarlas
+  manualmente.
 - Metadatos en `data/models/metadata.json` (features, targets, fecha, métricas,
   importancias de features, residuales, paths de artefactos).
 


### PR DESCRIPTION
## Summary
- clarify the README to state that latent embeddings now come exclusively from the trained autoencoder and no heuristic helper remains

## Testing
- `rg "make_waste_embeddings"`


------
https://chatgpt.com/codex/tasks/task_e_68d5fd13d4ac8331bd739d2d212fe25b