### PR TITLE
Add processed NASA reference tables and coverage

### DIFF
--- a/datasets/README.md
+++ b/datasets/README.md
@@ -1,0 +1,135 @@
+# NASA reference datasets
+
+This directory now contains processed NASA reference tables that can be merged
+into `rexai_nasa_waste_features.csv` via the helper
+`app.modules.generator._merge_reference_dataset`. The original spreadsheet style
+exports that used text ranges have been archived under `datasets/raw/` with a
+`*_raw.csv` suffix so the preprocessing can be reproduced.
+
+## Regeneration steps
+
+Use the following Python snippet to rebuild the processed CSVs from the raw
+inputs. It converts textual ranges (e.g. `15-58`) to numeric midpoints, sums
+multi-mission totals, and exposes the NASA identifiers as the `category`/
+`subitem` join keys expected by `_merge_reference_dataset`.
+
+```python
+from pathlib import Path
+import pandas as pd
+import polars as pl
+import re
+
+RAW_DIR = Path("datasets/raw")
+OUT_DIR = Path("datasets")
+
+
+def parse_numeric(value: object) -> float | None:
+    if value is None or value != value:  # handles None and NaN
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    text = str(value).strip().replace(",", "")
+    if not text:
+        return None
+    numbers = [abs(float(match)) for match in re.findall(r"[-+]?[0-9]*\.?[0-9]+", text)]
+    if "-" in text and len(numbers) >= 2:
+        return sum(numbers[:2]) / 2.0
+    if "+" in text and len(numbers) >= 2:
+        return sum(numbers)
+    return numbers[0] if numbers else None
+
+# Waste summary: map known waste types to canonical categories/subitems and
+# compute mission totals.
+summary_map = {
+    "Clothing": ("Fabrics", "Clothing"),
+    "Wipes/Tissues": ("Fabrics", "Cleaning Wipes"),
+    "Towels and Hygiene": ("Fabrics", "Towels/Wash Cloths"),
+    "Packaging": ("Other Packaging/Gloves (A)", "Bubble wrap filler"),
+    "Food Packaging": ("Food Packaging", "Overwrap"),
+}
+summary_rows = []
+for row in pd.read_csv(RAW_DIR / "nasa_waste_summary_raw.csv").to_dict(orient="records"):
+    category, subitem = summary_map.get(row["waste_type"], (row["waste_type"], None))
+    gateway_i = parse_numeric(row["gateway_phase_I_total_kg"])
+    gateway_ii = parse_numeric(row["gateway_phase_II_total_kg"])
+    mars = parse_numeric(row["mars_transit_total_kg"])
+    summary_rows.append({
+        "category": category,
+        "subitem": subitem,
+        "kg_per_cm_day": parse_numeric(row["kg_per_cm_day"]),
+        "gateway_phase_i_mass_kg": gateway_i,
+        "gateway_phase_ii_mass_kg": gateway_ii,
+        "mars_transit_mass_kg": mars,
+        "total_mass_kg": sum(v for v in (gateway_i, gateway_ii, mars) if v is not None),
+    })
+pl.DataFrame(summary_rows).write_csv(OUT_DIR / "nasa_waste_summary.csv")
+
+# Trash processing products: keep the NASA "approach" label and expose
+# propellant/water figures.
+processing_rows = []
+for row in pd.read_csv(RAW_DIR / "nasa_waste_processing_products_raw.csv").to_dict(orient="records"):
+    prop_day = parse_numeric(row["kg_propellant_per_cm_day"])
+    gateway_i = parse_numeric(row["gateway_phase_I_total_kg"])
+    gateway_ii = parse_numeric(row["gateway_phase_II_total_kg"])
+    mars = parse_numeric(row["mars_outbound_total_kg"])
+    processing_rows.append({
+        "category": "Trash Total",
+        "subitem": row["approach"],
+        "approach": row["approach"],
+        "propellant_per_cm_day_kg": prop_day,
+        "gateway_phase_i_propellant_kg": gateway_i,
+        "gateway_phase_ii_propellant_kg": gateway_ii,
+        "mars_outbound_propellant_kg": mars,
+        "total_propellant_kg": sum(v for v in (gateway_i, gateway_ii, mars) if v is not None),
+        "makeup_water_per_cm_day_kg": parse_numeric(row["makeup_water_kg_cm_day"]),
+        "o2_ch4_yield_kg": prop_day if ("O2" in row["products"] or "CH4" in row["products"]) else 0.0,
+    })
+pl.DataFrame(processing_rows).write_csv(OUT_DIR / "nasa_waste_processing_products.csv")
+
+# LEO mass savings: expose propulsion mode, ISP, gear ratio and convert the
+# savings range to min/max/mean values.
+leo_rows = []
+for row in pd.read_csv(RAW_DIR / "nasa_leo_mass_savings_raw.csv").to_dict(orient="records"):
+    numbers = [abs(float(match)) for match in re.findall(r"[-+]?[0-9]*\.?[0-9]+", str(row["leo_mass_savings_kg"]))]
+    if "-" in str(row["leo_mass_savings_kg"]) and len(numbers) >= 2:
+        savings_min, savings_max = sorted(numbers[:2])
+        savings = (savings_min + savings_max) / 2.0
+    elif numbers:
+        savings_min = savings_max = savings = numbers[0]
+    else:
+        savings_min = savings_max = savings = None
+    leo_rows.append({
+        "category": "Trash Total",
+        "subitem": row["delivery_method"],
+        "propulsion": row["delivery_method"],
+        "isp_seconds": parse_numeric(row["isp_sec"]),
+        "gear_ratio": parse_numeric(row["gear_ratio"]),
+        "max_phase_i_propellant_kg": parse_numeric(row["max_phase_I_propellant_kg"]),
+        "max_phase_ii_propellant_kg": parse_numeric(row["max_phase_II_propellant_kg"]),
+        "mass_savings_min_kg": savings_min,
+        "mass_savings_max_kg": savings_max,
+        "mass_savings_kg": savings,
+    })
+pl.DataFrame(leo_rows).write_csv(OUT_DIR / "nasa_leo_mass_savings.csv")
+
+# Propellant benefits: retain the mission/vehicle labels and convert the
+# delta-V requirements to floats.
+propellant_rows = []
+for row in pd.read_csv(RAW_DIR / "nasa_propellant_benefits_raw.csv").to_dict(orient="records"):
+    propellant_rows.append({
+        "category": "Trash Total",
+        "subitem": row["mission"],
+        "mission": row["mission"],
+        "vehicle": row.get("spacecraft"),
+        "propellant_mass_kg": parse_numeric(row["mass_kg"]),
+        "delta_v_ttg_m_s": parse_numeric(row["deltaV_ttg_m_s"]),
+        "delta_v_ttsg_m_s": parse_numeric(row["deltaV_ttsg_m_s"]),
+        "delta_v_requirement_m_s": parse_numeric(row["deltaV_requirement_m_s"]),
+    })
+pl.DataFrame(propellant_rows).write_csv(OUT_DIR / "nasa_propellant_benefits.csv")
+```
+
+Running the script will refresh the processed tables in place, ensuring the
+merged feature columns such as `summary_total_mass_kg`,
+`processing_o2_ch4_yield_kg`, `leo_mass_savings_kg`, and
+`propellant_propellant_mass_kg` stay in sync with NASA's published values.

--- a/datasets/nasa_leo_mass_savings.csv
+++ b/datasets/nasa_leo_mass_savings.csv
@@ -1,3 +1,3 @@
-delivery_method,isp_sec,gear_ratio,max_phase_I_propellant_kg,max_phase_II_propellant_kg,leo_mass_savings_kg
-Chemical,425,3.34,490,990,1635-3300
-SEP,1500,1.35,490,990,660-1340
+category,subitem,propulsion,isp_seconds,gear_ratio,max_phase_i_propellant_kg,max_phase_ii_propellant_kg,mass_savings_min_kg,mass_savings_max_kg,mass_savings_kg
+Trash Total,Chemical,Chemical,425.0,3.34,490.0,990.0,1635.0,3300.0,2467.5
+Trash Total,SEP,SEP,1500.0,1.35,490.0,990.0,660.0,1340.0,1000.0

--- a/datasets/nasa_propellant_benefits.csv
+++ b/datasets/nasa_propellant_benefits.csv
@@ -1,5 +1,5 @@
-mission,spacecraft,mass_kg,deltaV_ttg_m_s,deltaV_ttsg_m_s,deltaV_requirement_m_s
-Gateway Phase I,Core,28750,24.5,41.7,~15 (yearly station-keeping)
-Gateway Phase II,Core + MPLM,45573,30.8,52.5,~15 (yearly station-keeping)
-Robotic Lunar Mini-lander,200 kg dry + 265 kg payload,465,,2800.0,2800
-Mars DRA 5,Transit Vehicle,196000,12.8,21.8,25
+category,subitem,mission,vehicle,propellant_mass_kg,delta_v_ttg_m_s,delta_v_ttsg_m_s,delta_v_requirement_m_s
+Trash Total,Gateway Phase I,Gateway Phase I,Core,28750.0,24.5,41.7,15.0
+Trash Total,Gateway Phase II,Gateway Phase II,Core + MPLM,45573.0,30.8,52.5,15.0
+Trash Total,Robotic Lunar Mini-lander,Robotic Lunar Mini-lander,200 kg dry + 265 kg payload,465.0,,2800.0,2800.0
+Trash Total,Mars DRA 5,Mars DRA 5,Transit Vehicle,196000.0,12.8,21.8,25.0

--- a/datasets/nasa_waste_processing_products.csv
+++ b/datasets/nasa_waste_processing_products.csv
@@ -1,3 +1,3 @@
-approach,products,kg_propellant_per_cm_day,gateway_phase_I_total_kg,gateway_phase_II_total_kg,mars_outbound_total_kg,makeup_water_kg_cm_day
-TtG (Trash-to-Gas),"10% H2, 22% CO, 68% CO2",1.5,145-540,540-1080,1280-1920,0.28
-TtSG (Trash-to-Supply Gas),"59% O2, 41% CH4",1.37,130-490,490-990,1170-1750,0.15
+category,subitem,approach,propellant_per_cm_day_kg,gateway_phase_i_propellant_kg,gateway_phase_ii_propellant_kg,mars_outbound_propellant_kg,total_propellant_kg,makeup_water_per_cm_day_kg,o2_ch4_yield_kg
+Trash Total,TtG (Trash-to-Gas),TtG (Trash-to-Gas),1.5,342.5,810.0,1600.0,2752.5,0.28,1.5
+Trash Total,TtSG (Trash-to-Supply Gas),TtSG (Trash-to-Supply Gas),1.37,310.0,740.0,1460.0,2510.0,0.15,1.37

--- a/datasets/nasa_waste_summary.csv
+++ b/datasets/nasa_waste_summary.csv
@@ -1,11 +1,11 @@
-waste_type,kg_per_cm_day,gateway_phase_I_total_kg,gateway_phase_II_total_kg,mars_transit_total_kg
-Clothing,0.16,15-58,58-115,173
-Paper & Office Supplies,0.007,1-2,2-5,7
-Wipes/Tissues,0.137,13-49,49-99,148
-Towels and Hygiene,0.098,9-35,35-71,106
-Foam Packaging for Launch,0.04,4-14,14-29,43
-Other Crew Supplies,0.037,4-13,13-27,40
-Food & Packaging,0.352,24-127,127-253,380
-EVA Supplies,0.01,1-4,4-7,11
-Human Wastes,0.449,43-162,162-324,485
-Waste Recovery/Mgt System,0.162,16-58,58-116,174
+category,subitem,kg_per_cm_day,gateway_phase_i_mass_kg,gateway_phase_ii_mass_kg,mars_transit_mass_kg,total_mass_kg
+Fabrics,Clothing,0.16,36.5,86.5,173.0,296.0
+Paper & Office Supplies,,0.007,1.5,3.5,7.0,12.0
+Fabrics,Cleaning Wipes,0.137,31.0,74.0,148.0,253.0
+Fabrics,Towels/Wash Cloths,0.098,22.0,53.0,106.0,181.0
+Foam Packaging for Launch,,0.04,9.0,21.5,43.0,73.5
+Other Crew Supplies,,0.037,8.5,20.0,40.0,68.5
+Food & Packaging,,0.352,75.5,190.0,380.0,645.5
+EVA Supplies,,0.01,2.5,5.5,11.0,19.0
+Human Wastes,,0.449,102.5,243.0,485.0,830.5
+Waste Recovery/Mgt System,,0.162,37.0,87.0,174.0,298.0

--- a/datasets/raw/nasa_leo_mass_savings_raw.csv
+++ b/datasets/raw/nasa_leo_mass_savings_raw.csv
@@ -1,0 +1,3 @@
+delivery_method,isp_sec,gear_ratio,max_phase_I_propellant_kg,max_phase_II_propellant_kg,leo_mass_savings_kg
+Chemical,425,3.34,490,990,1635-3300
+SEP,1500,1.35,490,990,660-1340

--- a/datasets/raw/nasa_propellant_benefits_raw.csv
+++ b/datasets/raw/nasa_propellant_benefits_raw.csv
@@ -1,0 +1,5 @@
+mission,spacecraft,mass_kg,deltaV_ttg_m_s,deltaV_ttsg_m_s,deltaV_requirement_m_s
+Gateway Phase I,Core,28750,24.5,41.7,~15 (yearly station-keeping)
+Gateway Phase II,Core + MPLM,45573,30.8,52.5,~15 (yearly station-keeping)
+Robotic Lunar Mini-lander,200 kg dry + 265 kg payload,465,,2800.0,2800
+Mars DRA 5,Transit Vehicle,196000,12.8,21.8,25

--- a/datasets/raw/nasa_waste_processing_products_raw.csv
+++ b/datasets/raw/nasa_waste_processing_products_raw.csv
@@ -1,0 +1,3 @@
+approach,products,kg_propellant_per_cm_day,gateway_phase_I_total_kg,gateway_phase_II_total_kg,mars_outbound_total_kg,makeup_water_kg_cm_day
+TtG (Trash-to-Gas),"10% H2, 22% CO, 68% CO2",1.5,145-540,540-1080,1280-1920,0.28
+TtSG (Trash-to-Supply Gas),"59% O2, 41% CH4",1.37,130-490,490-990,1170-1750,0.15

--- a/datasets/raw/nasa_waste_summary_raw.csv
+++ b/datasets/raw/nasa_waste_summary_raw.csv
@@ -1,0 +1,11 @@
+waste_type,kg_per_cm_day,gateway_phase_I_total_kg,gateway_phase_II_total_kg,mars_transit_total_kg
+Clothing,0.16,15-58,58-115,173
+Paper & Office Supplies,0.007,1-2,2-5,7
+Wipes/Tissues,0.137,13-49,49-99,148
+Towels and Hygiene,0.098,9-35,35-71,106
+Foam Packaging for Launch,0.04,4-14,14-29,43
+Other Crew Supplies,0.037,4-13,13-27,40
+Food & Packaging,0.352,24-127,127-253,380
+EVA Supplies,0.01,1-4,4-7,11
+Human Wastes,0.449,43-162,162-324,485
+Waste Recovery/Mgt System,0.162,16-58,58-116,174


### PR DESCRIPTION
## Summary
- convert the NASA reference CSVs into normalized tables with `category`/`subitem` join keys
- document the preprocessing steps and archive the original raw files under `datasets/raw`
- extend `tests/test_generator.py` to ensure the merged reference columns surface in `prepare_waste_frame`

## Testing
- pytest tests/test_generator.py::test_prepare_waste_frame_includes_reference_columns

------
https://chatgpt.com/codex/tasks/task_e_68d61c8276a08331a17046c4d145890b