### PR TITLE
Normalize NASA reference tables and assertions

### DIFF
--- a/datasets/README.md
+++ b/datasets/README.md
@@ -6,6 +6,20 @@ into `rexai_nasa_waste_features.csv` via the helper
 exports that used text ranges have been archived under `datasets/raw/` with a
 `*_raw.csv` suffix so the preprocessing can be reproduced.
 
+## Source material
+
+| Processed file | NASA reference | Notes |
+| -------------- | -------------- | ----- |
+| `nasa_waste_summary.csv` | Logistics Reduction & Repurposing (LRR) – Logistics-to-Living Phase I/II non-metabolic waste inventory | Ranges such as `15-58 kg` are converted to numeric midpoints and mapped onto the canonical waste categories used by the demo (e.g. Foam Packaging → `Zotek F30`). |
+| `nasa_waste_processing_products.csv` | LRR Trash-to-Gas architecture study | Provides propellant and water yields for the Trash-to-Gas (TtG) and Trash-to-Supply-Gas (TtSG) flows. |
+| `nasa_leo_mass_savings.csv` | LRR delivery trade study for TtG/TtSG logistics | Captures chemical vs. solar-electric propulsion savings and their gear ratios. |
+| `nasa_propellant_benefits.csv` | LRR mission delta-V budget summary | Lists vehicle concepts and the propellant required to exploit trash-derived propellants. |
+| `l2l_parameters.csv` | NASA/TM-2021002072 "Logistics to Living" appendix A1b | Bag geometries, volumetric ratios, and other Logistics-to-Living constants; the `feature` column mirrors the terminology used in the report. |
+
+The raw CSVs under `datasets/raw/` contain the literal values transcribed from
+the NASA PDFs and slide decks so the preprocessing logic below remains
+reproducible.
+
 ## Regeneration steps
 
 Use the following Python snippet to rebuild the processed CSVs from the raw
@@ -44,8 +58,10 @@ summary_map = {
     "Clothing": ("Fabrics", "Clothing"),
     "Wipes/Tissues": ("Fabrics", "Cleaning Wipes"),
     "Towels and Hygiene": ("Fabrics", "Towels/Wash Cloths"),
-    "Packaging": ("Other Packaging/Gloves (A)", "Bubble wrap filler"),
-    "Food Packaging": ("Food Packaging", "Overwrap"),
+    "Foam Packaging for Launch": ("Foam Packaging", "Zotek F30 (PVDF foam)"),
+    "Other Crew Supplies": ("Other Packaging/Gloves (B)", "Nitrile gloves"),
+    "Food & Packaging": ("Food Packaging", "Overwrap"),
+    "EVA Supplies": ("EVA Waste", "Cargo Transfer Bags (CTB)"),
 }
 summary_rows = []
 for row in pd.read_csv(RAW_DIR / "nasa_waste_summary_raw.csv").to_dict(orient="records"):
@@ -133,3 +149,8 @@ Running the script will refresh the processed tables in place, ensuring the
 merged feature columns such as `summary_total_mass_kg`,
 `processing_o2_ch4_yield_kg`, `leo_mass_savings_kg`, and
 `propellant_propellant_mass_kg` stay in sync with NASA's published values.
+
+Because the Logistics-to-Living loader expects descriptor names, the processed
+`l2l_parameters.csv` also renames the raw `variable` header to `feature`. This
+ensures constants such as `l2l_geometry_ctb_small_volume_value` are materialized
+as distinct columns during feature engineering.

--- a/datasets/l2l_parameters.csv
+++ b/datasets/l2l_parameters.csv
@@ -1,4 +1,4 @@
-source,page_hint,category,variable,value,units,notes
+source,page_hint,category,feature,value,units,notes
 10-2072_A1b.pdf,2,geometry,ctb_small_length,50.2,cm,ISS soft stowage bag basic size
 10-2072_A1b.pdf,2,geometry,ctb_small_width,42.5,cm,ISS soft stowage bag basic size
 10-2072_A1b.pdf,2,geometry,ctb_small_height,24.8,cm,ISS soft stowage bag basic size

--- a/datasets/nasa_waste_summary.csv
+++ b/datasets/nasa_waste_summary.csv
@@ -3,9 +3,9 @@ Fabrics,Clothing,0.16,36.5,86.5,173.0,296.0
 Paper & Office Supplies,,0.007,1.5,3.5,7.0,12.0
 Fabrics,Cleaning Wipes,0.137,31.0,74.0,148.0,253.0
 Fabrics,Towels/Wash Cloths,0.098,22.0,53.0,106.0,181.0
-Foam Packaging for Launch,,0.04,9.0,21.5,43.0,73.5
-Other Crew Supplies,,0.037,8.5,20.0,40.0,68.5
-Food & Packaging,,0.352,75.5,190.0,380.0,645.5
-EVA Supplies,,0.01,2.5,5.5,11.0,19.0
+Foam Packaging,Zotek F30 (PVDF foam),0.04,9.0,21.5,43.0,73.5
+Other Packaging/Gloves (B),Nitrile gloves,0.037,8.5,20.0,40.0,68.5
+Food Packaging,Overwrap,0.352,75.5,190.0,380.0,645.5
+EVA Waste,Cargo Transfer Bags (CTB),0.01,2.5,5.5,11.0,19.0
 Human Wastes,,0.449,102.5,243.0,485.0,830.5
 Waste Recovery/Mgt System,,0.162,37.0,87.0,174.0,298.0

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -884,9 +884,25 @@ def test_prepare_waste_frame_includes_reference_columns(reference_dataset_tables
     ]
     assert not clothing_row.empty
     expected_total = float(clothing_row["total_mass_kg"].iloc[0])
+    expected_gateway = float(clothing_row["gateway_phase_i_mass_kg"].iloc[0])
+    expected_mars = float(clothing_row["mars_transit_mass_kg"].iloc[0])
 
     assert prepared.loc[0, "summary_total_mass_kg"] == pytest.approx(
         expected_total, rel=1e-6
+    )
+    assert prepared.loc[0, "summary_gateway_phase_i_mass_kg"] == pytest.approx(
+        expected_gateway, rel=1e-6
+    )
+    assert prepared.loc[0, "summary_mars_transit_mass_kg"] == pytest.approx(
+        expected_mars, rel=1e-6
+    )
+
+    l2l_params = data_sources.load_l2l_parameters()
+    constant_name = "l2l_geometry_ctb_small_volume_value"
+    assert constant_name in l2l_params.constants
+    assert constant_name in prepared.columns
+    assert prepared.loc[0, constant_name] == pytest.approx(
+        l2l_params.constants[constant_name], rel=1e-6
     )
 
 


### PR DESCRIPTION
## Summary
- document the NASA source material and preprocessing steps for the processed reference tables
- map the waste summary rows onto the canonical category/subitem pairs and rename the Logistics-to-Living feature column for predictable constant names
- extend the generator test to assert that the mission mass metrics and Logistics-to-Living constants are materialized when the CSVs are present

## Testing
- pytest tests/test_generator.py::test_prepare_waste_frame_includes_reference_columns -q

------
https://chatgpt.com/codex/tasks/task_e_68d626d486308331b1b5f87efb7c9b0a