### PR TITLE
Centralize shared data path constants

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,8 @@ __pycache__/
 # Processed datasets
 /data/processed/
 !/data/processed/
-/data/logs/
+/data/logs/*
+!/data/logs/.gitkeep
 /datasets/processed/
 !/datasets/processed/
 /datasets/derived/

--- a/app/modules/data_build.py
+++ b/app/modules/data_build.py
@@ -25,8 +25,9 @@ from app.modules import generator
 from app.modules.data_pipeline import GoldFeatureRow, GoldLabelRow
 from app.modules.model_training import FEATURE_COLUMNS
 from app.modules.label_mapper import derive_recipe_id
+from .paths import DATA_ROOT
 
-DATASETS_ROOT = Path(__file__).resolve().parents[2] / "datasets"
+DATASETS_ROOT = DATA_ROOT.parent / "datasets"
 RAW_DIR = DATASETS_ROOT / "raw"
 GOLD_DIR = DATASETS_ROOT / "gold"
 
@@ -225,7 +226,7 @@ def _build_gold_records() -> Iterator[GoldRecord]:
     trash_to_gas = _load_trash_to_gas()
     logistics = _load_logistics().set_index("scenario")
     regolith = _load_regolith_properties()
-    process_catalog = pd.read_csv(Path(__file__).resolve().parents[2] / "data" / "process_catalog.csv")
+    process_catalog = pd.read_csv(DATA_ROOT / "process_catalog.csv")
 
     for _, row in trash_to_gas.iterrows():
         mission = str(row["mission"])

--- a/app/modules/data_pipeline.py
+++ b/app/modules/data_pipeline.py
@@ -25,9 +25,9 @@ from pydantic import AliasChoices, BaseModel, ConfigDict, Field, field_validator
 
 LOGGER = logging.getLogger(__name__)
 
-INGESTION_ERROR_LOG_PATH = (
-    Path(__file__).resolve().parents[2] / "data" / "logs" / "ingestion.errors.jsonl"
-)
+from .paths import LOGS_DIR
+
+INGESTION_ERROR_LOG_PATH = LOGS_DIR / "ingestion.errors.jsonl"
 
 
 class InventoryRecord(BaseModel):

--- a/app/modules/data_sources.py
+++ b/app/modules/data_sources.py
@@ -29,7 +29,9 @@ import numpy as np
 import pandas as pd
 import polars as pl
 
-DATASETS_ROOT = Path(__file__).resolve().parents[2] / "datasets"
+from .paths import DATA_ROOT
+
+DATASETS_ROOT = DATA_ROOT.parent / "datasets"
 
 __all__ = [
     "DATASETS_ROOT",

--- a/app/modules/impact.py
+++ b/app/modules/impact.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from dataclasses import dataclass, asdict, field
 from datetime import datetime
-from pathlib import Path
 from typing import Any
 import json
 import uuid
@@ -16,8 +15,7 @@ except Exception:  # pragma: no cover - pyarrow is optional at runtime
     pa = None  # type: ignore[assignment]
     pq = None  # type: ignore[assignment]
 
-DATA_DIR = Path(__file__).resolve().parents[2] / "data"
-LOGS_DIR = DATA_DIR / "logs"
+from .paths import LOGS_DIR
 
 
 @dataclass

--- a/app/modules/io.py
+++ b/app/modules/io.py
@@ -1,12 +1,12 @@
 # app/modules/io.py
 from __future__ import annotations
 import json
-from pathlib import Path
-
 import pandas as pd
 import polars as pl
 
-DATA_DIR = Path(__file__).resolve().parents[2] / "data"
+from .paths import DATA_ROOT
+
+DATA_DIR = DATA_ROOT
 
 # Archivos que proporcionó NASA (ustedes)
 WASTE_CSV   = DATA_DIR / "waste_inventory_sample.csv"

--- a/app/modules/label_mapper.py
+++ b/app/modules/label_mapper.py
@@ -11,7 +11,9 @@ import pandas as pd
 
 # Paths -----------------------------------------------------------------------
 
-ROOT = Path(__file__).resolve().parents[2]
+from .paths import DATA_ROOT
+
+ROOT = DATA_ROOT.parent
 DATASETS_ROOT = ROOT / "datasets"
 GOLD_DIR = DATASETS_ROOT / "gold"
 GOLD_LABELS_PATH = GOLD_DIR / "labels.parquet"

--- a/app/modules/logging_utils.py
+++ b/app/modules/logging_utils.py
@@ -23,7 +23,9 @@ except Exception:  # pragma: no cover - pyarrow is expected in production
     pa = None  # type: ignore[assignment]
     pq = None  # type: ignore[assignment]
 
-LOGS_ROOT = Path(__file__).resolve().parents[2] / "data" / "logs"
+from .paths import LOGS_DIR
+
+LOGS_ROOT = LOGS_DIR
 
 
 @dataclass

--- a/app/modules/ml_models.py
+++ b/app/modules/ml_models.py
@@ -26,6 +26,8 @@ import pandas as pd
 import requests
 import streamlit as st
 
+from .paths import DATA_ROOT, MODELS_DIR
+
 try:  # Optional runtime for accelerated inference
     import onnxruntime as ort
 
@@ -47,8 +49,7 @@ except Exception:  # pragma: no cover - optional dependency missing
 LOGGER = logging.getLogger(__name__)
 
 # Rutas estándar
-DATA_ROOT = Path(__file__).resolve().parents[2] / "data"
-MODEL_DIR = DATA_ROOT / "models"
+MODEL_DIR = MODELS_DIR  # Backwards compatibility alias
 PIPELINE_PATH = MODEL_DIR / "rexai_regressor.joblib"
 METADATA_PATH = MODEL_DIR / "metadata_gold.json"
 LEGACY_METADATA_PATH = MODEL_DIR / "metadata.json"

--- a/app/modules/model_training.py
+++ b/app/modules/model_training.py
@@ -94,6 +94,7 @@ except Exception:  # pragma: no cover - environments without torch
     HAS_TORCH = False
 
 from app.modules.label_mapper import derive_recipe_id, load_curated_labels, lookup_labels
+from .paths import DATA_ROOT, MODELS_DIR
 
 LOGGER = logging.getLogger(__name__)
 
@@ -101,13 +102,12 @@ LOGGER = logging.getLogger(__name__)
 # Paths & constants
 # ---------------------------------------------------------------------------
 
-ROOT = Path(__file__).resolve().parents[2]
-DATA_ROOT = ROOT / "data"
+ROOT = DATA_ROOT.parent
 DATASETS_ROOT = ROOT / "datasets"
 RAW_DIR = DATASETS_ROOT / "raw"
 PROCESSED_DIR = DATASETS_ROOT / "processed"
 PROCESSED_ML = DATA_ROOT / "processed" / "ml"
-MODEL_DIR = DATA_ROOT / "models"
+MODEL_DIR = MODELS_DIR  # Backwards compatibility alias
 GOLD_DIR = DATASETS_ROOT / "gold"
 GOLD_FEATURES_PATH = GOLD_DIR / "features.parquet"
 GOLD_LABELS_PATH = GOLD_DIR / "labels.parquet"

--- a/app/modules/paths.py
+++ b/app/modules/paths.py
@@ -1,0 +1,22 @@
+"""Centralized filesystem locations for application artifacts."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# Shared data locations -----------------------------------------------------
+
+DATA_ROOT = _REPO_ROOT / "data"
+"""Directory containing curated datasets and generated artifacts."""
+
+MODELS_DIR = DATA_ROOT / "models"
+"""Directory storing trained model bundles shipped with the app."""
+
+LOGS_DIR = DATA_ROOT / "logs"
+"""Directory where runtime telemetry such as inference logs is persisted."""
+
+
+__all__ = ["DATA_ROOT", "MODELS_DIR", "LOGS_DIR"]

--- a/app/modules/retrain_from_feedback.py
+++ b/app/modules/retrain_from_feedback.py
@@ -21,9 +21,8 @@ from typing import Iterable, Sequence
 
 from app.modules import model_training
 
-ROOT = Path(__file__).resolve().parents[2]
-DATA_DIR = ROOT / "data"
-LOGS_DIR = DATA_DIR / "logs"
+from .paths import LOGS_DIR
+
 DEFAULT_PATTERN = LOGS_DIR / "feedback_*.parquet"
 
 

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -1,0 +1,10 @@
+from app.modules import paths
+
+
+def test_path_constants_align_with_repository_structure() -> None:
+    """Smoke test ensuring filesystem constants remain in sync."""
+
+    assert paths.DATA_ROOT.is_dir()
+    assert paths.MODELS_DIR.is_dir()
+    assert paths.LOGS_DIR.is_dir()
+    assert paths.LOGS_DIR.parent == paths.DATA_ROOT


### PR DESCRIPTION
## Summary
- add a shared app.modules.paths module exposing DATA_ROOT, MODELS_DIR, and LOGS_DIR
- refactor modules to import the centralized constants and track an empty data/logs directory
- add a smoke test verifying the paths resolve to existing directories

## Testing
- pytest tests/test_paths.py

------
https://chatgpt.com/codex/tasks/task_e_68d7064b69e0833197d5ef5acff82b7d