### PR TITLE
Normalize CTB flag casing

### DIFF
--- a/app/modules/generator.py
+++ b/app/modules/generator.py
@@ -371,7 +371,8 @@ def _close_inference_log_writer() -> None:
     """Close the cached Parquet writer used for inference logs."""
 
     _INFERENCE_LOG_MANAGER.close()
-=======
+
+
 def _to_lazy_frame(
     frame: pd.DataFrame | pl.DataFrame | pl.LazyFrame,
 ) -> tuple[pl.LazyFrame, str]:
@@ -422,7 +423,7 @@ def _slugify(value: str) -> str:
 
     text = re.sub(r"[^0-9a-zA-Z]+", "_", str(value).strip().lower())
     text = re.sub(r"_+", "_", text).strip("_")
-    return text or "value
+    return text or "value"
 
 
 def _load_regolith_vector() -> Dict[str, float]:

--- a/app/modules/io.py
+++ b/app/modules/io.py
@@ -16,10 +16,10 @@ TARGETS_JSON= DATA_DIR / "targets_presets.json"
 PROBLEM_TAGS = {
     "multilayer": "Lámina multicapa (PE/PET/Al)",
     "thermal": "Pouches térmicos",
-    "CTB": "EVA / Cargo Transfer Bag",
+    "ctb": "EVA / Cargo Transfer Bag",
     "closed_cell": "Espuma técnica (ZOTEK F30)",
     "nitrile": "Guantes de nitrilo",
-    "struts": "Estructuras/estrús Al"
+    "struts": "Estructuras/estrús Al",
 }
 
 def _ensure_exists():
@@ -53,7 +53,9 @@ def load_waste_df() -> pd.DataFrame:
         category_lower.str.contains("glove"),
         category_lower.str.contains("aluminum"),
     ]
-    problem_exprs.extend(flags_lower.str.contains(tag) for tag in PROBLEM_TAGS)
+    problem_exprs.extend(
+        flags_lower.str.contains(tag) for tag in PROBLEM_TAGS.keys()
+    )
 
     problematic_expr = pl.any_horizontal(*problem_exprs)
 

--- a/app/modules/process_planner.py
+++ b/app/modules/process_planner.py
@@ -15,10 +15,10 @@ SUITABILITY = {
 FLAG_BOOST = {
     "multilayer": ["P02"],
     "thermal": ["P02"],
-    "CTB": ["P04"],
+    "ctb": ["P04"],
     "closed_cell": ["P03", "P02"],
-    "nitrile": ["P01","P02"],
-    "struts": ["P04"]
+    "nitrile": ["P01", "P02"],
+    "struts": ["P04"],
 }
 
 def choose_process(target_name: str, proc_df: pd.DataFrame,

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -1905,6 +1905,7 @@ def test_prepare_waste_frame_density_missing_volume(monkeypatch):
         mission_reference_keys=(),
         mission_reference_index={},
         mission_reference_matrix=np.zeros((0, 0), dtype=np.float64),
+        mission_reference_dense=np.zeros((0, 0), dtype=np.float64),
         mission_names=(),
         mission_totals_vector=np.zeros(0, dtype=np.float64),
         processing_metrics={},


### PR DESCRIPTION
## Summary
- normalize problem flag keys to lowercase so PROBLEM_TAGS aligns with the flag-matching logic
- update downstream flag lookups and fixtures to expect the lowercase `ctb` tag
- clean up generator helpers to remove merge artifacts and restore the `_slugify` fallback

## Testing
- pytest tests/test_generator.py tests/test_data_pipeline.py

------
https://chatgpt.com/codex/tasks/task_e_68d6ff071c9c8331b6f2512893c536fd