### PR TITLE
Handle AsyncioBackend map when loop is already running

### DIFF
--- a/tests/test_execution_backend.py
+++ b/tests/test_execution_backend.py
@@ -1,4 +1,6 @@
+import asyncio
 import time
+
 
 from app.modules import execution
 
@@ -26,3 +28,19 @@ def test_thread_backend_outpaces_synchronous_execution():
 
     assert elapsed_parallel < elapsed_sync * 0.75
     assert elapsed_parallel < sleep_time * tasks
+
+
+def test_asyncio_backend_map_from_running_loop():
+    backend = execution.AsyncioBackend()
+
+    async def _invoke_map() -> list[int]:
+        result = backend.map(lambda x: x + 1, range(5))
+        assert isinstance(result, asyncio.Task)
+        return await result
+
+    try:
+        result = asyncio.run(_invoke_map())
+    finally:
+        backend.shutdown()
+
+    assert result == [1, 2, 3, 4, 5]


### PR DESCRIPTION
## Summary
- update `AsyncioBackend.map` to detect an active asyncio loop and return a scheduled task when one exists
- add regression coverage that invokes the backend from inside an already running loop

## Testing
- pytest tests/test_execution_backend.py

------
https://chatgpt.com/codex/tasks/task_e_68d70648f74c8331906eeb44bdb6f02b