### PR TITLE
Refactor inference logging writer caching

### DIFF
--- a/app/modules/logging_utils.py
+++ b/app/modules/logging_utils.py
@@ -8,25 +8,153 @@ API used by the generator and analytics tests.
 
 from __future__ import annotations
 
+import atexit
 import json
 import threading
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any, Dict, Tuple
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, Mapping, Tuple
 
 try:  # Optional heavy dependencies; gracefully disable logging if missing
     import pyarrow as pa
+    import pyarrow.parquet as pq
 except Exception:  # pragma: no cover - pyarrow is expected in production
     pa = None  # type: ignore[assignment]
-
-try:  # ``deltalake`` provides lightweight Delta transactions
-    from deltalake.writer import write_deltalake
-except Exception:  # pragma: no cover - deltalake is expected in production
-    write_deltalake = None  # type: ignore[assignment]
+    pq = None  # type: ignore[assignment]
 
 LOGS_ROOT = Path(__file__).resolve().parents[2] / "data" / "logs"
 
-_INFERENCE_LOG_LOCK = threading.Lock()
+
+@dataclass
+class _InferenceWriterState:
+    """Track the active Parquet writer along with its schema metadata."""
+
+    date_token: str
+    path: Path
+    schema: "pa.Schema"
+    writer: "pq.ParquetWriter"
+
+
+class _InferenceLogWriterManager:
+    """Manage a single append-only Parquet writer with daily rotation."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._state: _InferenceWriterState | None = None
+
+    def close(self) -> None:
+        """Close the active writer, if any."""
+
+        if pq is None:
+            return
+
+        with self._lock:
+            self._close_locked()
+
+    def _close_locked(self) -> None:
+        state = self._state
+        if state is None:
+            return
+
+        try:
+            state.writer.close()
+        except Exception:  # pragma: no cover - best effort cleanup
+            pass
+
+        self._state = None
+
+    def _open_locked(
+        self, timestamp: datetime, field_names: Iterable[str]
+    ) -> _InferenceWriterState | None:
+        if pa is None or pq is None:
+            return None
+
+        desired_fields = sorted(set(str(name) for name in field_names))
+        if not desired_fields:
+            return None
+
+        log_dir = resolve_inference_log_dir(timestamp)
+        try:
+            log_dir.mkdir(parents=True, exist_ok=True)
+        except Exception:
+            return None
+
+        date_token = timestamp.strftime("%Y%m%d")
+        path = self._resolve_log_path(log_dir, date_token)
+        schema = pa.schema(pa.field(name, pa.string()) for name in desired_fields)
+
+        try:
+            writer = pq.ParquetWriter(str(path), schema=schema)
+        except Exception:
+            return None
+
+        state = _InferenceWriterState(
+            date_token=date_token,
+            path=path,
+            schema=schema,
+            writer=writer,
+        )
+        self._state = state
+        return state
+
+    def _resolve_log_path(self, log_dir: Path, date_token: str) -> Path:
+        """Return a Parquet path for *date_token* avoiding overwriting shards."""
+
+        base = log_dir / f"inference_{date_token}.parquet"
+        if not base.exists():
+            return base
+
+        counter = 1
+        while True:
+            candidate = log_dir / f"inference_{date_token}_{counter:04d}.parquet"
+            if not candidate.exists():
+                return candidate
+            counter += 1
+
+    def _ensure_state_locked(
+        self, timestamp: datetime, field_names: Iterable[str]
+    ) -> _InferenceWriterState | None:
+        state = self._state
+        desired_fields = sorted(set(str(name) for name in field_names))
+        if not desired_fields:
+            return None
+
+        date_token = timestamp.strftime("%Y%m%d")
+        if state is not None:
+            if state.date_token != date_token or set(state.schema.names) != set(
+                desired_fields
+            ):
+                self._close_locked()
+                state = None
+
+        if state is None:
+            state = self._open_locked(timestamp, desired_fields)
+
+        return state
+
+    def write_event(self, timestamp: datetime, payload: Mapping[str, str | None]) -> None:
+        if pa is None or pq is None:
+            return
+
+        with self._lock:
+            state = self._ensure_state_locked(timestamp, payload.keys())
+            if state is None:
+                return
+
+            arrays = [
+                pa.array([payload.get(field.name)], type=field.type)
+                for field in state.schema
+            ]
+            table = pa.Table.from_arrays(arrays, schema=state.schema)
+
+            try:
+                state.writer.write_table(table)
+            except Exception:
+                self._close_locked()
+
+
+_INFERENCE_LOG_MANAGER = _InferenceLogWriterManager()
 
 __all__ = [
     "LOGS_ROOT",
@@ -37,7 +165,7 @@ __all__ = [
 
 
 def resolve_inference_log_dir(timestamp: datetime) -> Path:
-    """Return the Delta Lake directory for the given *timestamp*."""
+    """Return the directory storing Parquet logs for *timestamp*."""
 
     return LOGS_ROOT / "inference" / timestamp.strftime("%Y%m%d")
 
@@ -103,14 +231,9 @@ def append_inference_log(
     uncertainty: Dict[str, Any] | None,
     model_registry: Any | None,
 ) -> None:
-    """Persist an inference event using Delta transactions to avoid read-modify-write."""
+    """Persist an inference event using a streaming Parquet writer."""
 
-    if pa is None or write_deltalake is None:  # pragma: no cover - dependencies should exist
-        return
-
-    try:
-        LOGS_ROOT.mkdir(parents=True, exist_ok=True)
-    except Exception:
+    if pa is None or pq is None:  # pragma: no cover - dependencies should exist
         return
 
     event_time, event_payload = prepare_inference_event(
@@ -120,28 +243,8 @@ def append_inference_log(
         model_registry=model_registry,
     )
 
-    log_dir = resolve_inference_log_dir(event_time)
+    _INFERENCE_LOG_MANAGER.write_event(event_time, event_payload)
 
-    try:
-        log_dir.parent.mkdir(parents=True, exist_ok=True)
-    except Exception:
-        return
 
-    data = {
-        key: pa.array([value], type=pa.string())
-        for key, value in event_payload.items()
-    }
-
-    table = pa.table(data)
-
-    try:
-        with _INFERENCE_LOG_LOCK:
-            write_deltalake(
-                str(log_dir),
-                table,
-                mode="append",
-                schema_mode="merge",
-                engine="rust",
-            )
-    except Exception:
-        return
+if pq is not None:  # pragma: no branch - guard for optional dependency
+    atexit.register(_INFERENCE_LOG_MANAGER.close)

--- a/tests/test_logging_utils.py
+++ b/tests/test_logging_utils.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Dict
+
+import pytest
+
+from app.modules import logging_utils
+
+
+def test_append_inference_log_uses_cached_writer(monkeypatch, tmp_path):
+    """Ensure sequential appends reuse the same Parquet writer without reads."""
+
+    logging_utils._INFERENCE_LOG_MANAGER.close()
+
+    manager = logging_utils._InferenceLogWriterManager()
+    monkeypatch.setattr(logging_utils, "_INFERENCE_LOG_MANAGER", manager)
+    monkeypatch.setattr(logging_utils, "LOGS_ROOT", tmp_path)
+
+    created_paths: list[Path] = []
+    write_counts: list[int] = []
+
+    class WriterSpy:
+        def __init__(self, path: str, schema: Any) -> None:  # pragma: no cover - helper
+            self.path = Path(path)
+            self.schema = schema
+            self.count = 0
+
+        def write_table(self, table: Any) -> None:  # pragma: no cover - helper
+            self.count += 1
+            write_counts.append(self.count)
+
+        def close(self) -> None:  # pragma: no cover - helper
+            pass
+
+    def fake_writer(path: str, schema: Any) -> WriterSpy:
+        writer = WriterSpy(path, schema)
+        created_paths.append(writer.path)
+        return writer
+
+    monkeypatch.setattr(logging_utils.pq, "ParquetWriter", fake_writer)
+
+    def fail_read(*_args: Any, **_kwargs: Any) -> None:
+        pytest.fail("append_inference_log should not trigger Parquet reads")
+
+    if hasattr(logging_utils.pq, "read_table"):
+        monkeypatch.setattr(logging_utils.pq, "read_table", fail_read)
+
+    base = datetime(2024, 5, 4, 12, 0, tzinfo=UTC)
+    events = [
+        (
+            base,
+            {
+                "timestamp": base.isoformat(),
+                "input_features": "{}",
+                "prediction": "{}",
+                "uncertainty": "{}",
+                "model_hash": "abc",
+            },
+        ),
+        (
+            base.replace(hour=18),
+            {
+                "timestamp": base.replace(hour=18).isoformat(),
+                "input_features": "{\"foo\": 1}",
+                "prediction": "{\"bar\": 2}",
+                "uncertainty": "{}",
+                "model_hash": "def",
+            },
+        ),
+    ]
+
+    def fake_prepare(*_args: Any, **_kwargs: Any) -> tuple[datetime, Dict[str, str | None]]:
+        timestamp, payload = events.pop(0)
+        return timestamp, payload
+
+    monkeypatch.setattr(logging_utils, "prepare_inference_event", fake_prepare)
+
+    logging_utils.append_inference_log({}, {}, {}, None)
+    logging_utils.append_inference_log({}, {}, {}, None)
+
+    expected_path = (
+        tmp_path / "inference" / "20240504" / "inference_20240504.parquet"
+    )
+    assert created_paths == [expected_path]
+    assert write_counts == [1, 2]
+
+    manager.close()


### PR DESCRIPTION
## Summary
- replace the inference log read/concat/write path with a cached Parquet writer and daily rotation
- ensure the shared writer is closed at exit and reuse is protected by a lock
- add a unit test that verifies sequential appends reuse the same writer without performing reads

## Testing
- pytest tests/test_logging_utils.py

------
https://chatgpt.com/codex/tasks/task_e_68d626d5fd708331b47b1ed8bcd84489