### PR TITLE
Refactor generator data loaders to use Polars

### DIFF
--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -28,6 +28,7 @@ numpy==2.1.3
 nvidia-nccl-cu12==2.28.3
 packaging==24.2
 pandas==2.2.3
+polars==1.12.0
 pathspec==0.12.1
 pillow==10.4.0
 platformdirs==4.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 streamlit==1.38.0
 numpy==2.1.3
 pandas==2.2.3
+polars[pyarrow]==1.12.0
 plotly==5.22.0
 networkx==3.3
 altair==5.3.0


### PR DESCRIPTION
## Summary
- add polars dependency to requirements for faster CSV ingestion
- refactor generator data loading utilities to execute joins and aggregations with Polars lazy frames before returning pandas outputs
- extend generator tests to validate the new Polars-backed loaders and official feature bundle schema

## Testing
- pytest tests/test_generator.py

------
https://chatgpt.com/codex/tasks/task_e_68d5fff65e4c83319cdda3e3ba729600