### PR TITLE
Update ML deps for Python 3.13 compatibility

### DIFF
--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -20,7 +20,7 @@ Jinja2==3.1.6
 joblib==1.4.2
 jsonschema==4.25.1
 jsonschema-specifications==2025.9.1
-lightgbm==4.5.0
+lightgbm==4.6.0
 markdown-it-py==4.0.0
 MarkupSafe==3.0.2
 mdurl==0.1.2
@@ -34,7 +34,7 @@ numpy==2.1.3
 nvidia-nccl-cu12==2.28.3
 onnx==1.19.0
 onnxconverter-common==1.16.0
-onnxruntime==1.19.2
+onnxruntime==1.23.0
 packaging==24.2
 pandas==2.2.3
 polars==1.12.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,8 +13,8 @@ joblib==1.4.2
 # 🔧 Torch rompía el deploy en Py 3.13; se vuelve opcional (quitar pin duro)
 # torch==2.4.1
 xgboost==2.1.1
-lightgbm==4.5.0
-onnxruntime==1.19.2
+lightgbm==4.6.0
+onnxruntime==1.23.0
 skl2onnx==1.17.0
 # Fijamos rich compatible con Streamlit 1.38 para evitar conflictos en Cloud
 rich>=10.14.0,<14


### PR DESCRIPTION
## Summary
- bump LightGBM to 4.6.0 to ensure availability of Python 3.13 wheels
- bump ONNX Runtime to 1.23.0 for Python 3.13 compatibility

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d606dee7fc8331a96b124ca459d949