### PR TITLE
Refactor regolith ingestion to use Polars

### DIFF
--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -51,6 +51,17 @@ def reference_dataset_tables(monkeypatch):
         generator._official_features_bundle.cache_clear()
 
 
+def test_load_regolith_vector_matches_data_sources():
+    polars_vector = generator._load_regolith_vector()
+    pandas_vector = data_sources._load_regolith_vector()
+
+    assert set(polars_vector) == set(pandas_vector)
+    for key, expected in pandas_vector.items():
+        assert polars_vector[key] == pytest.approx(expected, rel=1e-9, abs=1e-9)
+
+    assert sum(polars_vector.values()) == pytest.approx(1.0, rel=1e-9)
+
+
 def test_append_inference_log_reuses_daily_writer(monkeypatch, tmp_path):
     generator._INFERENCE_LOG_MANAGER.close()
     monkeypatch.setattr(generator, "LOGS_ROOT", tmp_path)


### PR DESCRIPTION
## Summary
- load the regolith oxide reference data with Polars lazy frames and normalize weights without row-wise iteration
- convert the normalized lazy output into dictionaries only when needed so downstream consumers keep their schema
- add a regression test to ensure the Polars ingestion path matches the legacy pandas output

## Testing
- pytest tests/test_generator.py::test_load_regolith_vector_matches_data_sources

------
https://chatgpt.com/codex/tasks/task_e_68d6ba7dcc048331b1c486380aed2950