### PR TITLE
Refine process selection heuristics

### DIFF
--- a/app/modules/generator.py
+++ b/app/modules/generator.py
@@ -371,7 +371,7 @@ def _close_inference_log_writer() -> None:
     """Close the cached Parquet writer used for inference logs."""
 
     _INFERENCE_LOG_MANAGER.close()
-=======
+
 def _to_lazy_frame(
     frame: pd.DataFrame | pl.DataFrame | pl.LazyFrame,
 ) -> tuple[pl.LazyFrame, str]:
@@ -422,7 +422,7 @@ def _slugify(value: str) -> str:
 
     text = re.sub(r"[^0-9a-zA-Z]+", "_", str(value).strip().lower())
     text = re.sub(r"_+", "_", text).strip("_")
-    return text or "value
+    return text or "value"
 
 
 def _load_regolith_vector() -> Dict[str, float]:

--- a/app/modules/process_planner.py
+++ b/app/modules/process_planner.py
@@ -1,5 +1,9 @@
 # app/modules/process_planner.py
 from __future__ import annotations
+
+import re
+from typing import Iterable
+
 import pandas as pd
 
 # Reglas simples de idoneidad por residuo (pueden expandirse)
@@ -17,22 +21,114 @@ FLAG_BOOST = {
     "thermal": ["P02"],
     "CTB": ["P04"],
     "closed_cell": ["P03", "P02"],
-    "nitrile": ["P01","P02"],
-    "struts": ["P04"]
+    "nitrile": ["P01", "P02"],
+    "struts": ["P04"],
 }
 
-def choose_process(target_name: str, proc_df: pd.DataFrame,
-                   scenario: str|None = None,
-                   crew_time_low: bool = False) -> pd.DataFrame:
-    df = proc_df.copy()
+SCENARIO_HINTS = {
+    "residence renovations": {"P04": 4.0, "P02": 1.5, "P03": 1.0},
+    "cosmic celebrations": {"P02": 3.5, "P04": 1.5, "P03": 0.8},
+    "daring discoveries": {"P03": 3.8, "P01": 1.8, "P02": 0.8},
+}
 
-    # Penalización/bonificación según tiempo de tripulación
+SUITABILITY_WEIGHT = 3.0
+SUITABILITY_DECAY = 0.6
+FLAG_WEIGHT = 2.0
+FLAG_DECAY = 0.5
+
+
+def _tokenize(text: str | None) -> set[str]:
+    if not text:
+        return set()
+    tokens = [t for t in re.split(r"[^0-9a-zA-Z]+", str(text).lower()) if t]
+    return set(tokens)
+
+
+def _iter_pref_weights(process_ids: Iterable[str], base: float, decay: float) -> Iterable[tuple[str, float]]:
+    for idx, proc_id in enumerate(process_ids):
+        yield str(proc_id), max(0.0, base - decay * idx)
+
+
+def choose_process(
+    target_name: str,
+    proc_df: pd.DataFrame,
+    scenario: str | None = None,
+    crew_time_low: bool = False,
+) -> pd.DataFrame:
+    if proc_df is None or proc_df.empty:
+        return proc_df.copy() if proc_df is not None else pd.DataFrame()
+
+    df = proc_df.copy()
+    df["process_id"] = df["process_id"].astype(str)
+    df = df.drop_duplicates("process_id").set_index("process_id", drop=False)
+    df.index.name = "_process_index"
+
+    # Preparar columnas auxiliares
+    crew_minutes = pd.to_numeric(df.get("crew_min_per_batch"), errors="coerce").fillna(0.0)
     if crew_time_low:
-        # preferir procesos con menor crew_min_per_batch
-        df["crew_bias"] = - df["crew_min_per_batch"]
+        max_minutes = float(max(crew_minutes.max(), 1.0))
+        df["crew_bias"] = 1.0 - crew_minutes / max_minutes
     else:
         df["crew_bias"] = 0.0
 
-    # En esta función solo devolvemos el catálogo; la adecuación por residuo
-    # sucede durante la generación, cuando conocemos las filas del inventario.
-    return df
+    df["match_score"] = 0.0
+    df["_reasons"] = [[] for _ in range(len(df))]
+
+    tokens = _tokenize(target_name)
+    tokens_text = " ".join(sorted(tokens))
+    matched_ids: set[str] = set()
+
+    def _add_score(process_id: str, value: float, reason: str) -> None:
+        if process_id not in df.index:
+            return
+        df.at[process_id, "match_score"] += float(value)
+        df.at[process_id, "_reasons"].append(reason)
+        matched_ids.add(process_id)
+
+    # Matches by suitability (prioridad según orden en tabla)
+    for key, proc_ids in SUITABILITY.items():
+        key_tokens = _tokenize(key)
+        if not key_tokens:
+            continue
+        if key.lower() in tokens_text or key_tokens.issubset(tokens) or (tokens & key_tokens):
+            for proc_id, weight in _iter_pref_weights(proc_ids, SUITABILITY_WEIGHT, SUITABILITY_DECAY):
+                if weight <= 0:
+                    continue
+                _add_score(proc_id, weight, f"Adecuado para {key}")
+
+    # Matches by flags (boosts menores)
+    for key, proc_ids in FLAG_BOOST.items():
+        key_tokens = _tokenize(key)
+        if not key_tokens:
+            continue
+        if key.lower() in tokens_text or key_tokens.issubset(tokens) or (tokens & key_tokens):
+            for proc_id, weight in _iter_pref_weights(proc_ids, FLAG_WEIGHT, FLAG_DECAY):
+                if weight <= 0:
+                    continue
+                _add_score(proc_id, weight, f"Flag prioritario: {key}")
+
+    # Scenario hints (opcional)
+    if scenario:
+        scenario_key = str(scenario).strip().lower()
+        for proc_id, bonus in SCENARIO_HINTS.get(scenario_key, {}).items():
+            if bonus <= 0:
+                continue
+            _add_score(proc_id, bonus, f"Escenario {scenario}")
+
+    if not matched_ids:
+        # Si no hubo matches, usar todos los procesos disponibles
+        matched_ids = set(df.index)
+
+    df = df[df["process_id"].isin(matched_ids)].copy()
+    df["match_score"] = df["match_score"] + df["crew_bias"]
+    df["match_reason"] = df["_reasons"].apply(
+        lambda reasons: " · ".join(dict.fromkeys(str(r) for r in reasons if r))
+    )
+    df = df.drop(columns=["_reasons"], errors="ignore")
+
+    df = df.sort_values(
+        by=["match_score", "crew_min_per_batch", "process_id"],
+        ascending=[False, True, True],
+    )
+
+    return df.reset_index(drop=True)

--- a/app/pages/3_Generator.py
+++ b/app/pages/3_Generator.py
@@ -144,6 +144,21 @@ with col_control:
     if not use_ml:
         st.info("Modo heurístico activo: las métricas se basan en reglas físicas y no en ML.")
 
+    if isinstance(proc_filtered, pd.DataFrame) and not proc_filtered.empty:
+        preview_map = [
+            ("process_id", "ID"),
+            ("name", "Proceso"),
+            ("match_score", "Score"),
+            ("crew_min_per_batch", "Crew (min)"),
+            ("match_reason", "Por qué")
+        ]
+        cols_present = [col for col, _ in preview_map if col in proc_filtered.columns]
+        if cols_present:
+            st.markdown("#### Procesos sugeridos")
+            st.caption("Filtrado según residuo/flags y escenario seleccionado.")
+            preview_df = proc_filtered[cols_present].head(5).rename(columns=dict(preview_map))
+            st.dataframe(preview_df, hide_index=True, use_container_width=True)
+
 with col_ai:
     st.markdown("### 🧠 Modelo Rex-AI")
     trained_at = MODEL_REGISTRY.metadata.get("trained_at", "—")


### PR DESCRIPTION
## Summary
- score and filter the process catalog with suitability tables, flag boosts, crew-time bias, and scenario hints
- surface the ranked subset in the generator UI and fix the process planner regression test
- repair the generator helper utilities to unblock pytest collection

## Testing
- pytest tests/test_generator.py

------
https://chatgpt.com/codex/tasks/task_e_68d6ff09fcb48331b8fe0b990dca2900