### PR TITLE
Refine packaging family mappings

### DIFF
--- a/app/modules/data_sources.py
+++ b/app/modules/data_sources.py
@@ -123,16 +123,17 @@ def normalize_text(value: Any) -> str:
 _CATEGORY_SYNONYMS = {
     "foam": "foam packaging",
     "foam packaging": "foam packaging",
-    "packaging": "other packaging glove",
-    "other packaging": "other packaging glove",
-    "glove": "other packaging glove",
-    "other packaging glove": "other packaging glove",
+    "foam packaging for launch": "foam packaging",
+    "packaging": "packaging",
+    "other packaging": "other packaging",
+    "other packaging glove": "other packaging",
+    "glove": "gloves",
+    "gloves": "gloves",
     "food packaging": "food packaging",
-    "structural elements": "structural element",
-    "structural element": "structural element",
+    "structural elements": "structural elements",
+    "structural element": "structural elements",
     "eva": "eva waste",
     "eva waste": "eva waste",
-    "gloves": "other packaging glove",
 }
 
 


### PR DESCRIPTION
## Summary
- keep the packaging, other packaging, gloves, foam packaging, food packaging, structural elements, and EVA waste families distinct across generators
- update density estimation, official feature lookup, and logging helpers to work with the new family mapping
- refresh generator tests to assert the updated category keys and glove coverage

## Testing
- pytest tests/test_generator.py

------
https://chatgpt.com/codex/tasks/task_e_68d6210c34ac8331b539434684b7cd8a