### PR TITLE
Refactor generator logging to use shared utilities

### DIFF
--- a/app/modules/generator.py
+++ b/app/modules/generator.py
@@ -14,15 +14,16 @@ candidate assembly.
 
 from __future__ import annotations
 
+import atexit
 import itertools
+import json
 import logging
 import math
 import os
 import random
 import re
-import threading
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
 from functools import lru_cache
 from typing import Any, Dict, Iterable, Mapping, NamedTuple, Sequence, Tuple
@@ -71,7 +72,7 @@ from app.modules.data_sources import (
     to_lazy_frame,
     token_set,
 )
-from app.modules.logging_utils import append_inference_log
+import app.modules.logging_utils as logging_utils
 
 # The demo previously collapsed multiple NASA inventory families (Packaging,
 # Other Packaging, Gloves, Foam Packaging, Food Packaging, Structural Elements
@@ -104,8 +105,10 @@ _CATEGORY_FAMILY_FALLBACKS: Dict[str, tuple[str, ...]] = {
 }
 try:  # Optional heavy dependencies; used for fast vectorization
     import pyarrow as pa
+    import pyarrow.parquet as pq
 except Exception:  # pragma: no cover - pyarrow is expected in production
     pa = None  # type: ignore[assignment]
+    pq = None  # type: ignore[assignment]
 
 from app.modules.execution import (
     DEFAULT_PARALLEL_THRESHOLD,
@@ -125,169 +128,7 @@ _REGOLITH_OXIDE_NAMES = tuple(f"oxide_{name}" for name, _ in _REGOLITH_OXIDE_ITE
 _REGOLITH_OXIDE_VALUES = np.asarray([float(value) for _, value in _REGOLITH_OXIDE_ITEMS], dtype=float)
 
 
-@dataclass(slots=True)
-class _InferenceWriterState:
-    """Book-keeping for an active Parquet writer."""
-
-    date_token: str
-    path: Path
-    schema: "pa.Schema"
-    writer: Any
-
-
-class _InferenceLogWriterManager:
-    """Manage a single append-only Parquet writer with daily rotation."""
-
-    def __init__(self) -> None:
-        self._lock = threading.Lock()
-        self._state: _InferenceWriterState | None = None
-
-    def close(self) -> None:
-        """Close the active writer, if any."""
-
-        if pq is None:
-            return
-        with self._lock:
-            self._close_locked()
-
-    def _close_locked(self) -> None:
-        state = self._state
-        if state is None:
-            return
-        try:
-            state.writer.close()
-        except Exception:  # pragma: no cover - best effort cleanup
-            pass
-        self._state = None
-
-    def _open_locked(
-        self, timestamp: datetime, field_names: Iterable[str]
-    ) -> _InferenceWriterState | None:
-        if pa is None or pq is None:
-            return None
-
-        desired_fields = sorted(set(str(name) for name in field_names))
-        if not desired_fields:
-            return None
-
-        log_dir = _resolve_inference_log_dir(timestamp)
-        try:
-            log_dir.mkdir(parents=True, exist_ok=True)
-        except Exception:
-            return None
-
-        date_token = timestamp.strftime("%Y%m%d")
-        path = self._resolve_log_path(log_dir, date_token)
-        schema = pa.schema(pa.field(name, pa.string()) for name in desired_fields)
-
-        try:
-            writer = pq.ParquetWriter(str(path), schema=schema)
-        except Exception:
-            return None
-
-        state = _InferenceWriterState(
-            date_token=date_token,
-            path=path,
-            schema=schema,
-            writer=writer,
-        )
-        self._state = state
-        return state
-
-    def _resolve_log_path(self, log_dir: Path, date_token: str) -> Path:
-        """Return a Parquet path for *date_token* avoiding overwriting shards."""
-
-        base = log_dir / f"inference_{date_token}.parquet"
-        if not base.exists():
-            return base
-
-        counter = 1
-        while True:
-            candidate = log_dir / f"inference_{date_token}_{counter:04d}.parquet"
-            if not candidate.exists():
-                return candidate
-            counter += 1
-
-    def _ensure_state_locked(
-        self, timestamp: datetime, field_names: Iterable[str]
-    ) -> _InferenceWriterState | None:
-        state = self._state
-        desired_fields = sorted(set(str(name) for name in field_names))
-        if not desired_fields:
-            return None
-
-        date_token = timestamp.strftime("%Y%m%d")
-        if state is not None:
-            if state.date_token != date_token or set(state.schema.names) != set(
-                desired_fields
-            ):
-                self._close_locked()
-                state = None
-
-        if state is None:
-            state = self._open_locked(timestamp, desired_fields)
-
-        return state
-
-    def write_event(
-        self, timestamp: datetime, payload: Mapping[str, str | None]
-    ) -> None:
-        if pa is None or pq is None:
-            return
-
-        with self._lock:
-            state = self._ensure_state_locked(timestamp, payload.keys())
-            if state is None:
-                return
-
-            arrays = []
-            for field in state.schema:
-                arrays.append(pa.array([payload.get(field.name)], type=field.type))
-
-            table = pa.Table.from_arrays(arrays, schema=state.schema)
-
-            try:
-                state.writer.write_table(table)
-            except Exception:
-                self._close_locked()
-
-
-_INFERENCE_LOG_MANAGER = _InferenceLogWriterManager()
-
-LOGS_ROOT: Path | None = None
-
-_ORIGINAL_INFERENCE_LOG_MANAGER = _INFERENCE_LOG_MANAGER
-
-
-def _close_inference_log_writer() -> None:
-    """Expose a test hook to close the shared inference writer."""
-
-    _INFERENCE_LOG_MANAGER.close()
-def _to_serializable(value: Any) -> Any:
-    """Convert *value* into a JSON-serializable structure."""
-
-    if value is None or isinstance(value, (str, int, float, bool)):
-        return value
-    if isinstance(value, np.generic):
-        return value.item()
-    if isinstance(value, (list, tuple, set)):
-        return [_to_serializable(v) for v in value]
-    if isinstance(value, dict):
-        return {str(k): _to_serializable(v) for k, v in value.items()}
-    if isinstance(value, np.ndarray):
-        return [_to_serializable(v) for v in value.tolist()]
-    return str(value)
-
-
-def _resolve_inference_log_dir(timestamp: datetime) -> Path:
-    """Return the directory backing inference logs for *timestamp*."""
-
-    root = LOGS_ROOT if LOGS_ROOT is not None else logging_utils.LOGS_ROOT
-    return root / "inference" / timestamp.strftime("%Y%m%d")
-
-
-if pq is not None:  # pragma: no branch - guard for optional dependency
-    atexit.register(_INFERENCE_LOG_MANAGER.close)
+_INFERENCE_LOG_MANAGER = logging_utils._INFERENCE_LOG_MANAGER
 
 
 def _prepare_inference_event(
@@ -297,34 +138,15 @@ def _prepare_inference_event(
     model_registry: Any | None,
     timestamp: datetime | None = None,
 ) -> tuple[datetime, Dict[str, str | None]]:
-    """Build the serializable payload for an inference log event."""
+    """Thin wrapper around :func:`logging_utils.prepare_inference_event`."""
 
-    now = timestamp or datetime.now(UTC)
-
-    model_hash = ""
-    if model_registry is not None:
-        metadata = getattr(model_registry, "metadata", {}) or {}
-        if isinstance(metadata, dict):
-            model_hash = str(metadata.get("model_hash") or metadata.get("checksum") or "")
-        if not model_hash:
-            for attr in ("model_hash", "checksum", "pipeline_checksum", "pipeline_hash"):
-                value = getattr(model_registry, attr, None)
-                if value:
-                    model_hash = str(value)
-                    break
-
-    payload: Dict[str, str | None] = {
-        "timestamp": now.isoformat(timespec="microseconds"),
-        "input_features": json.dumps(_to_serializable(input_features or {}), sort_keys=True),
-        "prediction": json.dumps(_to_serializable(prediction or {}), sort_keys=True),
-        "uncertainty": json.dumps(_to_serializable(uncertainty or {}), sort_keys=True),
-        "model_hash": model_hash or None,
-    }
-
-    return now, payload
-
-
-_ORIGINAL_PREPARE_INFERENCE_EVENT = _prepare_inference_event
+    return logging_utils.prepare_inference_event(
+        input_features=input_features,
+        prediction=prediction,
+        uncertainty=uncertainty,
+        model_registry=model_registry,
+        timestamp=timestamp,
+    )
 
 
 def append_inference_log(
@@ -333,39 +155,24 @@ def append_inference_log(
     uncertainty: Dict[str, Any] | None,
     model_registry: Any | None,
 ) -> None:
-    """Persist an inference event using a streaming Parquet writer."""
+    """Proxy :func:`logging_utils.append_inference_log` for backward compatibility."""
 
-    if pa is None or pq is None:  # pragma: no cover - dependencies should exist
-        return
-
-    prepare_fn = globals().get("_prepare_inference_event", _prepare_inference_event)
-    if (
-        prepare_fn is _ORIGINAL_PREPARE_INFERENCE_EVENT
-        and hasattr(logging_utils, "prepare_inference_event")
-    ):
-        prepare_fn = logging_utils.prepare_inference_event
-
-    event_time, event_payload = prepare_fn(
+    logging_utils.append_inference_log(
         input_features=input_features,
         prediction=prediction,
         uncertainty=uncertainty,
         model_registry=model_registry,
     )
 
-    manager = globals().get("_INFERENCE_LOG_MANAGER", _INFERENCE_LOG_MANAGER)
-    if (
-        manager is _ORIGINAL_INFERENCE_LOG_MANAGER
-        and hasattr(logging_utils, "_INFERENCE_LOG_MANAGER")
-    ):
-        manager = logging_utils._INFERENCE_LOG_MANAGER
-
-    manager.write_event(event_time, event_payload)
-
 
 def _close_inference_log_writer() -> None:
     """Close the cached Parquet writer used for inference logs."""
 
-    _INFERENCE_LOG_MANAGER.close()
+    logging_utils._INFERENCE_LOG_MANAGER.close()
+
+
+if logging_utils.pq is not None:  # pragma: no branch - guard for optional dependency
+    atexit.register(logging_utils._INFERENCE_LOG_MANAGER.close)
 
 def _to_lazy_frame(
     frame: pd.DataFrame | pl.DataFrame | pl.LazyFrame,


### PR DESCRIPTION
## Summary
- replace the generator module's local inference logging helpers with thin wrappers around app.modules.logging_utils
- update imports so generator relies on the shared logging utilities for Parquet support and teardown hooks

## Testing
- pytest tests/test_generator.py::test_append_inference_log_reuses_daily_writer tests/test_generator.py::test_append_inference_log_skips_parquet_reads tests/test_generator.py::test_append_inference_log_rotates_daily

------
https://chatgpt.com/codex/tasks/task_e_68d706466c9083318deff721b91cc050