### PR TITLE
Refactor feature vector computation for batched tensor backend

### DIFF
--- a/app/modules/generator.py
+++ b/app/modules/generator.py
@@ -27,7 +27,15 @@ import threading
 from functools import lru_cache
 from pathlib import Path
 from typing import Any, Dict, Iterable, Mapping, NamedTuple, Sequence, Tuple
-from typing import Any, Dict, Iterable, Mapping, NamedTuple, Tuple
+
+try:
+    import jax.numpy as jnp
+    from jax import jit
+except Exception:  # pragma: no cover - JAX is optional during inference
+    jnp = None  # type: ignore[assignment]
+
+    def jit(fn):  # type: ignore[override]
+        return fn
 
 import numpy as np
 import pandas as pd
@@ -1317,6 +1325,22 @@ def _is_problematic(row: pd.Series) -> bool:
 # ---------------------------------------------------------------------------
 
 
+_KEYWORD_FEATURES: Dict[str, Tuple[str, ...]] = {
+    "aluminum_frac": ("aluminum", " alloy", " al "),
+    "foam_frac": ("foam", "zotek", "closed cell"),
+    "eva_frac": ("eva", "ctb", "nomex"),
+    "textile_frac": ("textile", "cloth", "fabric", "wipe"),
+    "multilayer_frac": ("multilayer", "pe-pet-al", "pouch"),
+    "glove_frac": ("glove", "nitrile"),
+    "polyethylene_frac": ("polyethylene", "pvdf", "ldpe"),
+    "carbon_fiber_frac": ("carbon fiber", "composite"),
+    "hydrogen_rich_frac": ("polyethylene", "cotton", "pvdf"),
+}
+
+_KEYWORD_INDEX = {name: idx for idx, name in enumerate(_KEYWORD_FEATURES)}
+_PACKAGING_TARGETS = ("packaging", "food packaging")
+
+
 def _material_tokens(row: pd.Series) -> str:
     parts = [
         str(row.get("material", "")),
@@ -1344,17 +1368,68 @@ def _category_fraction(categories: Iterable[str], weights: Iterable[float], targ
     return float(np.clip(score, 0.0, 1.0))
 
 
-def compute_feature_vector(
+@dataclass
+class CandidateFeatureContext:
+    total_mass: float
+    weights: np.ndarray
+    densities: np.ndarray
+    moisture: np.ndarray
+    difficulty: np.ndarray
+    pct_mass: np.ndarray
+    pct_volume: np.ndarray
+    tokens: Tuple[str, ...]
+    categories: Tuple[str, ...]
+    regolith_pct: float
+    mission_share: Dict[str, float]
+    mission_scaled_mass: Dict[str, float]
+    mission_official_mass: Dict[str, float]
+    official_composition: Dict[str, float]
+    num_items: int
+
+
+@dataclass
+class FeatureTensorBatch:
+    weights: Any
+    densities: Any
+    moisture: Any
+    difficulty: Any
+    pct_mass: Any
+    pct_volume: Any
+    keyword_hits: Any
+    packaging_hits: Any
+    mission_share: Any
+    mission_scaled_mass: Any
+    mission_official_mass: Any
+    mission_totals: Any
+    total_mass: Any
+    regolith: Any
+    keyword_names: Tuple[str, ...]
+    mission_names: Tuple[str, ...]
+    process_ids: Tuple[str, ...]
+    num_items: Tuple[int, ...]
+    official_comp: Tuple[Dict[str, float], ...]
+    l2l_constants: Dict[str, float]
+    bundle_processing_metrics: Dict[str, Dict[str, float]]
+    bundle_leo_mass_savings: Dict[str, Dict[str, float]]
+    bundle_propellant_benefits: Dict[str, Dict[str, float]]
+    logistics_ratio: float
+
+
+def _prepare_feature_context(
     picks: pd.DataFrame,
     weights: Iterable[float],
-    process: pd.Series,
     regolith_pct: float,
-) -> Dict[str, Any]:
+    bundle: "_OfficialFeaturesBundle",
+) -> CandidateFeatureContext:
     total_kg = max(0.001, float(picks["kg"].sum()))
-    base_weights = np.asarray(list(weights), dtype=float)
+    raw_weights = np.asarray(list(weights), dtype=float)
+    if len(raw_weights) < len(picks):
+        raw_weights = np.pad(raw_weights, (0, len(picks) - len(raw_weights)), constant_values=0.0)
+    elif len(raw_weights) > len(picks):
+        raw_weights = raw_weights[: len(picks)]
 
-    tokens = [_material_tokens(row) for _, row in picks.iterrows()]
-    categories = [str(row.get("category", "")).lower() for _, row in picks.iterrows()]
+    tokens = tuple(_material_tokens(row) for _, row in picks.iterrows())
+    categories = tuple(str(row.get("category", "")).lower() for _, row in picks.iterrows())
 
     pct_mass = picks.get("pct_mass", 0).to_numpy(dtype=float) / 100.0
     pct_volume = picks.get("pct_volume", 0).to_numpy(dtype=float) / 100.0
@@ -1362,36 +1437,6 @@ def compute_feature_vector(
     difficulty = picks.get("difficulty_factor", 1).to_numpy(dtype=float) / 3.0
     densities = picks.get("density_kg_m3", 0).to_numpy(dtype=float)
 
-    features: Dict[str, Any] = {
-        "process_id": str(process["process_id"]),
-        "total_mass_kg": total_kg,
-        "mass_input_kg": total_kg,
-        "num_items": int(len(picks)),
-        "density_kg_m3": float(np.dot(base_weights, densities)),
-        "moisture_frac": float(np.clip(np.dot(base_weights, moisture), 0.0, 1.0)),
-        "difficulty_index": float(np.clip(np.dot(base_weights, difficulty), 0.0, 1.0)),
-        "problematic_mass_frac": float(np.clip(np.dot(base_weights, pct_mass), 0.0, 1.0)),
-        "problematic_item_frac": float(np.clip(np.dot(base_weights, pct_volume), 0.0, 1.0)),
-        "regolith_pct": float(np.clip(regolith_pct, 0.0, 1.0)),
-        "packaging_frac": _category_fraction(tuple(categories), base_weights, ("packaging", "food packaging")),
-    }
-
-    keyword_map: Dict[str, Tuple[str, ...]] = {
-        "aluminum_frac": ("aluminum", " alloy", " al "),
-        "foam_frac": ("foam", "zotek", "closed cell"),
-        "eva_frac": ("eva", "ctb", "nomex"),
-        "textile_frac": ("textile", "cloth", "fabric", "wipe"),
-        "multilayer_frac": ("multilayer", "pe-pet-al", "pouch"),
-        "glove_frac": ("glove", "nitrile"),
-        "polyethylene_frac": ("polyethylene", "pvdf", "ldpe"),
-        "carbon_fiber_frac": ("carbon fiber", "composite"),
-        "hydrogen_rich_frac": ("polyethylene", "cotton", "pvdf"),
-    }
-
-    for name, keywords in keyword_map.items():
-        features[name] = _keyword_fraction(tuple(tokens), base_weights, keywords)
-
-    bundle = _official_features_bundle()
     official_comp: Dict[str, float] = {}
     if bundle.composition_columns:
         for column in bundle.composition_columns:
@@ -1400,61 +1445,12 @@ def compute_feature_vector(
             values = pd.to_numeric(picks[column], errors="coerce").fillna(0.0).to_numpy(dtype=float)
             if not len(values):
                 continue
-            frac = float(np.dot(base_weights, values / 100.0))
+            frac = float(np.dot(raw_weights[: len(values)], values / 100.0))
             official_comp[column] = frac
 
-    if official_comp:
-        clipped = {key: max(0.0, float(value)) for key, value in official_comp.items()}
-        total = sum(clipped.values())
-        if total > 1.0 + 1e-6:
-            official_comp = {key: value / total for key, value in clipped.items() if total > 0}
-        else:
-            official_comp = clipped
-            official_comp[column] = float(np.clip(frac, 0.0, 1.0))
-
-    def _set_official_fraction(name: str, *columns: str) -> None:
-        total = 0.0
-        found = False
-        for column in columns:
-            if column in official_comp:
-                total += official_comp[column]
-                found = True
-        if not found:
-            return
-        features[name] = float(np.clip(total, 0.0, 1.0))
-
-    if official_comp:
-        _set_official_fraction("aluminum_frac", "Aluminum_pct")
-        _set_official_fraction("carbon_fiber_frac", "Carbon_Fiber_pct")
-        _set_official_fraction("polyethylene_frac", "Polyethylene_pct")
-        _set_official_fraction("glove_frac", "Nitrile_pct")
-        _set_official_fraction("eva_frac", "Nomex_pct")
-        _set_official_fraction("foam_frac", "PVDF_pct")
-        _set_official_fraction("multilayer_frac", "EVOH_pct", "PET_pct")
-
-        textile_total = sum(
-            official_comp.get(column, 0.0)
-            for column in ("Cotton_Cellulose_pct", "Polyester_pct", "Nylon_pct")
-        )
-        if textile_total > 0:
-            features["textile_frac"] = float(np.clip(textile_total, 0.0, 1.0))
-
-        hydrogen_total = sum(
-            official_comp.get(column, 0.0)
-            for column in ("Polyethylene_pct", "Cotton_Cellulose_pct", "PVDF_pct")
-        )
-        if hydrogen_total > 0:
-            features["hydrogen_rich_frac"] = float(np.clip(hydrogen_total, 0.0, 1.0))
-
-    mission_similarity: Dict[str, float] = {}
+    mission_share: Dict[str, float] = {}
     mission_scaled_mass: Dict[str, float] = {}
     mission_official_mass: Dict[str, float] = {}
-    mission_similarity_clipped: Dict[str, float] = {}
-
-    l2l_constants = bundle.l2l_constants if bundle.l2l_constants else {}
-    for name, value in l2l_constants.items():
-        if isinstance(value, (int, float)) and np.isfinite(value):
-            features[name] = float(value)
 
     if bundle.mission_mass and bundle.mission_totals:
         match_keys_col = picks.get("_official_match_key")
@@ -1464,7 +1460,7 @@ def compute_feature_vector(
             match_keys_list = [""] * len(picks)
 
         for idx, (_, row) in enumerate(picks.iterrows()):
-            weight = float(base_weights[idx]) if idx < len(base_weights) else 0.0
+            weight = float(raw_weights[idx]) if idx < len(raw_weights) else 0.0
             if weight <= 0:
                 continue
 
@@ -1492,68 +1488,514 @@ def compute_feature_vector(
                     if not total_reference or total_reference <= 0:
                         continue
                     share = (reference_mass / total_reference) * weight
-                    mission_similarity[mission] = mission_similarity.get(mission, 0.0) + share
-                    mission_official_mass[mission] = mission_official_mass.get(mission, 0.0) + weight * reference_mass
+                    mission_share[mission] = mission_share.get(mission, 0.0) + share
+                    mission_official_mass[mission] = mission_official_mass.get(mission, 0.0) + weight * float(reference_mass)
                     mission_scaled_mass[mission] = mission_scaled_mass.get(mission, 0.0) + share * total_kg
 
-        if mission_similarity:
-            for mission, share in mission_similarity.items():
-                clipped = float(np.clip(share, 0.0, 1.0))
-                mission_similarity_clipped[mission] = clipped
-                features[f"mission_similarity_{mission}"] = clipped
-                total_reference = float(bundle.mission_totals.get(mission, 0.0))
-                features[f"mission_reference_mass_{mission}"] = float(max(0.0, clipped * total_reference))
-                features[f"mission_scaled_mass_{mission}"] = float(max(0.0, mission_scaled_mass.get(mission, 0.0)))
-                features[f"mission_official_mass_{mission}"] = float(max(0.0, mission_official_mass.get(mission, 0.0)))
+    return CandidateFeatureContext(
+        total_mass=total_kg,
+        weights=raw_weights,
+        densities=densities,
+        moisture=moisture,
+        difficulty=difficulty,
+        pct_mass=pct_mass,
+        pct_volume=pct_volume,
+        tokens=tokens,
+        categories=categories,
+        regolith_pct=float(regolith_pct),
+        mission_share=mission_share,
+        mission_scaled_mass=mission_scaled_mass,
+        mission_official_mass=mission_official_mass,
+        official_composition=official_comp,
+        num_items=int(len(picks)),
+    )
 
-            features["mission_similarity_total"] = float(
-                np.clip(sum(mission_similarity_clipped.values()), 0.0, 1.0)
-            )
 
-            def _apply_weighted_metrics(source: Dict[str, Dict[str, float]]) -> None:
-                if not source:
-                    return
-                weighted: Dict[str, float] = {}
-                for mission, share in mission_similarity_clipped.items():
-                    metrics = source.get(mission)
-                    if not metrics:
-                        continue
-                    for metric_name, value in metrics.items():
-                        expected_name = (
-                            metric_name
-                            if metric_name.endswith("_expected")
-                            else f"{metric_name}_expected"
-                        )
-                        weighted[expected_name] = weighted.get(expected_name, 0.0) + share * float(value)
-                        features[f"{metric_name}_{mission}"] = float(value)
+def _contexts_to_tensor_batch(
+    contexts: Sequence[CandidateFeatureContext],
+    processes: Sequence[pd.Series],
+    bundle: "_OfficialFeaturesBundle",
+    *,
+    backend: str = "jax",
+) -> FeatureTensorBatch:
+    if len(contexts) != len(processes):
+        raise ValueError("Number of contexts must match number of processes")
 
-                for metric_name, value in weighted.items():
-                    features[metric_name] = float(value)
+    batch = len(contexts)
+    max_items = max((ctx.num_items for ctx in contexts), default=0)
+    keyword_names = tuple(_KEYWORD_FEATURES.keys())
+    mission_names = tuple(sorted(bundle.mission_totals.keys())) if bundle.mission_totals else tuple()
 
-            _apply_weighted_metrics(bundle.processing_metrics)
-            _apply_weighted_metrics(bundle.leo_mass_savings)
-            _apply_weighted_metrics(bundle.propellant_benefits)
+    def _alloc(shape: tuple[int, ...]) -> np.ndarray:
+        return np.zeros(shape, dtype=float)
+
+    weights = _alloc((batch, max_items))
+    densities = _alloc((batch, max_items))
+    moisture = _alloc((batch, max_items))
+    difficulty = _alloc((batch, max_items))
+    pct_mass = _alloc((batch, max_items))
+    pct_volume = _alloc((batch, max_items))
+    keyword_hits = _alloc((batch, max_items, len(keyword_names)))
+    packaging_hits = _alloc((batch, max_items))
+    mission_share = _alloc((batch, len(mission_names)))
+    mission_scaled_mass = _alloc((batch, len(mission_names)))
+    mission_official_mass = _alloc((batch, len(mission_names)))
+
+    total_mass = np.zeros(batch, dtype=float)
+    regolith = np.zeros(batch, dtype=float)
+    num_items: list[int] = []
+    official_comp: list[Dict[str, float]] = []
+
+    mission_totals = np.array([float(bundle.mission_totals.get(name, 0.0)) for name in mission_names], dtype=float)
+
+    for idx, ctx in enumerate(contexts):
+        count = ctx.num_items
+        num_items.append(count)
+        official_comp.append(dict(ctx.official_composition))
+
+        if count:
+            weights[idx, :count] = ctx.weights[:count]
+            densities[idx, :count] = ctx.densities[:count]
+            moisture[idx, :count] = ctx.moisture[:count]
+            difficulty[idx, :count] = ctx.difficulty[:count]
+            pct_mass[idx, :count] = ctx.pct_mass[:count]
+            pct_volume[idx, :count] = ctx.pct_volume[:count]
+
+            for item_idx in range(count):
+                token = ctx.tokens[item_idx]
+                category = ctx.categories[item_idx]
+                for kw_idx, keywords in enumerate(keyword_names):
+                    patterns = _KEYWORD_FEATURES[keywords]
+                    if any(pattern in token for pattern in patterns):
+                        keyword_hits[idx, item_idx, kw_idx] = 1.0
+                if any(target in category for target in _PACKAGING_TARGETS):
+                    packaging_hits[idx, item_idx] = 1.0
+
+        for mission_idx, mission in enumerate(mission_names):
+            mission_share[idx, mission_idx] = ctx.mission_share.get(mission, 0.0)
+            mission_scaled_mass[idx, mission_idx] = ctx.mission_scaled_mass.get(mission, 0.0)
+            mission_official_mass[idx, mission_idx] = ctx.mission_official_mass.get(mission, 0.0)
+
+        total_mass[idx] = ctx.total_mass
+        regolith[idx] = ctx.regolith_pct
+
+    process_ids = tuple(str(proc.get("process_id")) for proc in processes)
+    l2l_constants = dict(bundle.l2l_constants or {})
+    logistics_ratio = float(l2l_constants.get("l2l_logistics_packaging_per_goods_ratio", float("nan")))
+
+    def _to_backend_array(array: np.ndarray) -> Any:
+        if backend == "jax" and jnp is not None:
+            return jnp.asarray(array)
+        return array
+
+    return FeatureTensorBatch(
+        weights=_to_backend_array(weights),
+        densities=_to_backend_array(densities),
+        moisture=_to_backend_array(moisture),
+        difficulty=_to_backend_array(difficulty),
+        pct_mass=_to_backend_array(pct_mass),
+        pct_volume=_to_backend_array(pct_volume),
+        keyword_hits=_to_backend_array(keyword_hits),
+        packaging_hits=_to_backend_array(packaging_hits),
+        mission_share=_to_backend_array(mission_share),
+        mission_scaled_mass=_to_backend_array(mission_scaled_mass),
+        mission_official_mass=_to_backend_array(mission_official_mass),
+        mission_totals=_to_backend_array(mission_totals),
+        total_mass=_to_backend_array(total_mass),
+        regolith=_to_backend_array(regolith),
+        keyword_names=keyword_names,
+        mission_names=mission_names,
+        process_ids=process_ids,
+        num_items=tuple(num_items),
+        official_comp=tuple(official_comp),
+        l2l_constants=l2l_constants,
+        bundle_processing_metrics=dict(bundle.processing_metrics or {}),
+        bundle_leo_mass_savings=dict(bundle.leo_mass_savings or {}),
+        bundle_propellant_benefits=dict(bundle.propellant_benefits or {}),
+        logistics_ratio=logistics_ratio,
+    )
+
+
+def build_feature_tensor_batch(
+    picks: Sequence[pd.DataFrame],
+    weights: Sequence[Iterable[float]],
+    processes: Sequence[pd.Series],
+    regolith_pct: Sequence[float],
+    *,
+    backend: str = "jax",
+) -> FeatureTensorBatch:
+    if not picks:
+        raise ValueError("picks must contain at least one candidate")
+
+    if not (len(picks) == len(weights) == len(processes) == len(regolith_pct)):
+        raise ValueError("picks, weights, processes and regolith_pct must share the same length")
+
+    bundle = _official_features_bundle()
+    contexts = [
+        _prepare_feature_context(p, w, r, bundle)
+        for p, w, r in zip(picks, weights, regolith_pct)
+    ]
+    return _contexts_to_tensor_batch(contexts, processes, bundle, backend=backend)
+
+
+def _feature_kernel_body(
+    xp: Any,
+    weights: Any,
+    densities: Any,
+    moisture: Any,
+    difficulty: Any,
+    pct_mass: Any,
+    pct_volume: Any,
+    keyword_hits: Any,
+    packaging_hits: Any,
+    mission_share: Any,
+    mission_scaled_mass: Any,
+    mission_official_mass: Any,
+    mission_totals: Any,
+    regolith: Any,
+    logistics_ratio: float,
+) -> Dict[str, Any]:
+    w = xp.asarray(weights)
+    densities = xp.asarray(densities)
+    moisture = xp.asarray(moisture)
+    difficulty = xp.asarray(difficulty)
+    pct_mass = xp.asarray(pct_mass)
+    pct_volume = xp.asarray(pct_volume)
+    keyword_hits = xp.asarray(keyword_hits)
+    packaging_hits = xp.asarray(packaging_hits)
+    mission_share = xp.asarray(mission_share)
+    mission_scaled_mass = xp.asarray(mission_scaled_mass)
+    mission_official_mass = xp.asarray(mission_official_mass)
+    mission_totals = xp.asarray(mission_totals)
+    regolith = xp.asarray(regolith)
+
+    density = xp.sum(w * densities, axis=1)
+    moisture_frac = xp.clip(xp.sum(w * moisture, axis=1), 0.0, 1.0)
+    difficulty_index = xp.clip(xp.sum(w * difficulty, axis=1), 0.0, 1.0)
+    problematic_mass_frac = xp.clip(xp.sum(w * pct_mass, axis=1), 0.0, 1.0)
+    problematic_item_frac = xp.clip(xp.sum(w * pct_volume, axis=1), 0.0, 1.0)
+
+    keyword = xp.clip(xp.sum(w[:, :, None] * keyword_hits, axis=1), 0.0, 1.0)
+    packaging = xp.clip(xp.sum(w * packaging_hits, axis=1), 0.0, 1.0)
+
+    mission_share_clipped = xp.clip(mission_share, 0.0, 1.0)
+    mission_similarity_total = xp.clip(xp.sum(mission_share_clipped, axis=1), 0.0, 1.0)
+    mission_reference_mass = xp.maximum(0.0, mission_share_clipped * mission_totals)
+    mission_scaled_mass = xp.maximum(0.0, mission_scaled_mass)
+    mission_official_mass = xp.maximum(0.0, mission_official_mass)
+
+    polyethylene = keyword[:, _KEYWORD_INDEX["polyethylene_frac"]] if keyword.shape[1] else xp.zeros(keyword.shape[0])
+    foam = keyword[:, _KEYWORD_INDEX["foam_frac"]] if keyword.shape[1] else xp.zeros(keyword.shape[0])
+    eva = keyword[:, _KEYWORD_INDEX["eva_frac"]] if keyword.shape[1] else xp.zeros(keyword.shape[0])
+    textile = keyword[:, _KEYWORD_INDEX["textile_frac"]] if keyword.shape[1] else xp.zeros(keyword.shape[0])
 
     gas_index = _GAS_MEAN_YIELD * (
-        0.7 * features.get("polyethylene_frac", 0.0)
-        + 0.4 * features.get("foam_frac", 0.0)
-        + 0.5 * features.get("eva_frac", 0.0)
-        + 0.2 * features.get("textile_frac", 0.0)
+        0.7 * polyethylene
+        + 0.4 * foam
+        + 0.5 * eva
+        + 0.2 * textile
     )
-    features["gas_recovery_index"] = float(np.clip(gas_index / 10.0, 0.0, 1.0))
+    gas_recovery_index = xp.clip(gas_index / 10.0, 0.0, 1.0)
 
-    packaging_term = features.get("packaging_frac", 0.0) + 0.5 * features.get("eva_frac", 0.0)
-    packaging_ratio = l2l_constants.get("l2l_logistics_packaging_per_goods_ratio")
-    if packaging_ratio and np.isfinite(packaging_ratio) and packaging_ratio > 0:
-        logistics_index = packaging_term / float(packaging_ratio)
+    ratio = xp.asarray(logistics_ratio)
+    ratio = xp.where(xp.isfinite(ratio), ratio, xp.asarray(float("nan")))
+    packaging_term = packaging + 0.5 * eva
+    ratio_broadcast = xp.broadcast_to(ratio, packaging_term.shape)
+    valid_ratio = xp.logical_and(xp.isfinite(ratio_broadcast), ratio_broadcast > 0)
+    reuse_term = packaging_term * _MEAN_REUSE
+    logistics_index = xp.where(valid_ratio, packaging_term / ratio_broadcast, reuse_term)
+    logistics_index = xp.clip(logistics_index, 0.0, 2.0)
+
+    regolith = xp.clip(regolith, 0.0, 1.0)
+
+    return {
+        "density": density,
+        "moisture": moisture_frac,
+        "difficulty": difficulty_index,
+        "problematic_mass": problematic_mass_frac,
+        "problematic_item": problematic_item_frac,
+        "keyword": keyword,
+        "packaging": packaging,
+        "mission_similarity": mission_share_clipped,
+        "mission_reference_mass": mission_reference_mass,
+        "mission_scaled_mass": mission_scaled_mass,
+        "mission_official_mass": mission_official_mass,
+        "mission_similarity_total": mission_similarity_total,
+        "gas_recovery_index": gas_recovery_index,
+        "logistics_reuse_index": logistics_index,
+        "regolith": regolith,
+    }
+
+
+if jnp is not None:
+
+    @jit
+    def _feature_kernel(
+        weights: Any,
+        densities: Any,
+        moisture: Any,
+        difficulty: Any,
+        pct_mass: Any,
+        pct_volume: Any,
+        keyword_hits: Any,
+        packaging_hits: Any,
+        mission_share: Any,
+        mission_scaled_mass: Any,
+        mission_official_mass: Any,
+        mission_totals: Any,
+        regolith: Any,
+        logistics_ratio: float,
+    ) -> Dict[str, Any]:
+        return _feature_kernel_body(
+            jnp,
+            weights,
+            densities,
+            moisture,
+            difficulty,
+            pct_mass,
+            pct_volume,
+            keyword_hits,
+            packaging_hits,
+            mission_share,
+            mission_scaled_mass,
+            mission_official_mass,
+            mission_totals,
+            regolith,
+            logistics_ratio,
+        )
+
+else:
+
+    def _feature_kernel(
+        weights: Any,
+        densities: Any,
+        moisture: Any,
+        difficulty: Any,
+        pct_mass: Any,
+        pct_volume: Any,
+        keyword_hits: Any,
+        packaging_hits: Any,
+        mission_share: Any,
+        mission_scaled_mass: Any,
+        mission_official_mass: Any,
+        mission_totals: Any,
+        regolith: Any,
+        logistics_ratio: float,
+    ) -> Dict[str, Any]:
+        return _feature_kernel_body(
+            np,
+            weights,
+            densities,
+            moisture,
+            difficulty,
+            pct_mass,
+            pct_volume,
+            keyword_hits,
+            packaging_hits,
+            mission_share,
+            mission_scaled_mass,
+            mission_official_mass,
+            mission_totals,
+            regolith,
+            logistics_ratio,
+        )
+
+
+def _apply_official_composition_overrides(
+    features: Dict[str, Any], official_comp: Mapping[str, float]
+) -> None:
+    if not official_comp:
+        return
+
+    clipped = {key: max(0.0, float(value)) for key, value in official_comp.items()}
+    total = sum(clipped.values())
+    if total > 1.0 + 1e-6 and total > 0:
+        normalized = {key: value / total for key, value in clipped.items()}
     else:
-        logistics_index = _MEAN_REUSE * packaging_term
-    features["logistics_reuse_index"] = float(np.clip(logistics_index, 0.0, 2.0))
+        normalized = {key: float(np.clip(value, 0.0, 1.0)) for key, value in clipped.items()}
 
-    for oxide, value in _REGOLITH_VECTOR.items():
-        features[f"oxide_{oxide}"] = float(value * regolith_pct)
+    def _set_official_fraction(name: str, *columns: str) -> None:
+        total_value = 0.0
+        found = False
+        for column in columns:
+            if column in normalized:
+                total_value += normalized[column]
+                found = True
+        if not found:
+            return
+        features[name] = float(np.clip(total_value, 0.0, 1.0))
 
-    return features
+    _set_official_fraction("aluminum_frac", "Aluminum_pct")
+    _set_official_fraction("carbon_fiber_frac", "Carbon_Fiber_pct")
+    _set_official_fraction("polyethylene_frac", "Polyethylene_pct")
+    _set_official_fraction("glove_frac", "Nitrile_pct")
+    _set_official_fraction("eva_frac", "Nomex_pct")
+    _set_official_fraction("foam_frac", "PVDF_pct")
+    _set_official_fraction("multilayer_frac", "EVOH_pct", "PET_pct")
+
+    textile_total = sum(
+        normalized.get(column, 0.0)
+        for column in ("Cotton_Cellulose_pct", "Polyester_pct", "Nylon_pct")
+    )
+    if textile_total > 0:
+        features["textile_frac"] = float(np.clip(textile_total, 0.0, 1.0))
+
+    hydrogen_total = sum(
+        normalized.get(column, 0.0)
+        for column in ("Polyethylene_pct", "Cotton_Cellulose_pct", "PVDF_pct")
+    )
+    if hydrogen_total > 0:
+        features["hydrogen_rich_frac"] = float(np.clip(hydrogen_total, 0.0, 1.0))
+
+
+def _apply_weighted_metrics(
+    features: Dict[str, Any],
+    mission_similarity_clipped: Mapping[str, float],
+    source: Mapping[str, Mapping[str, float]],
+) -> None:
+    if not source or not mission_similarity_clipped:
+        return
+    weighted: Dict[str, float] = {}
+    for mission, share in mission_similarity_clipped.items():
+        metrics = source.get(mission)
+        if not metrics:
+            continue
+        for metric_name, value in metrics.items():
+            expected_name = (
+                metric_name if metric_name.endswith("_expected") else f"{metric_name}_expected"
+            )
+            weighted[expected_name] = weighted.get(expected_name, 0.0) + share * float(value)
+            features[f"{metric_name}_{mission}"] = float(value)
+    for metric_name, value in weighted.items():
+        features[metric_name] = float(value)
+
+
+def _compute_features_from_batch(batch: FeatureTensorBatch) -> list[Dict[str, Any]]:
+    if not batch.process_ids:
+        return []
+
+    kernel_output = _feature_kernel(
+        batch.weights,
+        batch.densities,
+        batch.moisture,
+        batch.difficulty,
+        batch.pct_mass,
+        batch.pct_volume,
+        batch.keyword_hits,
+        batch.packaging_hits,
+        batch.mission_share,
+        batch.mission_scaled_mass,
+        batch.mission_official_mass,
+        batch.mission_totals,
+        batch.regolith,
+        batch.logistics_ratio,
+    )
+
+    to_numpy = np.asarray
+    density = to_numpy(kernel_output["density"])
+    moisture = to_numpy(kernel_output["moisture"])
+    difficulty = to_numpy(kernel_output["difficulty"])
+    problematic_mass = to_numpy(kernel_output["problematic_mass"])
+    problematic_item = to_numpy(kernel_output["problematic_item"])
+    keyword_matrix = to_numpy(kernel_output["keyword"])
+    packaging = to_numpy(kernel_output["packaging"])
+    mission_similarity = to_numpy(kernel_output["mission_similarity"])
+    mission_reference_mass = to_numpy(kernel_output["mission_reference_mass"])
+    mission_scaled_mass = to_numpy(kernel_output["mission_scaled_mass"])
+    mission_official_mass = to_numpy(kernel_output["mission_official_mass"])
+    mission_similarity_total = to_numpy(kernel_output["mission_similarity_total"])
+    gas_recovery = to_numpy(kernel_output["gas_recovery_index"])
+    logistics_reuse = to_numpy(kernel_output["logistics_reuse_index"])
+    regolith = to_numpy(kernel_output["regolith"])
+    total_mass = to_numpy(batch.total_mass)
+
+    features_list: list[Dict[str, Any]] = []
+    for idx, process_id in enumerate(batch.process_ids):
+        features: Dict[str, Any] = {
+            "process_id": str(process_id),
+            "total_mass_kg": float(total_mass[idx]),
+            "mass_input_kg": float(total_mass[idx]),
+            "num_items": int(batch.num_items[idx]),
+            "density_kg_m3": float(density[idx]) if density.size else 0.0,
+            "moisture_frac": float(moisture[idx]) if moisture.size else 0.0,
+            "difficulty_index": float(difficulty[idx]) if difficulty.size else 0.0,
+            "problematic_mass_frac": float(problematic_mass[idx]) if problematic_mass.size else 0.0,
+            "problematic_item_frac": float(problematic_item[idx]) if problematic_item.size else 0.0,
+            "regolith_pct": float(regolith[idx]) if regolith.size else 0.0,
+            "packaging_frac": float(packaging[idx]) if packaging.size else 0.0,
+        }
+
+        for name, kw_idx in _KEYWORD_INDEX.items():
+            if keyword_matrix.shape[1] > kw_idx:
+                features[name] = float(keyword_matrix[idx, kw_idx])
+
+        _apply_official_composition_overrides(features, batch.official_comp[idx])
+
+        for name, value in batch.l2l_constants.items():
+            if isinstance(value, (int, float)) and np.isfinite(value):
+                features[name] = float(value)
+
+        mission_similarity_row = mission_similarity[idx] if mission_similarity.size else np.array([])
+        mission_similarity_dict: Dict[str, float] = {}
+        if mission_similarity_row.size and np.any(mission_similarity_row > 0):
+            for mission_idx, mission in enumerate(batch.mission_names):
+                share = float(mission_similarity_row[mission_idx])
+                if share <= 0:
+                    continue
+                mission_similarity_dict[mission] = share
+                features[f"mission_similarity_{mission}"] = float(np.clip(share, 0.0, 1.0))
+                features[f"mission_reference_mass_{mission}"] = float(mission_reference_mass[idx, mission_idx])
+                features[f"mission_scaled_mass_{mission}"] = float(mission_scaled_mass[idx, mission_idx])
+                features[f"mission_official_mass_{mission}"] = float(mission_official_mass[idx, mission_idx])
+
+            features["mission_similarity_total"] = float(mission_similarity_total[idx])
+
+            _apply_weighted_metrics(features, mission_similarity_dict, batch.bundle_processing_metrics)
+            _apply_weighted_metrics(features, mission_similarity_dict, batch.bundle_leo_mass_savings)
+            _apply_weighted_metrics(features, mission_similarity_dict, batch.bundle_propellant_benefits)
+
+        features["gas_recovery_index"] = float(gas_recovery[idx]) if gas_recovery.size else 0.0
+        features["logistics_reuse_index"] = float(logistics_reuse[idx]) if logistics_reuse.size else 0.0
+
+        for oxide, value in _REGOLITH_VECTOR.items():
+            features[f"oxide_{oxide}"] = float(value * features["regolith_pct"])
+
+        features_list.append(features)
+
+    return features_list
+
+
+def compute_feature_vectors_batch(
+    picks: Sequence[pd.DataFrame],
+    weights: Sequence[Iterable[float]],
+    processes: Sequence[pd.Series],
+    regolith_pct: Sequence[float],
+    *,
+    backend: str = "jax",
+) -> list[Dict[str, Any]]:
+    batch = build_feature_tensor_batch(picks, weights, processes, regolith_pct, backend=backend)
+    return _compute_features_from_batch(batch)
+
+
+def compute_feature_vector(
+    picks: pd.DataFrame | FeatureTensorBatch,
+    weights: Iterable[float] | None = None,
+    process: pd.Series | None = None,
+    regolith_pct: float | None = None,
+) -> Dict[str, Any] | list[Dict[str, Any]]:
+    if isinstance(picks, FeatureTensorBatch):
+        return _compute_features_from_batch(picks)
+
+    if not isinstance(picks, pd.DataFrame):
+        raise TypeError("picks must be a pandas.DataFrame or a FeatureTensorBatch")
+    if weights is None or process is None or regolith_pct is None:
+        raise ValueError("weights, process and regolith_pct are required for DataFrame inputs")
+
+    bundle = _official_features_bundle()
+    context = _prepare_feature_context(picks, weights, regolith_pct, bundle)
+    batch = _contexts_to_tensor_batch([context], [process], bundle)
+    features = _compute_features_from_batch(batch)
+    return features[0] if features else {}
 
 
 def heuristic_props(
@@ -1669,15 +2111,27 @@ def _score_candidate(
     return float(score), breakdown, auxiliary
 
 
-def _build_candidate(
+@dataclass
+class CandidateComponents:
+    picks: pd.DataFrame
+    process: pd.Series
+    weights: list[float]
+    regolith_pct: float
+    total_mass: float
+    materials_for_plan: list[str]
+    weights_for_plan: list[float]
+    used_ids: list[str]
+    used_cats: list[str]
+    used_flags: list[str]
+    used_mats: list[str]
+
+
+def _create_candidate_components(
     picks: pd.DataFrame,
     proc_df: pd.DataFrame,
     rng: random.Random,
-    target: dict,
-    crew_time_low: bool,
-    use_ml: bool,
     tuning: dict[str, Any] | None,
-) -> dict | None:
+) -> CandidateComponents | None:
     if picks.empty or proc_df is None or proc_df.empty:
         return None
 
@@ -1708,7 +2162,41 @@ def _build_candidate(
         if total > 0:
             weights_for_plan = [round(w / total, 3) for w in weights_for_plan]
 
-    features = compute_feature_vector(picks, weights, proc, regolith_pct)
+    return CandidateComponents(
+        picks=picks,
+        process=proc,
+        weights=weights,
+        regolith_pct=regolith_pct,
+        total_mass=total_kg,
+        materials_for_plan=materials_for_plan,
+        weights_for_plan=weights_for_plan,
+        used_ids=used_ids,
+        used_cats=used_cats,
+        used_flags=used_flags,
+        used_mats=used_mats,
+    )
+
+
+def _finalize_candidate(
+    components: CandidateComponents,
+    features: Dict[str, Any],
+    target: dict,
+    crew_time_low: bool,
+    use_ml: bool,
+) -> dict | None:
+    picks = components.picks
+    proc = components.process
+    weights = components.weights
+    regolith_pct = components.regolith_pct
+    total_kg = components.total_mass
+    materials_for_plan = components.materials_for_plan
+    weights_for_plan = components.weights_for_plan
+    used_ids = components.used_ids
+    used_cats = components.used_cats
+    used_flags = components.used_flags
+    used_mats = components.used_mats
+
+    features = dict(features)
     recipe_id = derive_recipe_id(picks, proc, features)
     if recipe_id:
         features["recipe_id"] = recipe_id
@@ -1864,6 +2352,32 @@ def _build_candidate(
     }
 
 
+def _build_candidate(
+    picks: pd.DataFrame,
+    proc_df: pd.DataFrame,
+    rng: random.Random,
+    target: dict,
+    crew_time_low: bool,
+    use_ml: bool,
+    tuning: dict[str, Any] | None,
+) -> dict | None:
+    components = _create_candidate_components(picks, proc_df, rng, tuning)
+    if components is None:
+        return None
+
+    batch = build_feature_tensor_batch(
+        [components.picks],
+        [components.weights],
+        [components.process],
+        [components.regolith_pct],
+    )
+    features_batch = _compute_features_from_batch(batch)
+    if not features_batch:
+        return None
+
+    return _finalize_candidate(components, features_batch[0], target, crew_time_low, use_ml)
+
+
 # ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
@@ -1891,13 +2405,41 @@ def generate_candidates(
         override = override or {}
         bias = float(override.get("problematic_bias", 2.0))
         picks = _pick_materials(df, rng, n=rng.choice([2, 3]), bias=bias)
-        return _build_candidate(picks, proc_df, rng, target, crew_time_low, use_ml, override)
+        components = _create_candidate_components(picks, proc_df, rng, override)
+        if components is None:
+            return None
+        batch = build_feature_tensor_batch(
+            [components.picks],
+            [components.weights],
+            [components.process],
+            [components.regolith_pct],
+        )
+        features = _compute_features_from_batch(batch)
+        if not features:
+            return None
+        return _finalize_candidate(components, features[0], target, crew_time_low, use_ml)
+
+    components_batch: list[CandidateComponents] = []
+    for _ in range(n):
+        bias = 2.0
+        picks = _pick_materials(df, rng, n=rng.choice([2, 3]), bias=bias)
+        components = _create_candidate_components(picks, proc_df, rng, {})
+        if components:
+            components_batch.append(components)
 
     candidates: list[dict] = []
-    for _ in range(n):
-        candidate = sampler({})
-        if candidate:
-            candidates.append(candidate)
+    if components_batch:
+        batch = build_feature_tensor_batch(
+            [comp.picks for comp in components_batch],
+            [comp.weights for comp in components_batch],
+            [comp.process for comp in components_batch],
+            [comp.regolith_pct for comp in components_batch],
+        )
+        features_list = _compute_features_from_batch(batch)
+        for comp, feat in zip(components_batch, features_list):
+            candidate = _finalize_candidate(comp, feat, target, crew_time_low, use_ml)
+            if candidate:
+                candidates.append(candidate)
 
     history = pd.DataFrame()
     if optimizer_evals and optimizer_evals > 0:
@@ -1924,5 +2466,8 @@ __all__ = [
     "PredProps",
     "prepare_waste_frame",
     "compute_feature_vector",
+    "compute_feature_vectors_batch",
+    "build_feature_tensor_batch",
+    "FeatureTensorBatch",
     "heuristic_props",
 ]

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import shutil
+from datetime import datetime
 from pathlib import Path
 
 from deltalake import DeltaTable
@@ -10,6 +11,28 @@ import pandas as pd
 import pytest
 
 from app.modules import generator
+
+
+def _batched_feature_vectors(
+    picks: pd.DataFrame,
+    weights: list[float],
+    process: pd.Series,
+    regolith_pct: float,
+    repeat: int = 2,
+) -> list[dict]:
+    picks_list = [picks.copy(deep=True) for _ in range(repeat)]
+    weights_list = [list(weights) for _ in range(repeat)]
+    process_list = [process.copy(deep=True) for _ in range(repeat)]
+    regolith_list = [regolith_pct for _ in range(repeat)]
+    tensor_batch = generator.build_feature_tensor_batch(
+        picks_list,
+        weights_list,
+        process_list,
+        regolith_list,
+    )
+    batched = generator.compute_feature_vector(tensor_batch)
+    assert isinstance(batched, list)
+    return batched
 
 
 def test_load_waste_summary_data_polars(tmp_path, monkeypatch):
@@ -320,7 +343,6 @@ def test_generate_candidates_appends_inference_log(monkeypatch, tmp_path):
     shutil.rmtree(log_dir.parent, ignore_errors=True)
 
 def test_generate_candidates_heuristic_mode_skips_ml(monkeypatch, tmp_path):
-def test_generate_candidates_heuristic_mode_skips_ml(monkeypatch):
     calls: list[str] = []
 
     class NoCallRegistry:
@@ -450,6 +472,13 @@ def test_compute_feature_vector_blends_official_and_keyword_sources():
     assert features["gas_recovery_index"] > 0.0
     assert features["moisture_frac"] == pytest.approx(0.028, rel=1e-6)
 
+    batched = _batched_feature_vectors(prepared, [0.7, 0.3], process, 0.0)
+    assert len(batched) == 2
+    for candidate in batched:
+        assert candidate["polyethylene_frac"] == pytest.approx(features["polyethylene_frac"], rel=1e-6)
+        assert candidate["gas_recovery_index"] == pytest.approx(features["gas_recovery_index"], rel=1e-6)
+        assert candidate["moisture_frac"] == pytest.approx(features["moisture_frac"], rel=1e-6)
+
 
 def test_compute_feature_vector_keyword_fallback_triggers_polyethylene():
     waste_df = pd.DataFrame(
@@ -474,6 +503,12 @@ def test_compute_feature_vector_keyword_fallback_triggers_polyethylene():
 
     assert features["polyethylene_frac"] > 0.5
     assert features["gas_recovery_index"] > 0.0
+
+    batched = _batched_feature_vectors(prepared, [1.0], process, 0.0)
+    assert len(batched) == 2
+    for candidate in batched:
+        assert candidate["polyethylene_frac"] == pytest.approx(features["polyethylene_frac"], rel=1e-6)
+        assert candidate["gas_recovery_index"] == pytest.approx(features["gas_recovery_index"], rel=1e-6)
 
 
 def test_compute_feature_vector_includes_mission_metrics(monkeypatch):
@@ -535,6 +570,19 @@ def test_compute_feature_vector_includes_mission_metrics(monkeypatch):
     assert features["processing_o2_ch4_yield_kg_expected"] == pytest.approx(1.0, rel=1e-6)
     assert features["leo_mass_savings_kg_expected"] == pytest.approx(24.0, rel=1e-6)
     assert features["propellant_delta_v_m_s_expected"] == pytest.approx(7.0, rel=1e-6)
+
+    batched = _batched_feature_vectors(prepared, [1.0], process, 0.0)
+    assert len(batched) == 2
+    for candidate in batched:
+        assert candidate["mission_similarity_gateway_i"] == pytest.approx(features["mission_similarity_gateway_i"], rel=1e-6)
+        assert candidate["mission_reference_mass_gateway_i"] == pytest.approx(features["mission_reference_mass_gateway_i"], rel=1e-6)
+        assert candidate["mission_scaled_mass_gateway_i"] == pytest.approx(features["mission_scaled_mass_gateway_i"], rel=1e-6)
+        assert candidate["mission_official_mass_gateway_i"] == pytest.approx(features["mission_official_mass_gateway_i"], rel=1e-6)
+        assert candidate["mission_similarity_total"] == pytest.approx(features["mission_similarity_total"], rel=1e-6)
+        assert candidate["processing_o2_ch4_yield_kg_gateway_i"] == pytest.approx(features["processing_o2_ch4_yield_kg_gateway_i"], rel=1e-6)
+        assert candidate["processing_o2_ch4_yield_kg_expected"] == pytest.approx(features["processing_o2_ch4_yield_kg_expected"], rel=1e-6)
+        assert candidate["leo_mass_savings_kg_expected"] == pytest.approx(features["leo_mass_savings_kg_expected"], rel=1e-6)
+        assert candidate["propellant_delta_v_m_s_expected"] == pytest.approx(features["propellant_delta_v_m_s_expected"], rel=1e-6)
 
 
 def test_prepare_waste_frame_injects_l2l_features(monkeypatch):
@@ -634,3 +682,11 @@ def test_compute_feature_vector_uses_l2l_packaging_ratio(monkeypatch):
     packaging_term = features.get("packaging_frac", 0.0) + 0.5 * features.get("eva_frac", 0.0)
     expected = min(2.0, packaging_term / 0.2 if 0.2 else 0.0)
     assert features["logistics_reuse_index"] == pytest.approx(expected, rel=1e-6)
+
+    batched = _batched_feature_vectors(prepared, [1.0], process, 0.0)
+    assert len(batched) == 2
+    for candidate in batched:
+        assert candidate["l2l_logistics_packaging_per_goods_ratio"] == pytest.approx(
+            features["l2l_logistics_packaging_per_goods_ratio"], rel=1e-6
+        )
+        assert candidate["logistics_reuse_index"] == pytest.approx(features["logistics_reuse_index"], rel=1e-6)


### PR DESCRIPTION
## Summary
- refactor compute_feature_vector to operate on batched tensor payloads through a JAX-compiled kernel
- update generate_candidates to build batched feature tensors and reuse the vectorized pipeline
- extend generator tests to validate the new batched API against legacy scalar results

## Testing
- pytest tests/test_generator.py

------
https://chatgpt.com/codex/tasks/task_e_68d60908d0f48331a8b9647666e3f3d8