### PR TITLE
Add execution backend abstraction for candidate optimization

### DIFF
--- a/app/modules/execution.py
+++ b/app/modules/execution.py
@@ -1,0 +1,162 @@
+"""Execution backends for parallel candidate generation and scoring."""
+
+from __future__ import annotations
+
+import asyncio
+import functools
+import os
+from concurrent.futures import Future, ThreadPoolExecutor
+from typing import Any, Callable, Iterable, Sequence
+
+
+def _env_int(name: str, default: int) -> int:
+    try:
+        return int(os.getenv(name, ""))
+    except (TypeError, ValueError):
+        return default
+
+
+DEFAULT_PARALLEL_THRESHOLD = _env_int("REXAI_PARALLEL_THRESHOLD", 4)
+
+
+def max_workers_for(task_count: int) -> int:
+    if task_count <= 1:
+        return 1
+    cpu = os.cpu_count() or 1
+    return max(1, min(cpu, task_count))
+
+
+class ExecutionBackend:
+    """Simple protocol for execution backends used across the generator."""
+
+    def __init__(self, max_workers: int = 1) -> None:
+        self.max_workers = max(1, int(max_workers))
+
+    # The map/submit/shutdown trio mirrors the ``concurrent.futures.Executor``
+    # API but is intentionally lightweight so we can plug alternative
+    # implementations (Ray, asyncio, distributed executors) without rewriting
+    # call sites.
+    def map(self, func: Callable[[Any], Any], iterable: Iterable[Any]) -> list[Any]:
+        raise NotImplementedError
+
+    def submit(self, func: Callable[..., Any], *args: Any, **kwargs: Any) -> Future:
+        raise NotImplementedError
+
+    def shutdown(self) -> None:  # pragma: no cover - overriden by subclasses
+        return None
+
+    # Allow ``with backend:`` usage for lifecycle management.
+    def __enter__(self) -> "ExecutionBackend":
+        return self
+
+    def __exit__(self, _exc_type, _exc, _tb) -> None:
+        self.shutdown()
+
+
+class _ImmediateFuture(Future):
+    """Future compatible wrapper for synchronous backends."""
+
+    def __init__(self, value: Any) -> None:
+        super().__init__()
+        self.set_result(value)
+
+
+class SynchronousBackend(ExecutionBackend):
+    def __init__(self) -> None:
+        super().__init__(max_workers=1)
+
+    def map(self, func: Callable[[Any], Any], iterable: Iterable[Any]) -> list[Any]:
+        return [func(item) for item in iterable]
+
+    def submit(self, func: Callable[..., Any], *args: Any, **kwargs: Any) -> Future:
+        result = func(*args, **kwargs)
+        return _ImmediateFuture(result)
+
+
+class ThreadPoolBackend(ExecutionBackend):
+    def __init__(self, max_workers: int | None = None) -> None:
+        workers = max_workers_for(max_workers or 0) if max_workers else max_workers_for(0)
+        super().__init__(max_workers=workers)
+        self._executor = ThreadPoolExecutor(max_workers=self.max_workers)
+
+    def map(self, func: Callable[[Any], Any], iterable: Iterable[Any]) -> list[Any]:
+        return list(self._executor.map(func, iterable))
+
+    def submit(self, func: Callable[..., Any], *args: Any, **kwargs: Any) -> Future:
+        return self._executor.submit(func, *args, **kwargs)
+
+    def shutdown(self) -> None:
+        self._executor.shutdown()
+
+
+class AsyncioBackend(ExecutionBackend):
+    """Asyncio powered backend that still exposes a synchronous API."""
+
+    def __init__(self, max_workers: int | None = None) -> None:
+        workers = max_workers or max_workers_for(0)
+        super().__init__(max_workers=workers)
+        self._executor = ThreadPoolExecutor(max_workers=self.max_workers)
+
+    async def _run_map(
+        self,
+        func: Callable[[Any], Any],
+        items: Sequence[Any],
+    ) -> list[Any]:
+        loop = asyncio.get_running_loop()
+        tasks = [loop.run_in_executor(self._executor, functools.partial(func, item)) for item in items]
+        results: list[Any] = []
+        for task in tasks:
+            results.append(await task)
+        return results
+
+    def map(self, func: Callable[[Any], Any], iterable: Iterable[Any]) -> list[Any]:
+        items = list(iterable)
+        if not items:
+            return []
+        return asyncio.run(self._run_map(func, items))
+
+    def submit(self, func: Callable[..., Any], *args: Any, **kwargs: Any) -> Future:
+        return self._executor.submit(func, *args, **kwargs)
+
+    def shutdown(self) -> None:
+        self._executor.shutdown()
+
+
+def create_backend(
+    task_count: int,
+    *,
+    preferred: str | None = None,
+    threshold: int = DEFAULT_PARALLEL_THRESHOLD,
+    max_workers: int | None = None,
+) -> ExecutionBackend:
+    """Factory that produces an execution backend based on configuration."""
+
+    name = preferred or os.getenv("REXAI_EXECUTION_BACKEND", "auto")
+    name = str(name).strip().lower()
+
+    if name in {"sync", "sequential", "serial"}:
+        return SynchronousBackend()
+
+    if name == "asyncio":
+        workers = max_workers or max_workers_for(task_count)
+        if task_count < threshold:
+            workers = 1
+        return AsyncioBackend(max_workers=workers)
+
+    # Default behaviour covers "auto", "thread", "threads" and unknown labels.
+    if task_count < threshold or name == "sync":
+        return SynchronousBackend()
+
+    workers = max_workers or max_workers_for(task_count)
+    return ThreadPoolBackend(max_workers=workers)
+
+
+__all__ = [
+    "AsyncioBackend",
+    "ExecutionBackend",
+    "SynchronousBackend",
+    "ThreadPoolBackend",
+    "create_backend",
+    "DEFAULT_PARALLEL_THRESHOLD",
+    "max_workers_for",
+]

--- a/app/modules/generator.py
+++ b/app/modules/generator.py
@@ -23,7 +23,6 @@ import os
 import random
 import re
 import threading
-from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, Iterable, Mapping, NamedTuple, Sequence, Tuple
@@ -106,6 +105,11 @@ except Exception:  # pragma: no cover - pyarrow is expected in production
     pa = None  # type: ignore[assignment]
     pq = None  # type: ignore[assignment]
 
+from app.modules.execution import (
+    DEFAULT_PARALLEL_THRESHOLD,
+    ExecutionBackend,
+    create_backend,
+)
 from app.modules.label_mapper import derive_recipe_id, lookup_labels
 from app.modules.ranking import derive_auxiliary_signals, score_recipe
 
@@ -3090,14 +3094,7 @@ def _build_candidate(
 # ---------------------------------------------------------------------------
 
 
-_PARALLEL_THRESHOLD = 4
-
-
-def _max_workers_for(task_count: int) -> int:
-    if task_count <= 1:
-        return 1
-    cpu = os.cpu_count() or 1
-    return max(1, min(cpu, task_count))
+_PARALLEL_THRESHOLD = DEFAULT_PARALLEL_THRESHOLD
 
 
 def generate_candidates(
@@ -3108,6 +3105,8 @@ def generate_candidates(
     crew_time_low: bool = False,
     optimizer_evals: int = 0,
     use_ml: bool = True,
+    backend: ExecutionBackend | None = None,
+    backend_kind: str | None = None,
 ):
     """Generate *n* candidate recycling plans plus optional optimization history."""
 
@@ -3141,61 +3140,67 @@ def generate_candidates(
 
     candidates: list[dict] = []
     seeds = [_next_seed() for _ in range(n)]
-    worker_count = _max_workers_for(n) if n >= _PARALLEL_THRESHOLD else 1
-    executor: ThreadPoolExecutor | None = None
-    if worker_count > 1:
-        executor = ThreadPoolExecutor(max_workers=worker_count)
+    local_backend = backend
+    owns_backend = False
+    if local_backend is None:
+        task_count = max(n, 1)
+        local_backend = create_backend(
+            task_count,
+            preferred=backend_kind,
+            threshold=_PARALLEL_THRESHOLD,
+        )
+        owns_backend = True
     try:
-        if executor is not None:
-            results = executor.map(lambda seed: sampler({}, seed=seed), seeds)
-        else:
-            results = (sampler({}, seed=seed) for seed in seeds)
+        results = local_backend.map(lambda seed: sampler({}, seed=seed), seeds)
         for candidate in results:
             if candidate:
                 candidates.append(candidate)
-    finally:
-        if executor is not None:
-            executor.shutdown()
 
-    components_batch: list[CandidateComponents] = []
-    for _ in range(n):
-        bias = 2.0
-        picks = _pick_materials(df, rng, n=rng.choice([2, 3]), bias=bias)
-        components = _create_candidate_components(picks, proc_df, rng, {})
-        if components:
-            components_batch.append(components)
+        components_batch: list[CandidateComponents] = []
+        for _ in range(n):
+            bias = 2.0
+            picks = _pick_materials(df, rng, n=rng.choice([2, 3]), bias=bias)
+            components = _create_candidate_components(picks, proc_df, rng, {})
+            if components:
+                components_batch.append(components)
 
-    if components_batch:
-        _ = compute_feature_vector(
-            [component.picks for component in components_batch],
-            weights=[component.weights for component in components_batch],
-            process=[component.process for component in components_batch],
-            regolith_pct=[component.regolith_pct for component in components_batch],
-        )
-
-    attempts = 0
-    max_attempts = max(n * 2, 4)
-    while len(candidates) < n and attempts < max_attempts:
-        attempts += 1
-        candidate = sampler({})
-        if candidate:
-            candidates.append(candidate)
-
-    history = pd.DataFrame()
-    if optimizer_evals and optimizer_evals > 0:
-        try:
-            from app.modules.optimizer import optimize_candidates
-
-            pareto, history = optimize_candidates(
-                initial_candidates=candidates,
-                sampler=sampler,
-                target=target,
-                n_evals=int(optimizer_evals),
-                process_ids=process_ids,
+        if components_batch:
+            _ = compute_feature_vector(
+                [component.picks for component in components_batch],
+                weights=[component.weights for component in components_batch],
+                process=[component.process for component in components_batch],
+                regolith_pct=[component.regolith_pct for component in components_batch],
             )
-            candidates = pareto
-        except Exception:
-            history = pd.DataFrame()
+
+        attempts = 0
+        max_attempts = max(n * 2, 4)
+        while len(candidates) < n and attempts < max_attempts:
+            attempts += 1
+            candidate = sampler({})
+            if candidate:
+                candidates.append(candidate)
+
+        history = pd.DataFrame()
+        if optimizer_evals and optimizer_evals > 0:
+            try:
+                from app.modules.optimizer import optimize_candidates
+
+                pareto, history = optimize_candidates(
+                    initial_candidates=candidates,
+                    sampler=sampler,
+                    target=target,
+                    n_evals=int(optimizer_evals),
+                    process_ids=process_ids,
+                    backend=local_backend,
+                    backend_kind=backend_kind,
+                )
+                candidates = pareto
+            except Exception:
+                history = pd.DataFrame()
+
+    finally:
+        if owns_backend:
+            local_backend.shutdown()
 
     candidates.sort(key=lambda cand: cand.get("score", 0.0), reverse=True)
     return candidates, history

--- a/tests/test_execution_backend.py
+++ b/tests/test_execution_backend.py
@@ -1,0 +1,28 @@
+import time
+
+from app.modules import execution
+
+
+def test_thread_backend_outpaces_synchronous_execution():
+    tasks = 4
+    sleep_time = 0.05
+
+    def work(_idx: int) -> float:
+        time.sleep(sleep_time)
+        return time.perf_counter()
+
+    thread_backend = execution.ThreadPoolBackend(max_workers=tasks)
+    try:
+        start_parallel = time.perf_counter()
+        thread_backend.map(work, range(tasks))
+        elapsed_parallel = time.perf_counter() - start_parallel
+    finally:
+        thread_backend.shutdown()
+
+    sync_backend = execution.SynchronousBackend()
+    start_sync = time.perf_counter()
+    sync_backend.map(work, range(tasks))
+    elapsed_sync = time.perf_counter() - start_sync
+
+    assert elapsed_parallel < elapsed_sync * 0.75
+    assert elapsed_parallel < sleep_time * tasks


### PR DESCRIPTION
## Summary
- add a configurable execution backend module supporting synchronous, thread-pool, and asyncio strategies
- thread the new backend through candidate generation and optimization so heuristics and Ax runs can execute in parallel batches
- extend the test suite with determinism checks and a simple throughput benchmark for the parallel backend

## Testing
- pytest tests/test_generator.py::test_generate_candidates_uses_parallel_backend tests/test_generator.py::test_generate_candidates_parallel_is_deterministic tests/test_optimizer.py::test_optimize_candidates_parallel_heuristic tests/test_optimizer.py::test_optimize_candidates_parallel_ax tests/test_execution_backend.py::test_thread_backend_outpaces_synchronous_execution


------
https://chatgpt.com/codex/tasks/task_e_68d6ba7dae808331a474e89bc8647b0b