### PR TITLE
Remove duplicate official_features_bundle export

### DIFF
--- a/app/modules/generator.py
+++ b/app/modules/generator.py
@@ -954,12 +954,6 @@ def _official_features_bundle() -> _OfficialFeaturesBundle:
         hints,
     )
 
-def official_features_bundle() -> _OfficialFeaturesBundle:
-    """Public accessor for tests and external callers."""
-
-    return _official_features_bundle()
-
-
 def _lookup_official_feature_values(row: pd.Series) -> tuple[Dict[str, float], str]:
     """Resolve NASA reference features with packaging-aware fallbacks."""
 


### PR DESCRIPTION
## Summary
- remove the redundant public official_features_bundle definition in the generator module so only the cached helper is exposed

## Testing
- pytest tests/test_generator.py::test_official_features_bundle_polars_pipeline *(fails: NameError: name 'pq' is not defined when importing app.modules.generator)*

------
https://chatgpt.com/codex/tasks/task_e_68d6c6b0b15083318651f6ef4640467e