### PR TITLE
Refactor feature tensor pipeline for batched mission metrics

### DIFF
--- a/app/modules/generator.py
+++ b/app/modules/generator.py
@@ -894,6 +894,7 @@ class _OfficialFeaturesBundle(NamedTuple):
     mission_reference_keys: tuple[str, ...]
     mission_reference_index: Dict[str, int]
     mission_reference_matrix: Any
+    mission_reference_dense: np.ndarray
     mission_names: tuple[str, ...]
     mission_totals_vector: np.ndarray
     processing_metrics: Dict[str, Dict[str, float]]
@@ -1075,6 +1076,7 @@ def _official_features_bundle() -> _OfficialFeaturesBundle:
         (),
         {},
         empty_reference,
+        np.zeros((0, 0), dtype=np.float64),
         (),
         np.zeros(0, dtype=np.float64),
         {},
@@ -1169,6 +1171,11 @@ def _official_features_bundle() -> _OfficialFeaturesBundle:
         waste_summary.mass_by_key, waste_summary.mission_totals
     )
 
+    if sparse is not None and sparse.issparse(mission_reference_matrix):
+        mission_reference_dense = mission_reference_matrix.toarray()
+    else:
+        mission_reference_dense = np.asarray(mission_reference_matrix, dtype=np.float64)
+
     return _OfficialFeaturesBundle(
         value_columns,
         composition_columns,
@@ -1181,6 +1188,7 @@ def _official_features_bundle() -> _OfficialFeaturesBundle:
         mission_reference_keys,
         mission_reference_index,
         mission_reference_matrix,
+        mission_reference_dense,
         mission_names,
         mission_totals_vector,
         processing_metrics,
@@ -1870,10 +1878,9 @@ class CandidateFeatureContext:
     keyword_hits: np.ndarray
     packaging_hits: np.ndarray
     regolith_pct: float
-    mission_share: Dict[str, float]
-    mission_scaled_mass: Dict[str, float]
-    mission_official_mass: Dict[str, float]
-    official_composition: Dict[str, float]
+    mission_indices: np.ndarray
+    composition_matrix: np.ndarray
+    composition_presence: np.ndarray
     num_items: int
 
 
@@ -1887,22 +1894,55 @@ class FeatureTensorBatch:
     pct_volume: Any
     keyword_hits: Any
     packaging_hits: Any
-    mission_share: Any
-    mission_scaled_mass: Any
-    mission_official_mass: Any
+    mission_indices: Any
+    mission_reference: Any
     mission_totals: Any
+    composition_values: Any
     total_mass: Any
     regolith: Any
     keyword_names: Tuple[str, ...]
     mission_names: Tuple[str, ...]
+    composition_names: Tuple[str, ...]
     process_ids: Tuple[str, ...]
     num_items: Tuple[int, ...]
-    official_comp: Tuple[Dict[str, float], ...]
+    composition_presence: np.ndarray
     l2l_constants: Dict[str, float]
     bundle_processing_metrics: Dict[str, Dict[str, float]]
     bundle_leo_mass_savings: Dict[str, Dict[str, float]]
     bundle_propellant_benefits: Dict[str, Dict[str, float]]
     logistics_ratio: float
+
+
+def _coerce_feature_tensor_batch_like(
+    value: FeatureTensorBatch | Mapping[str, Any]
+) -> FeatureTensorBatch:
+    if isinstance(value, FeatureTensorBatch):
+        return value
+    if isinstance(value, Mapping):
+        data = dict(value)
+        tuple_keys = {
+            "keyword_names",
+            "mission_names",
+            "composition_names",
+            "process_ids",
+            "num_items",
+        }
+        for key in tuple_keys:
+            if key in data and not isinstance(data[key], tuple):
+                data[key] = tuple(data[key])
+        if "composition_presence" in data and not isinstance(
+            data["composition_presence"], np.ndarray
+        ):
+            data["composition_presence"] = np.asarray(data["composition_presence"], dtype=bool)
+
+        required = set(FeatureTensorBatch.__annotations__.keys())
+        missing = sorted(required.difference(data.keys()))
+        if missing:
+            raise ValueError(
+                "FeatureTensorBatch mapping is missing required fields: " + ", ".join(missing)
+            )
+        return FeatureTensorBatch(**data)
+    raise TypeError("Unsupported feature tensor batch input")
 
 
 def _coerce_weight_array(values: Iterable[float] | Any) -> np.ndarray:
@@ -2003,24 +2043,30 @@ def _prepare_feature_context(
     difficulty = _series_or_default("difficulty_factor", 1.0).to_numpy(dtype=float) / 3.0
     densities = _series_or_default("density_kg_m3", 0.0).to_numpy(dtype=float)
 
-    official_comp: Dict[str, float] = {}
-    if bundle.composition_columns:
-        for column in bundle.composition_columns:
+    composition_count = len(bundle.composition_columns)
+    if composition_count:
+        composition_matrix = np.zeros((item_count, composition_count), dtype=float)
+        composition_presence = np.zeros(composition_count, dtype=bool)
+    else:
+        composition_matrix = np.zeros((item_count, 0), dtype=float)
+        composition_presence = np.zeros(0, dtype=bool)
+
+    if composition_count:
+        for col_idx, column in enumerate(bundle.composition_columns):
             if column not in picks.columns:
                 continue
             series = picks[column]
-            if not series.notna().any():
+            numeric = pd.to_numeric(series, errors="coerce")
+            if not numeric.notna().any():
                 continue
-            values = pd.to_numeric(series, errors="coerce").fillna(0.0).to_numpy(dtype=float)
+            composition_presence[col_idx] = True
+            values = numeric.fillna(0.0).to_numpy(dtype=float) / 100.0
             if not len(values):
                 continue
-            frac = float(np.dot(raw_weights[: len(values)], values / 100.0))
-            official_comp[column] = frac
+            limit = min(len(values), item_count)
+            composition_matrix[:limit, col_idx] = values[:limit]
 
-    mission_share: Dict[str, float] = {}
-    mission_scaled_mass: Dict[str, float] = {}
-    mission_official_mass: Dict[str, float] = {}
-
+    mission_indices = np.full(item_count, -1, dtype=np.int32)
     if (
         item_count
         and bundle.mission_reference_keys
@@ -2056,40 +2102,7 @@ def _prepare_feature_context(
             )
             valid_mask = key_indices >= 0
             if np.any(valid_mask):
-                weights_valid = weights_arr[valid_mask]
-                if weights_valid.size:
-                    key_indices_valid = key_indices[valid_mask]
-                    weights_by_key = np.bincount(
-                        key_indices_valid,
-                        weights=weights_valid,
-                        minlength=len(bundle.mission_reference_keys),
-                    )
-                    if sparse is not None and sparse.issparse(bundle.mission_reference_matrix):
-                        weighted_mass = weights_by_key @ bundle.mission_reference_matrix
-                    else:
-                        weighted_mass = weights_by_key @ np.asarray(
-                            bundle.mission_reference_matrix, dtype=np.float64
-                        )
-                    weighted_mass = np.asarray(weighted_mass, dtype=float).ravel()
-                    totals_vector = bundle.mission_totals_vector
-                    share_vector = np.divide(
-                        weighted_mass,
-                        totals_vector,
-                        out=np.zeros_like(weighted_mass, dtype=float),
-                        where=totals_vector > 0,
-                    )
-
-                    for mission, share_val, mass_val in zip(
-                        bundle.mission_names,
-                        share_vector,
-                        weighted_mass,
-                        strict=False,
-                    ):
-                        if share_val <= 0 and mass_val <= 0:
-                            continue
-                        mission_share[mission] = float(max(0.0, share_val))
-                        mission_official_mass[mission] = float(max(0.0, mass_val))
-                        mission_scaled_mass[mission] = float(max(0.0, share_val * total_kg))
+                mission_indices = key_indices
 
     return CandidateFeatureContext(
         total_mass=total_kg,
@@ -2102,10 +2115,9 @@ def _prepare_feature_context(
         keyword_hits=keyword_hits,
         packaging_hits=packaging_hits,
         regolith_pct=float(regolith_pct),
-        mission_share=mission_share,
-        mission_scaled_mass=mission_scaled_mass,
-        mission_official_mass=mission_official_mass,
-        official_composition=official_comp,
+        mission_indices=mission_indices,
+        composition_matrix=composition_matrix,
+        composition_presence=composition_presence,
         num_items=int(len(picks)),
     )
 
@@ -2124,6 +2136,7 @@ def _contexts_to_tensor_batch(
     max_items = max((ctx.num_items for ctx in contexts), default=0)
     keyword_names = tuple(_KEYWORD_FEATURES.keys())
     mission_names = bundle.mission_names
+    composition_names = bundle.composition_columns
 
     def _alloc(shape: tuple[int, ...]) -> np.ndarray:
         return np.zeros(shape, dtype=float)
@@ -2136,21 +2149,19 @@ def _contexts_to_tensor_batch(
     pct_volume = _alloc((batch, max_items))
     keyword_hits = _alloc((batch, max_items, len(keyword_names)))
     packaging_hits = _alloc((batch, max_items))
-    mission_share = _alloc((batch, len(mission_names)))
-    mission_scaled_mass = _alloc((batch, len(mission_names)))
-    mission_official_mass = _alloc((batch, len(mission_names)))
+    composition_values = _alloc((batch, max_items, len(composition_names)))
+    mission_indices = np.full((batch, max_items), -1, dtype=np.int32)
 
     total_mass = np.zeros(batch, dtype=float)
     regolith = np.zeros(batch, dtype=float)
     num_items: list[int] = []
-    official_comp: list[Dict[str, float]] = []
+    composition_presence_matrix = np.zeros((batch, len(composition_names)), dtype=bool)
 
     mission_totals = np.asarray(bundle.mission_totals_vector, dtype=float)
 
     for idx, ctx in enumerate(contexts):
         count = ctx.num_items
         num_items.append(count)
-        official_comp.append(dict(ctx.official_composition))
 
         if count:
             weights[idx, :count] = ctx.weights[:count]
@@ -2164,11 +2175,18 @@ def _contexts_to_tensor_batch(
                 keyword_hits[idx, :count, :kw_cols] = ctx.keyword_hits[:count, :kw_cols]
             if ctx.packaging_hits.size:
                 packaging_hits[idx, :count] = ctx.packaging_hits[:count]
+            if ctx.composition_matrix.size:
+                comp_cols = min(ctx.composition_matrix.shape[1], len(composition_names))
+                composition_values[idx, :count, :comp_cols] = ctx.composition_matrix[
+                    :count, :comp_cols
+                ]
+            if ctx.mission_indices.size:
+                mission_count = min(len(ctx.mission_indices), count)
+                mission_indices[idx, :mission_count] = ctx.mission_indices[:mission_count]
 
-        for mission_idx, mission in enumerate(mission_names):
-            mission_share[idx, mission_idx] = ctx.mission_share.get(mission, 0.0)
-            mission_scaled_mass[idx, mission_idx] = ctx.mission_scaled_mass.get(mission, 0.0)
-            mission_official_mass[idx, mission_idx] = ctx.mission_official_mass.get(mission, 0.0)
+        if ctx.composition_presence.size:
+            comp_len = min(len(ctx.composition_presence), len(composition_names))
+            composition_presence_matrix[idx, :comp_len] = ctx.composition_presence[:comp_len]
 
         total_mass[idx] = ctx.total_mass
         regolith[idx] = ctx.regolith_pct
@@ -2191,17 +2209,18 @@ def _contexts_to_tensor_batch(
         pct_volume=_to_backend_array(pct_volume),
         keyword_hits=_to_backend_array(keyword_hits),
         packaging_hits=_to_backend_array(packaging_hits),
-        mission_share=_to_backend_array(mission_share),
-        mission_scaled_mass=_to_backend_array(mission_scaled_mass),
-        mission_official_mass=_to_backend_array(mission_official_mass),
+        mission_indices=_to_backend_array(mission_indices),
+        mission_reference=_to_backend_array(np.asarray(bundle.mission_reference_dense, dtype=float)),
         mission_totals=_to_backend_array(mission_totals),
+        composition_values=_to_backend_array(composition_values),
         total_mass=_to_backend_array(total_mass),
         regolith=_to_backend_array(regolith),
         keyword_names=keyword_names,
         mission_names=mission_names,
+        composition_names=composition_names,
         process_ids=process_ids,
         num_items=tuple(num_items),
-        official_comp=tuple(official_comp),
+        composition_presence=composition_presence_matrix,
         l2l_constants=l2l_constants,
         bundle_processing_metrics=dict(bundle.processing_metrics or {}),
         bundle_leo_mass_savings=dict(bundle.leo_mass_savings or {}),
@@ -2242,10 +2261,11 @@ def _feature_kernel_body(
     pct_volume: Any,
     keyword_hits: Any,
     packaging_hits: Any,
-    mission_share: Any,
-    mission_scaled_mass: Any,
-    mission_official_mass: Any,
+    mission_indices: Any,
+    mission_reference: Any,
     mission_totals: Any,
+    total_mass: Any,
+    composition_values: Any,
     regolith: Any,
     logistics_ratio: float,
 ) -> Dict[str, Any]:
@@ -2257,10 +2277,11 @@ def _feature_kernel_body(
     pct_volume = xp.asarray(pct_volume)
     keyword_hits = xp.asarray(keyword_hits)
     packaging_hits = xp.asarray(packaging_hits)
-    mission_share = xp.asarray(mission_share)
-    mission_scaled_mass = xp.asarray(mission_scaled_mass)
-    mission_official_mass = xp.asarray(mission_official_mass)
     mission_totals = xp.asarray(mission_totals)
+    mission_indices = xp.asarray(mission_indices)
+    mission_reference = xp.asarray(mission_reference)
+    total_mass = xp.asarray(total_mass)
+    composition_values = xp.asarray(composition_values)
     regolith = xp.asarray(regolith)
 
     density = xp.sum(w * densities, axis=1)
@@ -2272,11 +2293,31 @@ def _feature_kernel_body(
     keyword = xp.clip(xp.sum(w[:, :, None] * keyword_hits, axis=1), 0.0, 1.0)
     packaging = xp.clip(xp.sum(w * packaging_hits, axis=1), 0.0, 1.0)
 
+    batch_size = w.shape[0]
+    item_dim = w.shape[1] if w.ndim > 1 else 0
+    mission_dim = mission_totals.shape[0]
+    key_dim = mission_reference.shape[0] if mission_reference.ndim else 0
+
+    valid_indices = mission_indices >= 0
+    if mission_dim == 0 or key_dim == 0:
+        reference_rows = xp.zeros((batch_size, item_dim, mission_dim))
+        weighted_mass = xp.zeros((batch_size, mission_dim))
+    else:
+        safe_indices = xp.where(valid_indices, mission_indices, 0)
+        reference_rows = xp.take(mission_reference, safe_indices, axis=0)
+        reference_rows = xp.where(valid_indices[:, :, None], reference_rows, 0.0)
+        weighted_mass = xp.sum(w[:, :, None] * reference_rows, axis=1)
+
+    totals_positive = mission_totals > 0
+    totals_safe = xp.where(totals_positive, mission_totals, 1.0)
+    mission_share = xp.where(totals_positive, weighted_mass / totals_safe, 0.0)
     mission_share_clipped = xp.clip(mission_share, 0.0, 1.0)
     mission_similarity_total = xp.clip(xp.sum(mission_share_clipped, axis=1), 0.0, 1.0)
     mission_reference_mass = xp.maximum(0.0, mission_share_clipped * mission_totals)
-    mission_scaled_mass = xp.maximum(0.0, mission_scaled_mass)
-    mission_official_mass = xp.maximum(0.0, mission_official_mass)
+    mission_scaled_mass = xp.maximum(0.0, mission_share_clipped * total_mass[:, None])
+    mission_official_mass = xp.maximum(0.0, weighted_mass)
+
+    composition = xp.sum(w[:, :, None] * composition_values, axis=1)
 
     polyethylene = keyword[:, _KEYWORD_INDEX["polyethylene_frac"]] if keyword.shape[1] else xp.zeros(keyword.shape[0])
     foam = keyword[:, _KEYWORD_INDEX["foam_frac"]] if keyword.shape[1] else xp.zeros(keyword.shape[0])
@@ -2318,6 +2359,7 @@ def _feature_kernel_body(
         "gas_recovery_index": gas_recovery_index,
         "logistics_reuse_index": logistics_index,
         "regolith": regolith,
+        "composition": composition,
     }
 
 
@@ -2333,10 +2375,11 @@ if jnp is not None:
         pct_volume: Any,
         keyword_hits: Any,
         packaging_hits: Any,
-        mission_share: Any,
-        mission_scaled_mass: Any,
-        mission_official_mass: Any,
+        mission_indices: Any,
+        mission_reference: Any,
         mission_totals: Any,
+        total_mass: Any,
+        composition_values: Any,
         regolith: Any,
         logistics_ratio: float,
     ) -> Dict[str, Any]:
@@ -2350,10 +2393,11 @@ if jnp is not None:
             pct_volume,
             keyword_hits,
             packaging_hits,
-            mission_share,
-            mission_scaled_mass,
-            mission_official_mass,
+            mission_indices,
+            mission_reference,
             mission_totals,
+            total_mass,
+            composition_values,
             regolith,
             logistics_ratio,
         )
@@ -2369,10 +2413,11 @@ else:
         pct_volume: Any,
         keyword_hits: Any,
         packaging_hits: Any,
-        mission_share: Any,
-        mission_scaled_mass: Any,
-        mission_official_mass: Any,
+        mission_indices: Any,
+        mission_reference: Any,
         mission_totals: Any,
+        total_mass: Any,
+        composition_values: Any,
         regolith: Any,
         logistics_ratio: float,
     ) -> Dict[str, Any]:
@@ -2386,10 +2431,11 @@ else:
             pct_volume,
             keyword_hits,
             packaging_hits,
-            mission_share,
-            mission_scaled_mass,
-            mission_official_mass,
+            mission_indices,
+            mission_reference,
             mission_totals,
+            total_mass,
+            composition_values,
             regolith,
             logistics_ratio,
         )
@@ -2477,10 +2523,11 @@ def _compute_features_from_batch(batch: FeatureTensorBatch) -> list[Dict[str, An
         batch.pct_volume,
         batch.keyword_hits,
         batch.packaging_hits,
-        batch.mission_share,
-        batch.mission_scaled_mass,
-        batch.mission_official_mass,
+        batch.mission_indices,
+        batch.mission_reference,
         batch.mission_totals,
+        batch.total_mass,
+        batch.composition_values,
         batch.regolith,
         batch.logistics_ratio,
     )
@@ -2501,6 +2548,7 @@ def _compute_features_from_batch(batch: FeatureTensorBatch) -> list[Dict[str, An
     gas_recovery = to_numpy(kernel_output["gas_recovery_index"])
     logistics_reuse = to_numpy(kernel_output["logistics_reuse_index"])
     regolith = to_numpy(kernel_output["regolith"])
+    composition_total = to_numpy(kernel_output["composition"])
     total_mass = to_numpy(batch.total_mass)
 
     keyword_pairs = tuple(
@@ -2554,7 +2602,21 @@ def _compute_features_from_batch(batch: FeatureTensorBatch) -> list[Dict[str, An
         for name, kw_idx in keyword_pairs:
             features[name] = float(keyword_matrix[idx, kw_idx])
 
-        _apply_official_composition_overrides(features, batch.official_comp[idx])
+        official_comp: Dict[str, float] = {}
+        if batch.composition_names and composition_total.size:
+            presence_row = (
+                batch.composition_presence[idx]
+                if idx < len(batch.composition_presence)
+                else np.zeros(len(batch.composition_names), dtype=bool)
+            )
+            for name_idx, name in enumerate(batch.composition_names):
+                if presence_row.size > name_idx and not presence_row[name_idx]:
+                    continue
+                if composition_total.ndim >= 2 and composition_total.shape[0] > idx and composition_total.shape[1] > name_idx:
+                    official_comp[name] = float(composition_total[idx, name_idx])
+                elif composition_total.ndim == 1 and composition_total.size > name_idx:
+                    official_comp[name] = float(composition_total[name_idx])
+        _apply_official_composition_overrides(features, official_comp)
 
         if l2l_values.size:
             for name_idx, name in enumerate(l2l_names):
@@ -2618,8 +2680,9 @@ def compute_feature_vector(
     *,
     backend: str | None = None,
 ) -> Dict[str, Any] | list[Dict[str, Any]]:
-    if isinstance(picks, FeatureTensorBatch):
-        return _compute_features_from_batch(picks)
+    if isinstance(picks, (FeatureTensorBatch, Mapping)):
+        batch = _coerce_feature_tensor_batch_like(picks)  # type: ignore[arg-type]
+        return _compute_features_from_batch(batch)
 
     backend = backend or "jax"
 

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -1185,7 +1185,7 @@ def test_compute_feature_vector_dataframe_matches_tensor_batch():
     )
 
     tensor_batch = generator.build_feature_tensor_batch(
-        [prepared], [weights], [process], [regolith_pct]
+        [prepared], [weights], [process], [regolith_pct], backend="numpy"
     )
     tensor_features = generator.compute_feature_vector(tensor_batch)
 
@@ -1195,6 +1195,21 @@ def test_compute_feature_vector_dataframe_matches_tensor_batch():
     assert set(tensor_features) == set(dataframe_features)
     for key, value in dataframe_features.items():
         lhs = tensor_features[key]
+        if isinstance(value, numbers.Real):
+            assert lhs == pytest.approx(value, rel=1e-6, abs=1e-8)
+        else:
+            assert lhs == value
+
+    tensor_mapping = {
+        field: getattr(tensor_batch, field)
+        for field in generator.FeatureTensorBatch.__annotations__
+    }
+    mapping_features = generator.compute_feature_vector(tensor_mapping)
+    assert isinstance(mapping_features, list) and mapping_features
+    mapping_features = mapping_features[0]
+    assert set(mapping_features) == set(tensor_features)
+    for key, value in tensor_features.items():
+        lhs = mapping_features[key]
         if isinstance(value, numbers.Real):
             assert lhs == pytest.approx(value, rel=1e-6, abs=1e-8)
         else:
@@ -1392,6 +1407,9 @@ def test_compute_feature_vector_includes_mission_metrics(monkeypatch):
         mission_reference_keys=mission_reference_keys,
         mission_reference_index=mission_reference_index,
         mission_reference_matrix=mission_reference_matrix,
+        mission_reference_dense=np.asarray(mission_reference_matrix.todense())
+        if generator.sparse is not None and generator.sparse.issparse(mission_reference_matrix)
+        else np.asarray(mission_reference_matrix, dtype=np.float64),
         mission_names=mission_names,
         mission_totals_vector=mission_totals_vector,
         processing_metrics={"gateway_i": {"processing_o2_ch4_yield_kg": 5.0}},
@@ -1508,6 +1526,9 @@ def test_prepare_waste_frame_injects_l2l_features(monkeypatch):
         mission_reference_keys=(),
         mission_reference_index={},
         mission_reference_matrix=empty_reference,
+        mission_reference_dense=np.asarray(empty_reference.todense())
+        if generator.sparse is not None and generator.sparse.issparse(empty_reference)
+        else np.asarray(empty_reference, dtype=np.float64),
         mission_names=(),
         mission_totals_vector=np.zeros(0, dtype=np.float64),
         processing_metrics={},
@@ -1685,6 +1706,9 @@ def test_compute_feature_vector_uses_l2l_packaging_ratio(monkeypatch):
         mission_reference_keys=(),
         mission_reference_index={},
         mission_reference_matrix=empty_reference,
+        mission_reference_dense=np.asarray(empty_reference.todense())
+        if generator.sparse is not None and generator.sparse.issparse(empty_reference)
+        else np.asarray(empty_reference, dtype=np.float64),
         mission_names=(),
         mission_totals_vector=np.zeros(0, dtype=np.float64),
         processing_metrics={},


### PR DESCRIPTION
## Summary
- extend the cached official features bundle with a dense mission matrix for fast lookups
- move mission similarity and composition aggregation into the vectorized feature kernel and allow compute_feature_vector to accept tensor/mapping inputs
- update generator tests to cover the new tensor API and ensure parity across dataframe, tensor, and mapping callers

## Testing
- pytest tests/test_generator.py


------
https://chatgpt.com/codex/tasks/task_e_68d6ba7cb1248331a4ed9b1eec552001