### PR TITLE
Enable parallel candidate generation and optimization

### DIFF
--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import json
+import random
 import shutil
 from pathlib import Path
+from datetime import datetime
 
 from deltalake import DeltaTable
 
@@ -195,6 +197,89 @@ def _collect_single_log_dir(root: Path) -> Path:
     return day_dirs[0]
 
 
+def test_generate_candidates_uses_parallel_backend(monkeypatch):
+    monkeypatch.setattr(generator, "_PARALLEL_THRESHOLD", 1)
+
+    created: list[object] = []
+
+    class DummyExecutor:
+        def __init__(self, max_workers: int):
+            self.max_workers = max_workers
+            self.map_calls = 0
+            self.shutdown_called = False
+            created.append(self)
+
+        def map(self, func, iterable):
+            self.map_calls += 1
+            return [func(item) for item in iterable]
+
+        def shutdown(self):
+            self.shutdown_called = True
+
+    monkeypatch.setattr(generator, "ThreadPoolExecutor", DummyExecutor)
+    monkeypatch.setattr(generator, "prepare_waste_frame", lambda df: df)
+    monkeypatch.setattr(generator, "_pick_materials", lambda df, rng, n=2, bias=2.0: pd.DataFrame(
+        {
+            "kg": [1.0],
+            "_source_id": ["A"],
+            "_source_category": ["packaging"],
+            "_source_flags": [""],
+            "material": ["foil"],
+        }
+    ))
+
+    draws: list[float] = []
+
+    def fake_build(picks, proc_df, rng, target, crew_time_low, use_ml, tuning):
+        value = rng.random()
+        draws.append(value)
+        return {
+            "score": value,
+            "props": generator.PredProps(
+                rigidity=1.0,
+                tightness=1.0,
+                mass_final_kg=1.0,
+                energy_kwh=0.1,
+                water_l=0.1,
+                crew_min=1.0,
+            ),
+        }
+
+    monkeypatch.setattr(generator, "_build_candidate", fake_build)
+    base_random_cls = random.Random
+    monkeypatch.setattr(generator.random, "Random", lambda *args, **kwargs: base_random_cls(1234))
+
+    waste_df = pd.DataFrame(
+        {
+            "material": ["foil"],
+            "kg": [1.0],
+            "_problematic": [0],
+            "_source_id": ["A"],
+            "_source_category": ["packaging"],
+            "_source_flags": [""],
+        }
+    )
+    proc_df = pd.DataFrame({"process_id": ["P01"], "name": ["Process"]})
+
+    candidates, history = generator.generate_candidates(
+        waste_df,
+        proc_df,
+        target={},
+        n=5,
+        crew_time_low=False,
+        optimizer_evals=0,
+        use_ml=False,
+    )
+
+    assert len(candidates) == 5
+    scores = [cand["score"] for cand in candidates]
+    assert scores == sorted(scores, reverse=True)
+    assert len(draws) == 5
+    assert created and created[0].map_calls >= 1
+    assert created[0].shutdown_called is True
+    assert history.empty
+
+
 def test_append_inference_log_appends_without_reads(monkeypatch, tmp_path):
     monkeypatch.setattr(generator, "LOGS_ROOT", tmp_path)
 
@@ -319,8 +404,8 @@ def test_generate_candidates_appends_inference_log(monkeypatch, tmp_path):
 
     shutil.rmtree(log_dir.parent, ignore_errors=True)
 
+
 def test_generate_candidates_heuristic_mode_skips_ml(monkeypatch, tmp_path):
-def test_generate_candidates_heuristic_mode_skips_ml(monkeypatch):
     calls: list[str] = []
 
     class NoCallRegistry:

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -1,0 +1,124 @@
+import random
+import types
+
+from app.modules import optimizer
+
+
+def _make_candidate(score: float) -> optimizer.Candidate:
+    return {
+        "score": score,
+        "props": types.SimpleNamespace(
+            energy_kwh=0.1,
+            water_l=0.1,
+            crew_min=10.0,
+        ),
+    }
+
+
+def test_optimize_candidates_parallel_heuristic(monkeypatch):
+    monkeypatch.setattr(optimizer, "_PARALLEL_THRESHOLD", 1)
+
+    class DummyExecutor:
+        def __init__(self, max_workers: int):
+            self.max_workers = max_workers
+            self.map_calls = 0
+            self.submit_calls = 0
+            self.shutdown_called = False
+
+        def map(self, func, iterable):
+            self.map_calls += 1
+            return [func(item) for item in iterable]
+
+        def submit(self, func, *args, **kwargs):
+            self.submit_calls += 1
+            result = func(*args, **kwargs)
+            return types.SimpleNamespace(result=lambda: result)
+
+        def shutdown(self):
+            self.shutdown_called = True
+
+    dummy_executor = DummyExecutor(4)
+    monkeypatch.setattr(optimizer, "ThreadPoolExecutor", lambda max_workers: dummy_executor)
+
+    random.seed(42)
+
+    def sampler(_override):
+        return _make_candidate(random.random())
+
+    initial = [_make_candidate(0.5)]
+    pareto, history = optimizer.optimize_candidates(initial, sampler, target={}, n_evals=3)
+
+    assert len(history) == 4
+    assert history.iteration.tolist() == [0, 1, 2, 3]
+    assert dummy_executor.map_calls >= 2
+    assert dummy_executor.shutdown_called is True
+    assert pareto and all(isinstance(item, dict) for item in pareto)
+
+
+def test_optimize_candidates_parallel_ax(monkeypatch):
+    monkeypatch.setattr(optimizer, "_PARALLEL_THRESHOLD", 1)
+
+    class DummyExecutor:
+        def __init__(self, max_workers: int):
+            self.max_workers = max_workers
+            self.map_calls = 0
+            self.submit_calls = 0
+            self.shutdown_called = False
+
+        def map(self, func, iterable):
+            self.map_calls += 1
+            return [func(item) for item in iterable]
+
+        def submit(self, func, *args, **kwargs):
+            self.submit_calls += 1
+            result = func(*args, **kwargs)
+            return types.SimpleNamespace(result=lambda: result)
+
+        def shutdown(self):
+            self.shutdown_called = True
+
+    dummy_executor = DummyExecutor(4)
+    monkeypatch.setattr(optimizer, "ThreadPoolExecutor", lambda max_workers: dummy_executor)
+
+    class DummyAxClient:
+        def __init__(self, enforce_sequential_optimization: bool = True):
+            self.enforce_sequential_optimization = enforce_sequential_optimization
+            self.calls = 0
+            self.completed: list[tuple[int, float]] = []
+
+        def create_experiment(self, **kwargs):
+            return None
+
+        def get_next_trial(self):
+            params = {
+                "problematic_bias": 1.0 + 0.1 * self.calls,
+                "regolith_pct": 0.05 * self.calls,
+                "process_choice": "P02",
+            }
+            idx = self.calls
+            self.calls += 1
+            return params, idx
+
+        def complete_trial(self, trial_index: int, raw_data: float):
+            self.completed.append((trial_index, raw_data))
+
+    monkeypatch.setattr(optimizer, "AX_AVAILABLE", True)
+    monkeypatch.setattr(optimizer, "AxClient", DummyAxClient)
+
+    def sampler(override):
+        score = float(override.get("problematic_bias", 1.0))
+        return _make_candidate(score)
+
+    pareto, history = optimizer.optimize_candidates(
+        initial_candidates=[],
+        sampler=sampler,
+        target={},
+        n_evals=2,
+        process_ids=["P01"],
+    )
+
+    assert len(history) == 3
+    assert history.iteration.tolist() == [0, 1, 2]
+    assert dummy_executor.submit_calls >= 2
+    assert dummy_executor.shutdown_called is True
+    assert pareto and all(isinstance(item, dict) for item in pareto)


### PR DESCRIPTION
## Summary
- add a thread-pool backend that builds initial candidates in parallel with deterministic seeding
- run heuristic and Ax optimizer branches through the same backend while parallelising Pareto metric evaluation
- extend generator and optimizer unit tests to exercise the concurrent execution paths

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d6090b325083319622e24cb79c8c55