### PR TITLE
Centralize Streamlit theme CSS and helper

### DIFF
--- a/app/Home.py
+++ b/app/Home.py
@@ -9,6 +9,7 @@ if str(ROOT) not in sys.path:
 from datetime import datetime
 import streamlit as st
 from app.modules.ml_models import MODEL_REGISTRY
+from app.modules.ui_blocks import load_theme
 
 st.set_page_config(
     page_title="Rex-AI • Mission Copilot",
@@ -16,20 +17,12 @@ st.set_page_config(
     layout="wide",
 )
 
+load_theme()
+
 # ──────────── Estilos (oscuro, cards y métricas) ────────────
 st.markdown(
     """
     <style>
-    :root {
-      --bg: #0b0d12;
-      --card: rgba(18,21,29,0.72);
-      --stroke: rgba(255,255,255,0.08);
-      --accent: #60a5fa;
-      --ink: #f8fafc;
-      --muted: rgba(226,232,240,0.68);
-    }
-    body {background: var(--bg);}
-    .block-container {padding: 2.6rem 3rem 3rem 3rem;}
     .hero {
       border-radius: 28px;
       padding: 36px 42px;

--- a/app/modules/ui_blocks.py
+++ b/app/modules/ui_blocks.py
@@ -1,23 +1,35 @@
-import streamlit as st
+from pathlib import Path
 from typing import Literal
 
-CSS = """
-<style>
-.card {
-  background:#151A21; border:1px solid #242C37; border-radius:16px; padding:18px; margin-bottom:12px;
-}
-.kpi { display:flex; gap:14px; }
-.kpi .pill { background:#0E1117; border:1px solid #242C37; border-radius:999px; padding:6px 12px; }
-.badge-ok { color:#0FD68B; }
-.badge-warn { color:#F39C12; }
-.badge-risk { color:#E74C3C; }
-.btn-primary { background:#00B894; color:#0E1117; border-radius:12px; padding:10px 16px; font-weight:700; }
-.small { opacity:0.8; font-size:0.9rem; }
-</style>
-"""
+import streamlit as st
+
+_THEME_KEY = "__rexai_theme_loaded__"
+
+
+def _theme_path() -> Path:
+    return Path(__file__).resolve().parents[1] / "static" / "theme.css"
+
+
+def load_theme() -> None:
+    """Inject the shared Rex-AI theme CSS once per Streamlit session."""
+
+    if st.session_state.get(_THEME_KEY):
+        return
+
+    theme_file = _theme_path()
+    try:
+        css = theme_file.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return
+
+    st.markdown(f"<style>{css}</style>", unsafe_allow_html=True)
+    st.session_state[_THEME_KEY] = True
+
 
 def inject_css():
-    st.markdown(CSS, unsafe_allow_html=True)
+    """Backward-compatible alias for legacy code paths."""
+
+    load_theme()
 
 def card(title:str, body:str=""):
     st.markdown(f"""<div class="card"><h4>{title}</h4><div class="small">{body}</div></div>""", unsafe_allow_html=True)

--- a/app/pages/0_Project_Brief.py
+++ b/app/pages/0_Project_Brief.py
@@ -13,24 +13,12 @@ if str(repo_root) not in sys.path:
 import streamlit as st
 from pathlib import Path
 
+from app.modules.ui_blocks import load_theme
+
 # ⚠️ PRIMER comando Streamlit:
 st.set_page_config(page_title="REX-AI Mars — Brief", page_icon="🛰️", layout="wide")
 
-# ---------- Estilos mínimos (seguros) ----------
-st.markdown("""
-<style>
-:root{
-  --bd: rgba(130,140,160,.28);
-}
-.hero{border:1px solid var(--bd); border-radius:18px; padding:18px;
-      background: radial-gradient(900px 260px at 25% -10%, rgba(80,120,255,.10), transparent);}
-.card{border:1px solid var(--bd); border-radius:16px; padding:16px; margin-bottom:12px;}
-.kpi{border:1px solid var(--bd); border-radius:14px; padding:14px; margin-bottom:10px;}
-.kpi h3{margin:0 0 6px 0; font-size:.95rem; opacity:.8}
-.kpi .v{font-size:1.5rem; font-weight:800; letter-spacing:.2px}
-.small{font-size:.92rem; opacity:.9}
-</style>
-""", unsafe_allow_html=True)
+load_theme()
 
 # ---------- Header ----------
 logo_svg = repo_root / "app" / "static" / "logo_rexai.svg"

--- a/app/pages/3_Generator.py
+++ b/app/pages/3_Generator.py
@@ -16,11 +16,11 @@ from app.modules.io import load_waste_df, load_process_df  # si tu IO usa load_p
 from app.modules.ml_models import MODEL_REGISTRY
 from app.modules.process_planner import choose_process
 from app.modules.safety import check_safety, safety_badge
-from app.modules.ui_blocks import inject_css
+from app.modules.ui_blocks import load_theme
 
 st.set_page_config(page_title="Rex-AI • Generador", page_icon="🤖", layout="wide")
 
-inject_css()
+load_theme()
 
 # ----------------------------- CSS local -----------------------------
 st.markdown(

--- a/app/pages/4_Results_and_Tradeoffs.py
+++ b/app/pages/4_Results_and_Tradeoffs.py
@@ -10,9 +10,13 @@ import pandas as pd
 import plotly.graph_objects as go
 import streamlit as st
 
+from app.modules.ui_blocks import load_theme
+
 from app.modules.explain import score_breakdown
 
 st.set_page_config(page_title="Rex-AI • Resultados", page_icon="📊", layout="wide")
+
+load_theme()
 
 selected = st.session_state.get("selected")
 target = st.session_state.get("target")

--- a/app/pages/5_Compare_and_Explain.py
+++ b/app/pages/5_Compare_and_Explain.py
@@ -11,9 +11,12 @@ import plotly.express as px
 import plotly.graph_objects as go
 
 from app.modules.explain import compare_table, score_breakdown
+from app.modules.ui_blocks import load_theme
 
 # ⚠️ Debe ser la PRIMERA llamada de Streamlit en la página
 st.set_page_config(page_title="Comparar & Explicar", page_icon="🧪", layout="wide")
+
+load_theme()
 
 # ======== estado requerido ========
 cands  = st.session_state.get("candidates", [])
@@ -23,23 +26,18 @@ if not cands or not target:
     st.stop()
 
 # ======== estilo visual ========
-st.markdown("""
-<style>
-/* Cards / KPIs */
-.kpi {border:1px solid rgba(128,128,128,0.25); border-radius:14px; padding:14px; margin-bottom:12px;}
-.kpi h3 {margin:0 0 6px 0; font-size:0.95rem; opacity:0.8;}
-.kpi .v {font-size:1.6rem; font-weight:700; letter-spacing:0.2px;}
-.kpi .hint {font-size:0.85rem; opacity:0.75;}
-/* Pills */
-.pill {display:inline-block; padding:4px 10px; border-radius:999px; font-weight:600; font-size:0.85rem;}
-.pill.ok {background:#e8f7ee; color:#136c3a; border:1px solid #b3e2c4;}
-.pill.med {background:#fff3cd; color:#8a6d1d; border:1px solid #ffe69b;}
-.pill.bad {background:#fdeceb; color:#8b1b13; border:1px solid #f5c2c0;}
-/* Secciones */
-h2 span.sub {font-size:0.95rem; font-weight:500; opacity:0.7; margin-left:8px;}
-.small {font-size:0.9rem; opacity:0.85;}
-</style>
-""", unsafe_allow_html=True)
+st.markdown(
+    """
+    <style>
+    .kpi {border-color: rgba(128,128,128,0.25); margin-bottom:12px;}
+    .kpi .v {font-weight:700;}
+    .pill {font-weight:600; font-size:0.85rem;}
+    h2 span.sub {font-size:0.95rem; font-weight:500; opacity:0.7; margin-left:8px;}
+    .small {font-size:0.9rem; opacity:0.85;}
+    </style>
+    """,
+    unsafe_allow_html=True,
+)
 
 st.markdown("# 🧪 Compare & Explain")
 st.caption("Compará candidatos como en un *design review*: qué rinde más, dónde gasta menos, y por qué elige la IA esa receta.")

--- a/app/pages/6_Pareto_and_Export.py
+++ b/app/pages/6_Pareto_and_Export.py
@@ -16,9 +16,12 @@ from app.modules.explain import compare_table
 from app.modules.analytics import pareto_front
 from app.modules.exporters import candidate_to_json, candidate_to_csv
 from app.modules.safety import check_safety  # recalcular badge al seleccionar
+from app.modules.ui_blocks import load_theme
 
 # ⚠️ PRIMERA llamada
 st.set_page_config(page_title="Pareto & Export", page_icon="📤", layout="wide")
+
+load_theme()
 
 # ======== estado requerido ========
 cands  = st.session_state.get("candidates", [])
@@ -30,25 +33,15 @@ if not cands or not target:
     st.stop()
 
 # ======== estilos (NASA/SpaceX-like) ========
-st.markdown("""
-<style>
-:root{ --bd: rgba(140,140,160,.28); --muted: rgba(255,255,255,.55); }
-.block{border:1px solid var(--bd); border-radius:16px; padding:16px;}
-.hero{border:1px solid var(--bd); border-radius:16px; padding:18px 18px 8px;
-      background: radial-gradient(1200px 380px at 20% -10%, rgba(80,120,255,.08), transparent);}
-.kpi{border:1px solid var(--bd); border-radius:14px; padding:14px; margin-bottom:10px;}
-.kpi h3{margin:0 0 6px 0; font-size:.95rem; opacity:.8}
-.kpi .v{font-size:1.6rem; font-weight:800; letter-spacing:.2px}
-.pill{display:inline-block; padding:4px 10px; border-radius:999px; font-weight:700; font-size:.78rem;
-      border:1px solid var(--bd); margin-right:6px}
-.pill.ok{background:#e8f7ee; color:#136c3a; border-color:#b3e2c4}
-.pill.info{background:#e7f1ff; color:#174ea6; border-color:#c6dcff}
-.pill.warn{background:#fff3cd; color:#8a6d1d; border-color:#ffe69b}
-.small{font-size:.92rem; opacity:.9}
-.legend{font-size:.86rem; opacity:.75}
-.section-title{margin-top:6px; margin-bottom:6px}
-</style>
-""", unsafe_allow_html=True)
+st.markdown(
+    """
+    <style>
+    .hero {border-radius:16px; padding:18px 18px 8px; background: radial-gradient(1200px 380px at 20% -10%, rgba(80,120,255,.08), transparent);}
+    .section-title{margin-top:6px; margin-bottom:6px}
+    </style>
+    """,
+    unsafe_allow_html=True,
+)
 
 # ======== HERO ========
 st.markdown("""

--- a/app/pages/7_Scenario_Playbooks.py
+++ b/app/pages/7_Scenario_Playbooks.py
@@ -10,9 +10,12 @@ import streamlit as st
 import pandas as pd
 
 from app.modules.scenarios import PLAYBOOKS  # dict: {scenario: Playbook(name, summary, steps=[...])}
+from app.modules.ui_blocks import load_theme
 
 # ⚠️ Debe ser la primera llamada
 st.set_page_config(page_title="Scenario Playbooks", page_icon="📚", layout="wide")
+
+load_theme()
 
 # ======== Estado compartido ========
 target      = st.session_state.get("target", None)
@@ -21,27 +24,17 @@ candidato   = state_sel["data"] if state_sel else None
 props       = candidato["props"] if candidato else None
 
 # ======== Estilos SpaceX/NASA-like ========
-st.markdown("""
-<style>
-:root{ --bd: rgba(140,140,160,.28); --ink: #0f172a; --muted: rgba(15,23,42,.65); }
-.hero{border:1px solid var(--bd); border-radius:16px; padding:18px;
-      background: radial-gradient(900px 260px at 20% -10%, rgba(80,120,255,.10), transparent);}
-.pill{display:inline-block; padding:4px 10px; border-radius:999px; font-weight:700; font-size:.78rem;
-      border:1px solid var(--bd); margin-right:6px}
-.pill.ok{background:#e8f7ee; color:#136c3a; border-color:#b3e2c4}
-.pill.info{background:#e7f1ff; color:#174ea6; border-color:#c6dcff}
-.pill.warn{background:#fff3cd; color:#8a6d1d; border-color:#ffe69b}
-.block{border:1px solid var(--bd); border-radius:16px; padding:16px;}
-.step{border:1px dashed var(--bd); border-radius:14px; padding:14px; margin-bottom:12px;}
-.step h4{margin:0 0 6px 0;}
-.kpi{border:1px solid var(--bd); border-radius:14px; padding:14px; margin-bottom:10px;}
-.kpi h3{margin:0 0 6px 0; font-size:.95rem; opacity:.8}
-.kpi .v{font-size:1.6rem; font-weight:800; letter-spacing:.2px}
-.legend{font-size:.9rem; opacity:.8}
-.small{font-size:.92rem; opacity:.9}
-.mono{font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;}
-</style>
-""", unsafe_allow_html=True)
+st.markdown(
+    """
+    <style>
+    .hero {border-radius:16px; background: radial-gradient(900px 260px at 20% -10%, rgba(80,120,255,.10), transparent);}
+    .step{border:1px dashed var(--bd); border-radius:14px; padding:14px; margin-bottom:12px;}
+    .step h4{margin:0 0 6px 0;}
+    .mono{font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;}
+    </style>
+    """,
+    unsafe_allow_html=True,
+)
 
 # ======== HERO ========
 st.markdown("""

--- a/app/pages/8_Feedback_and_Impact.py
+++ b/app/pages/8_Feedback_and_Impact.py
@@ -8,7 +8,11 @@ if str(ROOT) not in sys.path:
 
 # ⚠️ Debe ser la PRIMERA llamada Streamlit:
 import streamlit as st
+from app.modules.ui_blocks import load_theme
+
 st.set_page_config(page_title="Feedback & Impact", page_icon="📝", layout="wide")
+
+load_theme()
 
 import json
 import pandas as pd
@@ -79,26 +83,7 @@ def _with_extra_columns(df: pd.DataFrame, rename_map: dict[str, str] | None = No
     return work
 
 # ========= estilos SpaceX/NASA-like =========
-st.markdown("""
-<style>
-:root{ --bd: rgba(140,140,160,.28); --ink:#0f172a; --muted: rgba(15,23,42,.65); }
-.hero{border:1px solid var(--bd); border-radius:18px; padding:18px;
-      background: radial-gradient(900px 260px at 25% -10%, rgba(80,120,255,.10), transparent);}
-.pill{display:inline-block; padding:4px 10px; border-radius:999px; font-weight:700; font-size:.78rem;
-      border:1px solid var(--bd); margin-right:6px}
-.pill.ok{background:#e8f7ee; color:#136c3a; border-color:#b3e2c4}
-.pill.info{background:#e7f1ff; color:#174ea6; border-color:#c6dcff}
-.pill.warn{background:#fff3cd; color:#8a6d1d; border-color:#ffe69b}
-.block{border:1px solid var(--bd); border-radius:16px; padding:16px;}
-.kpi{border:1px solid var(--bd); border-radius:14px; padding:14px; margin-bottom:10px;}
-.kpi h3{margin:0 0 6px 0; font-size:.95rem; opacity:.8}
-.kpi .v{font-size:1.6rem; font-weight:800; letter-spacing:.2px}
-.small{font-size:.92rem; opacity:.9}
-.legend{font-size:.9rem; opacity:.8}
-hr{border:none;height:1px;background:var(--bd); margin:8px 0 16px 0}
-table{font-size:0.95rem}
-</style>
-""", unsafe_allow_html=True)
+# (Se cargan desde app/static/theme.css vía load_theme)
 
 # ========= estado compartido =========
 target      = st.session_state.get("target", None)

--- a/app/pages/9_Capacity_Simulator.py
+++ b/app/pages/9_Capacity_Simulator.py
@@ -8,7 +8,11 @@ if str(ROOT) not in sys.path:
 
 # ⚠️ Debe ser la PRIMERA llamada de Streamlit
 import streamlit as st
+from app.modules.ui_blocks import load_theme
+
 st.set_page_config(page_title="Capacity Simulator", page_icon="🧮", layout="wide")
+
+load_theme()
 
 import math
 import numpy as np
@@ -19,31 +23,14 @@ import plotly.express as px
 from app.modules.capacity import LineConfig, simulate
 
 # ============== Estilos SpaceX/NASA-like ==============
-st.markdown("""
-<style>
-:root{
-  --bd: rgba(140,140,160,.28);
-  --ink:#0f172a;
-  --muted: rgba(15,23,42,.65);
-}
-.hero{border:1px solid var(--bd); border-radius:18px; padding:18px;
-      background: radial-gradient(900px 260px at 25% -10%, rgba(80,120,255,.10), transparent);}
-.pill{display:inline-block; padding:4px 10px; border-radius:999px; font-weight:700; font-size:.78rem;
-      border:1px solid var(--bd); margin-right:6px}
-.pill.ok{background:#e8f7ee; color:#136c3a; border-color:#b3e2c4}
-.pill.info{background:#e7f1ff; color:#174ea6; border-color:#c6dcff}
-.pill.warn{background:#fff3cd; color:#8a6d1d; border-color:#ffe69b}
-.block{border:1px solid var(--bd); border-radius:16px; padding:16px;}
-.kpi{border:1px solid var(--bd); border-radius:14px; padding:14px; margin-bottom:10px;}
-.kpi h3{margin:0 0 6px 0; font-size:.95rem; opacity:.8}
-.kpi .v{font-size:1.6rem; font-weight:800; letter-spacing:.2px}
-.small{font-size:.92rem; opacity:.9}
-.legend{font-size:.9rem; opacity:.8}
-hr{border:none;height:1px;background:var(--bd); margin:8px 0 16px 0}
-table{font-size:0.95rem}
-.callout{border-left:4px solid #8ab4ff; padding:10px 12px; background:rgba(138,180,255,.08); border-radius:8px;}
-</style>
-""", unsafe_allow_html=True)
+st.markdown(
+    """
+    <style>
+    .callout{border-left:4px solid #8ab4ff; padding:10px 12px; background:rgba(138,180,255,.08); border-radius:8px;}
+    </style>
+    """,
+    unsafe_allow_html=True,
+)
 
 # ============== Estado compartido con el resto de la app ==============
 target    = st.session_state.get("target", None)

--- a/app/static/theme.css
+++ b/app/static/theme.css
@@ -1,0 +1,131 @@
+:root {
+  --bg: #0b0d12;
+  --card: rgba(18, 21, 29, 0.72);
+  --stroke: rgba(255, 255, 255, 0.08);
+  --accent: #60a5fa;
+  --ink: #f8fafc;
+  --muted: rgba(226, 232, 240, 0.68);
+  --bd: rgba(140, 140, 160, 0.28);
+  --hero-background: radial-gradient(900px 260px at 25% -10%, rgba(80, 120, 255, 0.10), transparent);
+}
+
+body {
+  background: var(--bg);
+}
+
+.block-container {
+  padding: 2.6rem 3rem 3rem 3rem;
+}
+
+.hero {
+  border: 1px solid var(--bd);
+  border-radius: 18px;
+  padding: 18px;
+  background: var(--hero-background);
+}
+
+.block {
+  border: 1px solid var(--bd);
+  border-radius: 16px;
+  padding: 16px;
+}
+
+.card {
+  background: #151a21;
+  border: 1px solid #242c37;
+  border-radius: 16px;
+  padding: 18px;
+  margin-bottom: 12px;
+}
+
+.kpi {
+  border: 1px solid var(--bd);
+  border-radius: 14px;
+  padding: 14px;
+  margin-bottom: 10px;
+}
+
+.kpi h3 {
+  margin: 0 0 6px 0;
+  font-size: 0.95rem;
+  opacity: 0.8;
+}
+
+.kpi .v {
+  font-size: 1.6rem;
+  font-weight: 800;
+  letter-spacing: 0.2px;
+}
+
+.kpi .hint {
+  font-size: 0.85rem;
+  opacity: 0.75;
+}
+
+.pill {
+  display: inline-block;
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-weight: 700;
+  font-size: 0.78rem;
+  border: 1px solid var(--bd);
+  margin-right: 6px;
+}
+
+.pill.ok {
+  background: #e8f7ee;
+  color: #136c3a;
+  border-color: #b3e2c4;
+}
+
+.pill.info {
+  background: #e7f1ff;
+  color: #174ea6;
+  border-color: #c6dcff;
+}
+
+.pill.warn,
+.pill.med {
+  background: #fff3cd;
+  color: #8a6d1d;
+  border-color: #ffe69b;
+}
+
+.pill.bad {
+  background: #fdeceb;
+  color: #8b1b13;
+  border-color: #f5c2c0;
+}
+
+.small {
+  font-size: 0.92rem;
+  opacity: 0.9;
+}
+
+.legend {
+  font-size: 0.9rem;
+  opacity: 0.8;
+}
+
+hr {
+  border: none;
+  height: 1px;
+  background: var(--bd);
+  margin: 8px 0 16px 0;
+}
+
+table {
+  font-size: 0.95rem;
+}
+
+.badge-ok {
+  color: #0fd68b;
+}
+
+.badge-warn {
+  color: #f39c12;
+}
+
+.badge-risk {
+  color: #e74c3c;
+}


### PR DESCRIPTION
## Summary
- add a shared `app/static/theme.css` file and `load_theme()` helper to inject the theme CSS once per Streamlit session
- refactor the home view and every page to call the helper instead of duplicating `<style>` blocks, leaving only page-specific overrides
- keep unique visual tweaks (hero gradients, callouts, etc.) in trimmed page-level CSS so layouts and components render as before

## Testing
- `pytest` *(fails: requires optional dependency `pq` for generator module)*

------
https://chatgpt.com/codex/tasks/task_e_68d6c6d4ac848331bf60716c34c990ca