### PR TITLE
Document removal of legacy helper modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@ código testeable y comprensible:
 Los tests unitarios apuntan a estos límites para garantizar que cada módulo
 permanezca enfocado en su dominio (ingesta, generación y logging).
 
+> Nota: los helpers legacy `app/modules/branding.py`, `app/modules/charts.py`
+> y `app/modules/embeddings.py` fueron eliminados. La app se apoya en
+> `app/modules/ui_blocks.py` para el layout y en los modelos entrenados para
+> producir incrustaciones latentes reales.
+
 ## Requisitos
 - Python 3.10+
 - `pip install -r requirements.txt`

--- a/tests/test_legacy_charts_cleanup.py
+++ b/tests/test_legacy_charts_cleanup.py
@@ -1,16 +1,29 @@
-"""Regression tests ensuring the legacy charts helper stays removed."""
+"""Regression tests ensuring removed legacy helpers stay gone."""
 from __future__ import annotations
 
 from pathlib import Path
 
 
-def test_no_legacy_charts_helper_references() -> None:
-    """Ensure the deprecated charts helper is not referenced anywhere."""
+def test_no_legacy_helper_references() -> None:
+    """Ensure deprecated helpers are not referenced anywhere in the codebase."""
     repo_root = Path(__file__).resolve().parents[1]
-    targets = ["predictions_ci_" + "chart", "modules." + "charts"]
+    targets = [
+        "predictions_ci_" + "chart",
+        "modules." + "charts",
+        "modules." + "branding",
+        "modules." + "embeddings",
+        "from app.modules import branding",
+        "from app.modules import charts",
+        "from app.modules import embeddings",
+        "import app.modules.branding",
+        "import app.modules.charts",
+        "import app.modules.embeddings",
+    ]
 
     offenders: list[tuple[Path, str]] = []
     for path in repo_root.rglob("*.py"):
+        if path == Path(__file__):
+            continue
         text = path.read_text(encoding="utf-8", errors="ignore")
         for target in targets:
             if target in text:


### PR DESCRIPTION
## Summary
- document in the README that the legacy branding, charts, and embeddings helpers have been removed
- extend the regression test so it also fails if those legacy helpers reappear anywhere in the codebase

## Testing
- pytest tests/test_legacy_charts_cleanup.py

------
https://chatgpt.com/codex/tasks/task_e_68d6ba7fa19c8331ace50cd0b39d782d