### PR TITLE
Vectorize density fallbacks in generator

### DIFF
--- a/app/modules/generator.py
+++ b/app/modules/generator.py
@@ -453,6 +453,9 @@ _COMPOSITION_DENSITY_MAP = {
     "EVOH_pct": 1250.0,
     "PET_pct": 1370.0,
     "Nitrile_pct": 1030.0,
+    "approx_moisture_pct": 1000.0,
+    "Other_pct": 500.0,
+    "Plastic_Resin_pct": 950.0,
 }
 
 _CATEGORY_DENSITY_DEFAULTS = {
@@ -1743,6 +1746,7 @@ def prepare_waste_frame(waste_df: pd.DataFrame) -> pd.DataFrame:
     out["_source_category"] = out["category"].astype(str)
     out["_source_flags"] = out["flags"].astype(str)
 
+    bundle = _official_features_bundle()
     out = _inject_official_features(out)
 
     mass = pd.to_numeric(out["kg"], errors="coerce").fillna(0.0)
@@ -1760,18 +1764,39 @@ def prepare_waste_frame(waste_df: pd.DataFrame) -> pd.DataFrame:
     cat_density = cat_mass.divide(cat_volume).where((cat_volume > 0) & cat_volume.notna())
     density = density.fillna(cat_density)
 
-    composition_columns: dict[str, pd.Series] = {}
-    for column in _COMPOSITION_DENSITY_MAP:
-        if column in out.columns:
-            composition_columns[column] = pd.to_numeric(out[column], errors="coerce").fillna(0.0)
-        else:
-            composition_columns[column] = pd.Series(0.0, index=out.index, dtype=float)
+    selected_columns: list[str] = []
+    if getattr(bundle, "composition_columns", None):
+        selected_columns.extend(
+            [
+                column
+                for column in bundle.composition_columns
+                if column in out.columns and column in _COMPOSITION_DENSITY_MAP
+            ]
+        )
+    fallback_columns = [
+        column
+        for column in _COMPOSITION_DENSITY_MAP
+        if column in out.columns and column not in selected_columns
+    ]
+    selected_columns.extend(fallback_columns)
 
-    composition_df = pd.DataFrame(composition_columns, index=out.index)
-    composition_frac = composition_df.div(100.0)
-    frac_total = composition_frac.sum(axis=1)
-    density_weights = composition_frac.mul(pd.Series(_COMPOSITION_DENSITY_MAP))
-    weighted_density = density_weights.sum(axis=1).div(frac_total).where(frac_total > 0)
+    if selected_columns:
+        composition_numeric = {
+            column: pd.to_numeric(out[column], errors="coerce").fillna(0.0)
+            for column in selected_columns
+        }
+        composition_frac = pd.DataFrame(composition_numeric, index=out.index).div(100.0)
+        frac_total = composition_frac.sum(axis=1)
+        density_lookup = pd.Series(
+            {column: float(_COMPOSITION_DENSITY_MAP[column]) for column in selected_columns},
+            index=selected_columns,
+            dtype=float,
+        )
+        density_weights = composition_frac.multiply(density_lookup, axis=1)
+        weighted_density = density_weights.sum(axis=1)
+        weighted_density = weighted_density.divide(frac_total).where(frac_total > 0)
+    else:
+        weighted_density = pd.Series(np.nan, index=out.index, dtype=float)
 
     normalized_category = _vectorized_normalize_category(out["category"])
     foam_mask = normalized_category == "foam packaging"
@@ -1783,6 +1808,35 @@ def prepare_waste_frame(waste_df: pd.DataFrame) -> pd.DataFrame:
         )
 
     density = density.fillna(weighted_density)
+
+    logistic_density_map: Dict[str, float] = {}
+    category_features = getattr(bundle, "l2l_category_features", None)
+    if isinstance(category_features, Mapping):
+        for key, features in category_features.items():
+            if not isinstance(features, Mapping):
+                continue
+            density_value: float | None = None
+            for name, value in features.items():
+                if not isinstance(value, (int, float)):
+                    continue
+                if not np.isfinite(value):
+                    continue
+                name_lower = str(name).lower()
+                if "density" not in name_lower:
+                    continue
+                density_value = float(value)
+                break
+            if density_value is None:
+                continue
+            normalized_key = normalize_category(key)
+            if not normalized_key:
+                continue
+            logistic_density_map.setdefault(normalized_key, density_value)
+
+    if logistic_density_map:
+        logistic_density = normalized_category.map(logistic_density_map)
+        logistic_density = pd.to_numeric(logistic_density, errors="coerce")
+        density = density.fillna(logistic_density)
 
     category_defaults = normalized_category.map(_CATEGORY_DENSITY_DEFAULTS).astype(float)
     density = density.fillna(category_defaults)

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -1639,10 +1639,87 @@ def test_prepare_waste_frame_vectorized_large_inventory():
         (volume_series > 0) & volume_series.notna()
     )
 
-    missing = expected_density.isna() | ~np.isfinite(expected_density)
-    if missing.any():
-        fallback = prepared.loc[missing].apply(generator._estimate_density_from_row, axis=1)
-        expected_density.loc[missing] = fallback
+    cat_mass = pd.to_numeric(prepared.get("category_total_mass_kg"), errors="coerce")
+    if not isinstance(cat_mass, pd.Series):
+        cat_mass = pd.Series(cat_mass, index=prepared.index, dtype=float)
+    cat_volume = pd.to_numeric(prepared.get("category_total_volume_m3"), errors="coerce")
+    if not isinstance(cat_volume, pd.Series):
+        cat_volume = pd.Series(cat_volume, index=prepared.index, dtype=float)
+    cat_density = cat_mass.divide(cat_volume).where((cat_volume > 0) & cat_volume.notna())
+    expected_density = expected_density.fillna(cat_density)
+
+    bundle = generator._official_features_bundle()
+    selected_columns: list[str] = []
+    if getattr(bundle, "composition_columns", None):
+        selected_columns.extend(
+            [
+                column
+                for column in bundle.composition_columns
+                if column in prepared.columns
+                and column in generator._COMPOSITION_DENSITY_MAP
+            ]
+        )
+    fallback_columns = [
+        column
+        for column in generator._COMPOSITION_DENSITY_MAP
+        if column in prepared.columns and column not in selected_columns
+    ]
+    selected_columns.extend(fallback_columns)
+
+    if selected_columns:
+        composition_numeric = {
+            column: pd.to_numeric(prepared[column], errors="coerce").fillna(0.0)
+            for column in selected_columns
+        }
+        composition_frac = pd.DataFrame(composition_numeric, index=prepared.index).div(100.0)
+        frac_total = composition_frac.sum(axis=1)
+        density_lookup = pd.Series(
+            {
+                column: float(generator._COMPOSITION_DENSITY_MAP[column])
+                for column in selected_columns
+            },
+            index=selected_columns,
+            dtype=float,
+        )
+        weighted_density = composition_frac.multiply(density_lookup, axis=1).sum(axis=1)
+        weighted_density = weighted_density.divide(frac_total).where(frac_total > 0)
+    else:
+        weighted_density = pd.Series(np.nan, index=prepared.index, dtype=float)
+
+    normalized_category = generator._vectorized_normalize_category(prepared["category"])
+    foam_mask = normalized_category == "foam packaging"
+    foam_default = generator._CATEGORY_DENSITY_DEFAULTS.get("foam packaging")
+    if foam_default is not None:
+        weighted_density = weighted_density.where(
+            ~foam_mask,
+            weighted_density.clip(upper=float(foam_default)),
+        )
+
+    expected_density = expected_density.fillna(weighted_density)
+
+    logistic_density_map: Dict[str, float] = {}
+    category_features = getattr(bundle, "l2l_category_features", None)
+    if isinstance(category_features, dict):
+        for key, features in category_features.items():
+            if not isinstance(features, dict):
+                continue
+            for name, value in features.items():
+                if not isinstance(value, (int, float)) or not np.isfinite(value):
+                    continue
+                if "density" not in str(name).lower():
+                    continue
+                normalized_key = generator.normalize_category(key)
+                if normalized_key:
+                    logistic_density_map.setdefault(normalized_key, float(value))
+                break
+
+    if logistic_density_map:
+        logistic_series = normalized_category.map(logistic_density_map)
+        logistic_series = pd.to_numeric(logistic_series, errors="coerce")
+        expected_density = expected_density.fillna(logistic_series)
+
+    category_defaults = normalized_category.map(generator._CATEGORY_DENSITY_DEFAULTS).astype(float)
+    expected_density = expected_density.fillna(category_defaults)
 
     default_density = float(
         generator._CATEGORY_DENSITY_DEFAULTS.get("packaging", 500.0)
@@ -1655,6 +1732,80 @@ def test_prepare_waste_frame_vectorized_large_inventory():
         check_names=False,
     )
 
+
+def test_prepare_waste_frame_density_missing_volume(monkeypatch):
+    data_sources.official_features_bundle.cache_clear()
+    generator._official_features_bundle.cache_clear()
+
+    dummy_table = pl.DataFrame(
+        schema={"category_norm": pl.Utf8, "subitem_norm": pl.Utf8},
+        data=[],
+    )
+
+    dummy_bundle = generator._OfficialFeaturesBundle(
+        value_columns=(),
+        composition_columns=("Aluminum_pct", "Plastic_Resin_pct", "approx_moisture_pct"),
+        direct_map={},
+        category_tokens={},
+        table=dummy_table,
+        value_matrix=np.empty((0, 0), dtype=np.float64),
+        mission_mass={},
+        mission_totals={},
+        mission_reference_keys=(),
+        mission_reference_index={},
+        mission_reference_matrix=np.zeros((0, 0), dtype=np.float64),
+        mission_names=(),
+        mission_totals_vector=np.zeros(0, dtype=np.float64),
+        processing_metrics={},
+        leo_mass_savings={},
+        propellant_benefits={},
+        l2l_constants={},
+        l2l_category_features={
+            "food packaging": {"l2l_packaging_density_kg_m3": 630.0},
+            "foam packaging": {"l2l_packaging_density_kg_m3": 95.0},
+        },
+        l2l_item_features={},
+        l2l_hints={},
+    )
+
+    def fake_bundle():
+        return dummy_bundle
+
+    fake_bundle.cache_clear = lambda: None  # type: ignore[attr-defined]
+    monkeypatch.setattr(generator, "official_features_bundle", fake_bundle)
+    monkeypatch.setattr(generator, "_official_features_bundle", fake_bundle)
+
+    waste_df = pd.DataFrame(
+        {
+            "id": ["A", "B", "C", "D", "E"],
+            "category": [
+                "Food Packaging",
+                "Structural Elements",
+                "Food Packaging",
+                "Foam Packaging",
+                "Other Packaging",
+            ],
+            "kg": [12.0, 5.0, 1.0, 0.8, 0.5],
+            "volume_l": [np.nan, np.nan, np.nan, np.nan, np.nan],
+            "category_total_mass_kg": [180.0, np.nan, np.nan, np.nan, np.nan],
+            "category_total_volume_m3": [0.25, np.nan, np.nan, np.nan, np.nan],
+            "Aluminum_pct": [0.0, 60.0, 0.0, 0.0, 0.0],
+            "Plastic_Resin_pct": [0.0, 40.0, 0.0, 0.0, 0.0],
+            "approx_moisture_pct": [0.0, 0.0, 0.0, 0.0, 0.0],
+        }
+    )
+
+    prepared = generator.prepare_waste_frame(waste_df)
+
+    densities = prepared["density_kg_m3"].to_numpy()
+
+    assert densities[0] == pytest.approx(720.0, rel=1e-6)
+    assert densities[1] == pytest.approx(2000.0, rel=1e-6)
+    assert densities[2] == pytest.approx(630.0, rel=1e-6)
+    assert densities[3] == pytest.approx(95.0, rel=1e-6)
+    assert densities[4] == pytest.approx(
+        generator._CATEGORY_DENSITY_DEFAULTS["other packaging"], rel=1e-6
+    )
 
 def test_compute_feature_vector_uses_l2l_packaging_ratio(monkeypatch):
     data_sources.official_features_bundle.cache_clear()


### PR DESCRIPTION
## Summary
- leverage the official composition columns and Logistics-to-Living category densities when estimating fallback densities in `prepare_waste_frame`
- extend the composition density map to cover additional official composition fields
- expand generator tests to cover missing volume scenarios and assert the vectorised density pipeline

## Testing
- pytest tests/test_generator.py::test_prepare_waste_frame_vectorized_large_inventory tests/test_generator.py::test_prepare_waste_frame_density_missing_volume


------
https://chatgpt.com/codex/tasks/task_e_68d6ba7c66948331a859a7c2e7f54fe4