### PR TITLE
Add coverage to ensure inference logs skip Parquet reads

### DIFF
--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -126,6 +126,86 @@ def test_append_inference_log_reuses_daily_writer(monkeypatch, tmp_path):
     manager.close()
 
 
+def test_append_inference_log_skips_parquet_reads(monkeypatch, tmp_path):
+    """Ensure append operations never trigger a Parquet read."""
+
+    generator._INFERENCE_LOG_MANAGER.close()
+    monkeypatch.setattr(generator, "LOGS_ROOT", tmp_path)
+
+    manager = generator._InferenceLogWriterManager()
+    monkeypatch.setattr(generator, "_INFERENCE_LOG_MANAGER", manager)
+
+    created_paths: list[Path] = []
+    write_counts: list[int] = []
+
+    class WriterSpy:
+        def __init__(self, path: str, schema: Any) -> None:  # pragma: no cover - helper
+            self.path = Path(path)
+            self.schema = schema
+            self.count = 0
+
+        def write_table(self, table: Any) -> None:  # pragma: no cover - helper
+            self.count += 1
+            write_counts.append(self.count)
+
+        def close(self) -> None:  # pragma: no cover - helper
+            pass
+
+    def fake_writer(path: str, schema: Any) -> WriterSpy:
+        writer = WriterSpy(path, schema)
+        created_paths.append(writer.path)
+        return writer
+
+    monkeypatch.setattr(generator.pq, "ParquetWriter", fake_writer)
+
+    def fail_read(*_args: Any, **_kwargs: Any) -> None:
+        pytest.fail("append_inference_log should not read existing shards")
+
+    if hasattr(generator.pq, "read_table"):
+        monkeypatch.setattr(generator.pq, "read_table", fail_read)
+
+    base = datetime(2024, 6, 1, 8, 30, tzinfo=UTC)
+    events = [
+        (
+            base,
+            {
+                "timestamp": base.isoformat(),
+                "input_features": "{}",
+                "prediction": "{}",
+                "uncertainty": "{}",
+                "model_hash": "alpha",
+            },
+        ),
+        (
+            base.replace(hour=21),
+            {
+                "timestamp": base.replace(hour=21).isoformat(),
+                "input_features": "{\"foo\": 1}",
+                "prediction": "{\"bar\": 2}",
+                "uncertainty": "{}",
+                "model_hash": "bravo",
+            },
+        ),
+    ]
+
+    def fake_prepare(*_args: Any, **_kwargs: Any) -> tuple[datetime, Dict[str, str | None]]:
+        ts, payload = events.pop(0)
+        return ts, payload
+
+    monkeypatch.setattr(generator, "_prepare_inference_event", fake_prepare)
+
+    generator.append_inference_log({}, {}, {}, None)
+    generator.append_inference_log({}, {}, {}, None)
+
+    expected_path = (
+        tmp_path / "inference" / "20240601" / "inference_20240601.parquet"
+    )
+    assert created_paths == [expected_path]
+    assert write_counts == [1, 2]
+
+    manager.close()
+
+
 def test_append_inference_log_rotates_daily(monkeypatch, tmp_path):
     generator._INFERENCE_LOG_MANAGER.close()
     monkeypatch.setattr(generator, "LOGS_ROOT", tmp_path)


### PR DESCRIPTION
## Summary
- add a regression test that patches the Parquet writer to ensure inference logging never triggers a read of existing shards

## Testing
- pytest tests/test_generator.py::test_append_inference_log_skips_parquet_reads

------
https://chatgpt.com/codex/tasks/task_e_68d6b93dc5c48331ae84ff7cd550c591