### PR TITLE
Vectorize feature tensor preparation in generator

### DIFF
--- a/app/modules/generator.py
+++ b/app/modules/generator.py
@@ -1459,17 +1459,6 @@ _KEYWORD_INDEX = {name: idx for idx, name in enumerate(_KEYWORD_FEATURES)}
 _PACKAGING_TARGETS = ("packaging", "food packaging")
 
 
-def _material_tokens(row: pd.Series) -> str:
-    parts = [
-        str(row.get("material", "")),
-        str(row.get("category", "")),
-        str(row.get("flags", "")),
-        str(row.get("material_family", "")),
-        str(row.get("key_materials", "")),
-    ]
-    return " ".join(parts).lower()
-
-
 def _keyword_fraction(tokens: Iterable[str], weights: Iterable[float], keywords: Tuple[str, ...]) -> float:
     score = 0.0
     for token, weight in zip(tokens, weights):
@@ -1495,8 +1484,8 @@ class CandidateFeatureContext:
     difficulty: np.ndarray
     pct_mass: np.ndarray
     pct_volume: np.ndarray
-    tokens: Tuple[str, ...]
-    categories: Tuple[str, ...]
+    keyword_hits: np.ndarray
+    packaging_hits: np.ndarray
     regolith_pct: float
     mission_share: Dict[str, float]
     mission_scaled_mass: Dict[str, float]
@@ -1546,8 +1535,54 @@ def _prepare_feature_context(
     elif len(raw_weights) > len(picks):
         raw_weights = raw_weights[: len(picks)]
 
-    tokens = tuple(_material_tokens(row) for _, row in picks.iterrows())
-    categories = tuple(str(row.get("category", "")).lower() for _, row in picks.iterrows())
+    item_count = len(picks)
+
+    if item_count:
+        token_arrays: list[np.ndarray] = []
+        for column in ("material", "category", "flags", "material_family", "key_materials"):
+            if column in picks.columns:
+                values = np.asarray(
+                    picks[column].astype(str).fillna("").to_numpy(), dtype=str
+                )
+            else:
+                values = np.full(item_count, "", dtype=str)
+            token_arrays.append(values)
+
+        tokens_array = token_arrays[0].astype(str)
+        for part in token_arrays[1:]:
+            tokens_array = np.char.add(np.char.add(tokens_array, " "), part.astype(str))
+        tokens_array = np.asarray(np.char.lower(np.char.strip(tokens_array)))
+    else:
+        tokens_array = np.empty(0, dtype=str)
+
+    if "category" in picks.columns:
+        category_raw = np.asarray(
+            picks["category"].astype(str).fillna("").to_numpy(), dtype=str
+        )
+    else:
+        category_raw = np.full(item_count, "", dtype=str)
+    category_lower = np.asarray(np.char.lower(category_raw)) if item_count else np.empty(0, dtype=str)
+
+    keyword_hits = np.zeros((item_count, len(_KEYWORD_FEATURES)), dtype=float)
+    if item_count and len(_KEYWORD_FEATURES):
+        for kw_idx, patterns in enumerate(_KEYWORD_FEATURES.values()):
+            if not patterns:
+                continue
+            mask = np.zeros(item_count, dtype=bool)
+            for pattern in patterns:
+                if not pattern:
+                    continue
+                mask |= np.char.find(tokens_array, pattern.lower()) >= 0
+            keyword_hits[:, kw_idx] = mask.astype(float)
+
+    packaging_hits = np.zeros(item_count, dtype=float)
+    if item_count and _PACKAGING_TARGETS:
+        mask = np.zeros(item_count, dtype=bool)
+        for target in _PACKAGING_TARGETS:
+            if not target:
+                continue
+            mask |= np.char.find(category_lower, target.lower()) >= 0
+        packaging_hits = mask.astype(float)
 
     pct_mass = picks.get("pct_mass", 0).to_numpy(dtype=float) / 100.0
     pct_volume = picks.get("pct_volume", 0).to_numpy(dtype=float) / 100.0
@@ -1574,44 +1609,58 @@ def _prepare_feature_context(
     mission_official_mass: Dict[str, float] = {}
 
     if bundle.mission_mass and bundle.mission_totals:
-        match_keys_col = picks.get("_official_match_key")
-        if match_keys_col is not None:
-            match_keys_list = match_keys_col.fillna("").astype(str).tolist()
-        else:
-            match_keys_list = [""] * len(picks)
+        if item_count:
+            if "_official_match_key" in picks.columns:
+                match_keys = np.asarray(
+                    picks["_official_match_key"].astype(str).fillna("").to_numpy(),
+                    dtype=str,
+                )
+            else:
+                match_keys = np.full(item_count, "", dtype=str)
 
-        for idx, (_, row) in enumerate(picks.iterrows()):
-            weight = float(raw_weights[idx]) if idx < len(raw_weights) else 0.0
-            if weight <= 0:
-                continue
+            normalized_categories = np.array(
+                [_normalize_category(value) for value in category_raw], dtype=object
+            )
+            effective_keys = match_keys.astype(object)
+            empty_mask = effective_keys == ""
+            if empty_mask.any():
+                effective_keys[empty_mask] = normalized_categories[empty_mask]
 
-            keys_to_check: list[str] = []
-            match_key = match_keys_list[idx] if idx < len(match_keys_list) else ""
-            if match_key:
-                keys_to_check.append(match_key)
+            weights_arr = raw_weights[:item_count]
+            positive_mask = (weights_arr > 0) & np.isfinite(weights_arr)
+            if not positive_mask.all():
+                effective_keys = effective_keys.astype(object)
+                effective_keys[~positive_mask] = ""
 
-            if not match_key:
-                category_key = _normalize_category(row.get("category", ""))
-                if category_key:
-                    keys_to_check.append(category_key)
-
-            seen_keys: set[str] = set()
-            for key in keys_to_check:
-                if not key or key in seen_keys:
-                    continue
-                seen_keys.add(key)
-                missions = bundle.mission_mass.get(key)
-                if not missions:
-                    continue
-
-                for mission, reference_mass in missions.items():
-                    total_reference = bundle.mission_totals.get(mission)
-                    if not total_reference or total_reference <= 0:
+            if effective_keys.size:
+                unique_keys, inverse = np.unique(effective_keys, return_inverse=True)
+                for key_idx, key in enumerate(unique_keys):
+                    if not key:
                         continue
-                    share = (reference_mass / total_reference) * weight
-                    mission_share[mission] = mission_share.get(mission, 0.0) + share
-                    mission_official_mass[mission] = mission_official_mass.get(mission, 0.0) + weight * float(reference_mass)
-                    mission_scaled_mass[mission] = mission_scaled_mass.get(mission, 0.0) + share * total_kg
+                    missions = bundle.mission_mass.get(str(key))
+                    if not missions:
+                        continue
+                    mask = inverse == key_idx
+                    if not mask.any():
+                        continue
+                    weights_for_key = weights_arr[mask]
+                    if not weights_for_key.size:
+                        continue
+                    for mission, reference_mass in missions.items():
+                        total_reference = bundle.mission_totals.get(mission)
+                        if not total_reference or total_reference <= 0:
+                            continue
+                        ref_mass_float = float(reference_mass)
+                        reference_total = float(total_reference)
+                        share_values = (ref_mass_float / reference_total) * weights_for_key
+                        share_total = float(np.sum(share_values))
+                        if share_total <= 0:
+                            continue
+                        mission_share[mission] = mission_share.get(mission, 0.0) + share_total
+                        mission_official_mass[mission] = mission_official_mass.get(mission, 0.0) + float(
+                            np.sum(weights_for_key * ref_mass_float)
+                        )
+                        mission_scaled_mass[mission] = mission_scaled_mass.get(mission, 0.0) + share_total * total_kg
 
     return CandidateFeatureContext(
         total_mass=total_kg,
@@ -1621,8 +1670,8 @@ def _prepare_feature_context(
         difficulty=difficulty,
         pct_mass=pct_mass,
         pct_volume=pct_volume,
-        tokens=tokens,
-        categories=categories,
+        keyword_hits=keyword_hits,
+        packaging_hits=packaging_hits,
         regolith_pct=float(regolith_pct),
         mission_share=mission_share,
         mission_scaled_mass=mission_scaled_mass,
@@ -1681,16 +1730,11 @@ def _contexts_to_tensor_batch(
             difficulty[idx, :count] = ctx.difficulty[:count]
             pct_mass[idx, :count] = ctx.pct_mass[:count]
             pct_volume[idx, :count] = ctx.pct_volume[:count]
-
-            for item_idx in range(count):
-                token = ctx.tokens[item_idx]
-                category = ctx.categories[item_idx]
-                for kw_idx, keywords in enumerate(keyword_names):
-                    patterns = _KEYWORD_FEATURES[keywords]
-                    if any(pattern in token for pattern in patterns):
-                        keyword_hits[idx, item_idx, kw_idx] = 1.0
-                if any(target in category for target in _PACKAGING_TARGETS):
-                    packaging_hits[idx, item_idx] = 1.0
+            if ctx.keyword_hits.size:
+                kw_cols = min(ctx.keyword_hits.shape[1], len(keyword_names))
+                keyword_hits[idx, :count, :kw_cols] = ctx.keyword_hits[:count, :kw_cols]
+            if ctx.packaging_hits.size:
+                packaging_hits[idx, :count] = ctx.packaging_hits[:count]
 
         for mission_idx, mission in enumerate(mission_names):
             mission_share[idx, mission_idx] = ctx.mission_share.get(mission, 0.0)
@@ -2570,42 +2614,14 @@ def generate_candidates(
     finally:
         if executor is not None:
             executor.shutdown()
-        picks = _pick_materials(df, rng, n=rng.choice([2, 3]), bias=bias)
-        components = _create_candidate_components(picks, proc_df, rng, override)
-        if components is None:
-            return None
-        batch = build_feature_tensor_batch(
-            [components.picks],
-            [components.weights],
-            [components.process],
-            [components.regolith_pct],
-        )
-        features = _compute_features_from_batch(batch)
-        if not features:
-            return None
-        return _finalize_candidate(components, features[0], target, crew_time_low, use_ml)
 
-    components_batch: list[CandidateComponents] = []
-    for _ in range(n):
-        bias = 2.0
-        picks = _pick_materials(df, rng, n=rng.choice([2, 3]), bias=bias)
-        components = _create_candidate_components(picks, proc_df, rng, {})
-        if components:
-            components_batch.append(components)
-
-    candidates: list[dict] = []
-    if components_batch:
-        batch = build_feature_tensor_batch(
-            [comp.picks for comp in components_batch],
-            [comp.weights for comp in components_batch],
-            [comp.process for comp in components_batch],
-            [comp.regolith_pct for comp in components_batch],
-        )
-        features_list = _compute_features_from_batch(batch)
-        for comp, feat in zip(components_batch, features_list):
-            candidate = _finalize_candidate(comp, feat, target, crew_time_low, use_ml)
-            if candidate:
-                candidates.append(candidate)
+    attempts = 0
+    max_attempts = max(n * 2, 4)
+    while len(candidates) < n and attempts < max_attempts:
+        attempts += 1
+        candidate = sampler({})
+        if candidate:
+            candidates.append(candidate)
 
     history = pd.DataFrame()
     if optimizer_evals and optimizer_evals > 0:

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import numbers
 import random
 import shutil
 from datetime import datetime
@@ -599,6 +600,48 @@ def test_compute_feature_vector_keyword_fallback_triggers_polyethylene():
     for candidate in batched:
         assert candidate["polyethylene_frac"] == pytest.approx(features["polyethylene_frac"], rel=1e-6)
         assert candidate["gas_recovery_index"] == pytest.approx(features["gas_recovery_index"], rel=1e-6)
+
+
+def test_compute_feature_vector_dataframe_matches_tensor_batch():
+    waste_df = pd.DataFrame(
+        {
+            "id": ["X", "Y", "Z"],
+            "category": ["Food Packaging", "Food Packaging", "Logistics"],
+            "material": [
+                "Rehydratable Pouch",
+                "Nomex shipping bag",
+                "Polyethylene foam block",
+            ],
+            "kg": [7.0, 2.0, 4.0],
+            "volume_l": [0.0, 1.0, 8.0],
+            "flags": ["", "multilayer", ""],
+        }
+    )
+
+    prepared = generator.prepare_waste_frame(waste_df)
+    process = _dummy_process_series()
+    weights = [0.5, 0.3, 0.2]
+    regolith_pct = 0.15
+
+    dataframe_features = generator.compute_feature_vector(
+        prepared, weights, process, regolith_pct
+    )
+
+    tensor_batch = generator.build_feature_tensor_batch(
+        [prepared], [weights], [process], [regolith_pct]
+    )
+    tensor_features = generator.compute_feature_vector(tensor_batch)
+
+    assert isinstance(tensor_features, list) and tensor_features, "Tensor batch returned no features"
+    tensor_features = tensor_features[0]
+
+    assert set(tensor_features) == set(dataframe_features)
+    for key, value in dataframe_features.items():
+        lhs = tensor_features[key]
+        if isinstance(value, numbers.Real):
+            assert lhs == pytest.approx(value, rel=1e-6, abs=1e-8)
+        else:
+            assert lhs == value
 
 
 def test_compute_feature_vector_includes_mission_metrics(monkeypatch):


### PR DESCRIPTION
## Summary
- compute feature contexts with NumPy string ops to precompute keyword/packaging hits and mission similarity weights without iterrows
- wire the precomputed arrays into tensor batch assembly and tidy generate_candidates' parallel sampler
- extend generator unit tests to exercise the vectorised/JIT path and ensure parity with DataFrame usage

## Testing
- pytest tests/test_generator.py

------
https://chatgpt.com/codex/tasks/task_e_68d60dfa356c8331b6c8433912c9278a