### PR TITLE
Stream PyArrow impact log appends

### DIFF
--- a/app/modules/impact.py
+++ b/app/modules/impact.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
+import json
+import os
+import uuid
 from dataclasses import dataclass, asdict, field
 from datetime import datetime
 from pathlib import Path
 from typing import Any
-import json
-import uuid
 
 import pandas as pd
 
@@ -79,6 +80,46 @@ def _entry_date(ts_iso: str) -> str:
     return dt.strftime("%Y-%m-%d")
 
 
+def _align_table_to_schema(table: "pa.Table" | "pa.RecordBatch", schema: "pa.Schema") -> "pa.Table":
+    """Return *table* aligned to *schema*, filling missing columns with nulls."""
+
+    if isinstance(table, pa.RecordBatch):
+        base_table = pa.Table.from_batches([table])
+    else:
+        base_table = table
+
+    columns = []
+    for field in schema:
+        if field.name in base_table.column_names:
+            column = base_table[field.name]
+            if column.type != field.type:
+                column = column.cast(field.type)
+        else:
+            column = pa.nulls(base_table.num_rows, type=field.type)
+        columns.append(column)
+
+    return pa.Table.from_arrays(columns, schema=schema)
+
+
+def _updated_schema(
+    existing_schema: "pa.Schema | None", row_schema: "pa.Schema"
+) -> tuple["pa.Schema", bool]:
+    """Return schema extended with any new fields from *row_schema*."""
+
+    if existing_schema is None:
+        return row_schema, False
+
+    schema = existing_schema
+    changed = False
+    existing_names = set(existing_schema.names)
+    for field in row_schema:
+        if field.name not in existing_names:
+            inferred = pa.field(field.name, field.type, nullable=True)
+            schema = schema.append(inferred)
+            changed = True
+    return schema, changed
+
+
 def _append_record(filename: str, payload: dict[str, Any]) -> None:
     _ensure_dirs()
     path = LOGS_DIR / filename
@@ -93,42 +134,37 @@ def _append_record(filename: str, payload: dict[str, Any]) -> None:
         df.to_parquet(path, index=False)
         return
 
-    row_dict = {key: [value] for key, value in payload.items()}
+    row_table = pa.Table.from_pydict({key: [value] for key, value in payload.items()})
 
     if not path.exists():
-        table = pa.Table.from_pydict(row_dict)
-        pq.write_table(table, path)
+        pq.write_table(row_table, path)
         return
 
     try:
         parquet_file = pq.ParquetFile(path)
         existing_schema = parquet_file.schema_arrow
-        existing_fields = list(existing_schema.names)
     except Exception:
+        parquet_file = None
         existing_schema = None
-        existing_fields = []
 
-    if existing_fields:
-        new_columns = [col for col in row_dict if col not in existing_fields]
-        if new_columns:
-            row_df = pd.DataFrame([payload])
-            existing = pd.read_parquet(path)
-            df = pd.concat([existing, row_df], ignore_index=True, sort=False)
-            df.to_parquet(path, index=False)
-            return
+    target_schema, schema_changed = _updated_schema(existing_schema, row_table.schema)
+    aligned_row = _align_table_to_schema(row_table, target_schema)
 
-        data = {}
-        for name in existing_fields:
-            data[name] = [payload.get(name)]
-        table = (
-            pa.Table.from_pydict(data, schema=existing_schema)
-            if existing_schema is not None
-            else pa.Table.from_pydict(data)
-        )
-    else:
-        table = pa.Table.from_pydict(row_dict)
+    temp_path = path.with_suffix(path.suffix + ".tmp")
+    with pq.ParquetWriter(temp_path, target_schema) as writer:
+        if parquet_file is not None:
+            for batch in parquet_file.iter_batches():
+                if schema_changed:
+                    aligned_batch = _align_table_to_schema(batch, target_schema)
+                else:
+                    aligned_batch = pa.Table.from_batches([batch])
+                writer.write_table(aligned_batch)
+        writer.write_table(aligned_row)
 
-    pq.write_table(table, path, append=True)
+    if parquet_file is not None:
+        del parquet_file
+
+    os.replace(temp_path, path)
 
 
 def append_impact(entry: ImpactEntry) -> str:


### PR DESCRIPTION
## Summary
- add helpers that align PyArrow tables to the stored schema so new fields are filled with nulls when absent
- rewrite `_append_record` to stream existing row groups into a temporary Parquet file with PyArrow and atomically swap it back in place
- continue to fall back to pandas only when PyArrow is unavailable

## Testing
- pytest tests/test_impact_logging.py
- python - <<'PY'
import shutil
from datetime import datetime, timedelta
from time import perf_counter

import pandas as pd

from app.modules.impact import FeedbackEntry, LOGS_DIR, append_feedback

if LOGS_DIR.exists():
    shutil.rmtree(LOGS_DIR)

def _blocked_read(*args, **kwargs):
    raise RuntimeError("pd.read_parquet should not be invoked when pyarrow is available")

pd.read_parquet = _blocked_read

base_time = datetime.utcnow()
start = perf_counter()
for idx in range(200):
    ts = (base_time + timedelta(seconds=idx)).isoformat()
    entry = FeedbackEntry(
        ts_iso=ts,
        astronaut=f"ASTRO_{idx%3}",
        scenario="benchmark",
        target_name="target",
        option_idx=idx % 5,
        rigidity_ok=bool(idx % 2),
        ease_ok=bool((idx + 1) % 2),
        issues="",
        notes="baseline",
        extra={"seed": idx},
    )
    append_feedback(entry)
initial_duration = perf_counter() - start

new_ts = (base_time + timedelta(seconds=500)).isoformat()
extra_entry = FeedbackEntry(
    ts_iso=new_ts,
    astronaut="ASTRO_X",
    scenario="benchmark",
    target_name="target",
    option_idx=1,
    rigidity_ok=True,
    ease_ok=True,
    issues="",
    notes="schema update",
    extra={"seed": 999, "new_metric": 42.0},
)
start = perf_counter()
append_feedback(extra_entry)
extend_duration = perf_counter() - start

print({
    "initial_append_s": round(initial_duration, 4),
    "schema_extend_s": round(extend_duration, 4),
    "log_files": sorted(p.name for p in LOGS_DIR.glob('feedback_*.parquet')),
})
PY

------
https://chatgpt.com/codex/tasks/task_e_68d7064c31f08331869f33d0eebafd28