### PR TITLE
Consolidate heuristic label failure tests

### DIFF
--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -793,8 +793,6 @@ def test_generate_candidates_heuristic_mode_skips_ml(monkeypatch, tmp_path):
 
     log_dir = generator.LOGS_ROOT
     log_dir.mkdir(parents=True, exist_ok=True)
-    log_path = log_dir / f"inference_{datetime.utcnow().strftime('%Y%m%d')}.parquet"
-    log_path.unlink(missing_ok=True)
     waste_df = pd.DataFrame(
         {
             "id": ["W1", "W2"],
@@ -833,87 +831,7 @@ def test_generate_candidates_heuristic_mode_skips_ml(monkeypatch, tmp_path):
     assert "auxiliary" in cand
 
 
-def test_generate_candidates_handles_missing_curated_labels(monkeypatch, tmp_path):
-    monkeypatch.setattr(label_mapper, "_LABELS_CACHE", None, raising=False)
-    monkeypatch.setattr(label_mapper, "_LABELS_CACHE_PATH", None, raising=False)
-
-    missing_labels_path = tmp_path / "missing" / "labels.parquet"
-    monkeypatch.setattr(label_mapper, "GOLD_LABELS_PATH", missing_labels_path, raising=False)
-
-    calls: list[tuple[str, tuple, dict]] = []
-
-    def boom(*args, **kwargs):
-        calls.append(("ensure", args, kwargs))
-        raise RuntimeError("boom")
-
-    monkeypatch.setattr(
-        "app.modules.data_build.ensure_gold_dataset",
-        boom,
-    )
-
-    picks_template = pd.DataFrame(
-        {
-            "kg": [1.0, 0.5],
-            "_source_id": ["A", "B"],
-            "_source_category": ["packaging", "eva"],
-            "_source_flags": ["", ""],
-            "_problematic": [0, 0],
-            "material": ["aluminum foil", "eva foam"],
-            "category": ["packaging", "eva"],
-            "flags": ["", ""],
-            "moisture_pct": [5.0, 10.0],
-            "difficulty_factor": [1.0, 2.0],
-        }
-    )
-
-    monkeypatch.setattr(generator, "prepare_waste_frame", lambda df: df)
-    monkeypatch.setattr(
-        generator,
-        "_pick_materials",
-        lambda df, rng, n=2, bias=2.0: picks_template.copy(),
-    )
-    monkeypatch.setattr(
-        generator,
-        "build_feature_tensor_batch",
-        lambda *args, **kwargs: object(),
-    )
-    monkeypatch.setattr(
-        generator,
-        "_compute_features_from_batch",
-        lambda batch: [{"process_id": "P01"}],
-    )
-    monkeypatch.setattr(generator, "MODEL_REGISTRY", None)
-
-    waste_df = picks_template.copy()
-    proc_df = pd.DataFrame(
-        {
-            "process_id": ["P01"],
-            "name": ["Process"],
-            "energy_kwh_per_kg": [1.0],
-            "water_l_per_kg": [0.5],
-            "crew_min_per_batch": [30.0],
-        }
-    )
-
-    candidates, history = generator.generate_candidates(waste_df, proc_df, target={}, n=1)
-
-    assert calls, "ensure_gold_dataset should have been invoked"
-    assert candidates, "Expected heuristic candidates even when gold labels are unavailable"
-
-    features = candidates[0].get("features", {})
-    assert features.get("curated_label_targets") == {}
-    assert features.get("prediction_mode") == "heuristic"
-    assert history.empty
-
-    cache = label_mapper._LABELS_CACHE
-    assert isinstance(cache, pd.DataFrame)
-    assert cache.empty
-    assert label_mapper._LABELS_CACHE_PATH == missing_labels_path
-
-
-def test_generate_candidates_warns_when_curated_labels_fail(
-    monkeypatch, tmp_path, caplog
-):
+def test_generate_candidates_handles_missing_curated_labels(monkeypatch, tmp_path, caplog):
     caplog.set_level(logging.WARNING, logger="app.modules.label_mapper")
     monkeypatch.setattr(label_mapper, "_LABELS_CACHE", None, raising=False)
     monkeypatch.setattr(label_mapper, "_LABELS_CACHE_PATH", None, raising=False)


### PR DESCRIPTION
## Summary
- collapse the duplicated heuristic curated-label failure tests into a single case that exercises warning emission and fallback behavior
- remove redundant log cleanup left over from the copied heuristic-mode test setup

## Testing
- pytest -k heuristic_mode

------
https://chatgpt.com/codex/tasks/task_e_68d6ba8113088331b76865e2c1ed6a1d