### PR TITLE
Bootstrap Streamlit pages via package import

### DIFF
--- a/app/Home.py
+++ b/app/Home.py
@@ -1,10 +1,5 @@
 # app/Home.py
-# ───────────────────────── path guard ─────────────────────────
-import sys, pathlib
-ROOT = pathlib.Path(__file__).resolve().parents[1]
-if str(ROOT) not in sys.path:
-    sys.path.insert(0, str(ROOT))
-# ──────────────────────────────────────────────────────────────
+import app  # noqa: F401
 
 from datetime import datetime
 import streamlit as st

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,1 +1,12 @@
 """Streamlit app package."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+__all__ = ["ROOT"]

--- a/app/pages/0_Project_Brief.py
+++ b/app/pages/0_Project_Brief.py
@@ -1,17 +1,10 @@
 # app/pages/0_Project_Brief.py
-# --- path guard universal ---
-import sys, pathlib
-_here = pathlib.Path(__file__).resolve()
-p = _here.parent
-while p.name != "app" and p.parent != p:
-    p = p.parent
-repo_root = p.parent if p.name == "app" else _here.parent
-if str(repo_root) not in sys.path:
-    sys.path.insert(0, str(repo_root))
-# --------------------------------
+import app  # noqa: F401
 
 import streamlit as st
 from pathlib import Path
+
+repo_root = Path(app.ROOT)
 
 # ⚠️ PRIMER comando Streamlit:
 st.set_page_config(page_title="REX-AI Mars — Brief", page_icon="🛰️", layout="wide")

--- a/app/pages/1_Inventory_Builder.py
+++ b/app/pages/1_Inventory_Builder.py
@@ -1,9 +1,4 @@
-# --- path guard para Streamlit Cloud ---
-import sys, pathlib
-ROOT = pathlib.Path(__file__).resolve().parents[1]  # carpeta raíz del repo
-if str(ROOT) not in sys.path:
-    sys.path.insert(0, str(ROOT))
-# ---------------------------------------
+import app  # noqa: F401
 
 import streamlit as st
 import pandas as pd

--- a/app/pages/2_Target_Designer.py
+++ b/app/pages/2_Target_Designer.py
@@ -1,13 +1,4 @@
-# --- path guard universal (funciona en Home.py y en pages/*) ---
-import sys, pathlib
-_here = pathlib.Path(__file__).resolve()
-p = _here.parent
-while p.name != "app" and p.parent != p:
-    p = p.parent
-repo_root = p.parent if p.name == "app" else _here.parent  # fallback
-if str(repo_root) not in sys.path:
-    sys.path.insert(0, str(repo_root))
-# ----------------------------------------------------------------
+import app  # noqa: F401
 
 import streamlit as st
 

--- a/app/pages/3_Generator.py
+++ b/app/pages/3_Generator.py
@@ -1,9 +1,4 @@
-# --- path guard para Streamlit Cloud ---
-import sys, pathlib
-ROOT = pathlib.Path(__file__).resolve().parents[1]
-if str(ROOT) not in sys.path:
-    sys.path.insert(0, str(ROOT))
-# ---------------------------------------
+import app  # noqa: F401
 
 from datetime import datetime
 

--- a/app/pages/4_Results_and_Tradeoffs.py
+++ b/app/pages/4_Results_and_Tradeoffs.py
@@ -1,9 +1,4 @@
-# --- path guard para Streamlit Cloud ---
-import sys, pathlib
-ROOT = pathlib.Path(__file__).resolve().parents[1]
-if str(ROOT) not in sys.path:
-    sys.path.insert(0, str(ROOT))
-# ---------------------------------------
+import app  # noqa: F401
 
 import altair as alt
 import pandas as pd

--- a/app/pages/5_Compare_and_Explain.py
+++ b/app/pages/5_Compare_and_Explain.py
@@ -1,9 +1,4 @@
-# --- path guard para Streamlit Cloud ---
-import sys, pathlib
-ROOT = pathlib.Path(__file__).resolve().parents[1]  # carpeta raíz del repo
-if str(ROOT) not in sys.path:
-    sys.path.insert(0, str(ROOT))
-# ---------------------------------------
+import app  # noqa: F401
 
 import streamlit as st
 import pandas as pd

--- a/app/pages/6_Pareto_and_Export.py
+++ b/app/pages/6_Pareto_and_Export.py
@@ -1,10 +1,5 @@
 # app/pages/6_Pareto_and_Export.py
-# --- path guard para Streamlit Cloud ---
-import sys, pathlib
-ROOT = pathlib.Path(__file__).resolve().parents[1]
-if str(ROOT) not in sys.path:
-    sys.path.insert(0, str(ROOT))
-# ---------------------------------------
+import app  # noqa: F401
 
 import streamlit as st
 import numpy as np

--- a/app/pages/7_Scenario_Playbooks.py
+++ b/app/pages/7_Scenario_Playbooks.py
@@ -1,10 +1,5 @@
 # app/pages/7_Scenario_Playbooks.py
-# --- path guard para Streamlit Cloud ---
-import sys, pathlib
-ROOT = pathlib.Path(__file__).resolve().parents[1]
-if str(ROOT) not in sys.path:
-    sys.path.insert(0, str(ROOT))
-# ---------------------------------------
+import app  # noqa: F401
 
 import streamlit as st
 import pandas as pd

--- a/app/pages/8_Feedback_and_Impact.py
+++ b/app/pages/8_Feedback_and_Impact.py
@@ -1,10 +1,5 @@
 # app/pages/8_Feedback_and_Impact.py
-# --- path guard para Streamlit Cloud ---
-import sys, pathlib
-ROOT = pathlib.Path(__file__).resolve().parents[1]
-if str(ROOT) not in sys.path:
-    sys.path.insert(0, str(ROOT))
-# ---------------------------------------
+import app  # noqa: F401
 
 # ⚠️ Debe ser la PRIMERA llamada Streamlit:
 import streamlit as st

--- a/app/pages/9_Capacity_Simulator.py
+++ b/app/pages/9_Capacity_Simulator.py
@@ -1,10 +1,5 @@
 # app/pages/9_Capacity_Simulator.py
-# --- path guard para Streamlit Cloud ---
-import sys, pathlib
-ROOT = pathlib.Path(__file__).resolve().parents[1]
-if str(ROOT) not in sys.path:
-    sys.path.insert(0, str(ROOT))
-# ---------------------------------------
+import app  # noqa: F401
 
 # ⚠️ Debe ser la PRIMERA llamada de Streamlit
 import streamlit as st


### PR DESCRIPTION
## Summary
- add a package import hook that injects the repository root into `sys.path`
- replace the repeated per-page path guards with a simple `import app  # noqa: F401`
- keep the project brief page functional by resolving assets via `Path(app.ROOT)`

## Testing
- streamlit run app/Home.py --server.headless true --server.port 8888

------
https://chatgpt.com/codex/tasks/task_e_68d6c6c04c888331aa005583a1146bf7