### PR TITLE
Fix playbook formatting in scenarios module

### DIFF
--- a/app/modules/scenarios.py
+++ b/app/modules/scenarios.py
@@ -1,10 +1,12 @@
 from dataclasses import dataclass
 from typing import List
 
+
 @dataclass
 class Step:
     title: str
     detail: str
+
 
 @dataclass
 class Playbook:
@@ -12,44 +14,86 @@ class Playbook:
     summary: str
     steps: List[Step]
 
+
 PLAYBOOKS = {
-"Residence Renovations": Playbook(
-    name="Residence Renovations",
-    summary="Reuso de CTB/estructuras + laminación de espumas y films para outfitting robusto con mínimo tiempo de tripulación.",
-    steps=[
-        Step("Auditar marcos y puntales de aluminio",
-             "Reconfigurar longitudes y unir con herrajes CTB para formar estantes/particiones."),
-        Step("Aprovechar espumas (ZOTEK/bubble wrap)",
-             "Laminarlas por presión/calor para crear paneles livianos y skins protectoras."),
-        Step("Refuerzo con regolito (opcional)",
-             "Sinterizar mezcla polímero+MGS-1 para bases o bordes con mayor resistencia a impacto."),
-        Step("Checklist de seguridad",
-             "Evitar incineración; preferir encapsulado para minimizar microplásticos.")
-]) ,
-"Cosmic Celebrations": Playbook(
-    name="Cosmic Celebrations",
-    summary="Laminados textiles + films multicapa para utilería y decoración segura sin agua.",
-    steps=[
-        Step("Seleccionar textiles y wipes limpios",
-             "Priorizar poliéster/nylon para mayor estabilidad dimensional."),
-        Step("Encapsular films/plásticos delgados",
-             "Prensado térmico para evitar desprendimientos de microplásticos."),
-        Step("Cortes modulares",
-             "Plantillas con esquinas redondeadas; fijación con herrajes CTB o clips."),
-        Step("Checklist de seguridad",
-             "Nada de llamas abiertas; verificar olores volátiles tras enfriado.")
-]),
-"Daring Discoveries": Playbook(
-    name="Daring Discoveries",
-    summary="Uso del carbono sobrante como carga/refuerzo y redes/filtros como mallas.",
-    steps=[
-        Step("Clasificar carbono y meshes",
-             "Separar granulometrías; reservar mallas metálicas/poliméricas para refuerzo superficial."),
-        Step("Mezcla con polímeros disponibles",
-             "Añadir 5–20% carbono en laminado/compactación; o sinter con MGS-1 para piezas rígidas."),
-        Step("Protección frente a polvo",
-             "Preferir procesos indoor; sellos perimetrales posproceso."),
-        Step("Checklist de seguridad",
-             "Evitar generadores de humo; registrar cualquier residuo fino en filtros HEPA.")
-])
+    "Residence Renovations": Playbook(
+        name="Residence Renovations",
+        summary=(
+            "Reuso de CTB/estructuras + laminación de espumas y films para outfitting "
+            "robusto con mínimo tiempo de tripulación."
+        ),
+        steps=[
+            Step(
+                "Auditar marcos y puntales de aluminio",
+                "Reconfigurar longitudes y unir con herrajes CTB para formar estantes/"
+                "particiones.",
+            ),
+            Step(
+                "Aprovechar espumas (ZOTEK/bubble wrap)",
+                "Laminarlas por presión/calor para crear paneles livianos y skins "
+                "protectoras.",
+            ),
+            Step(
+                "Refuerzo con regolito (opcional)",
+                "Sinterizar mezcla polímero+MGS-1 para bases o bordes con mayor "
+                "resistencia a impacto.",
+            ),
+            Step(
+                "Checklist de seguridad",
+                "Evitar incineración; preferir encapsulado para minimizar microplásticos.",
+            ),
+        ],
+    ),
+    "Cosmic Celebrations": Playbook(
+        name="Cosmic Celebrations",
+        summary=(
+            "Laminados textiles + films multicapa para utilería y decoración segura sin "
+            "agua."
+        ),
+        steps=[
+            Step(
+                "Seleccionar textiles y wipes limpios",
+                "Priorizar poliéster/nylon para mayor estabilidad dimensional.",
+            ),
+            Step(
+                "Encapsular films/plásticos delgados",
+                "Prensado térmico para evitar desprendimientos de microplásticos.",
+            ),
+            Step(
+                "Cortes modulares",
+                "Plantillas con esquinas redondeadas; fijación con herrajes CTB o clips.",
+            ),
+            Step(
+                "Checklist de seguridad",
+                "Nada de llamas abiertas; verificar olores volátiles tras enfriado.",
+            ),
+        ],
+    ),
+    "Daring Discoveries": Playbook(
+        name="Daring Discoveries",
+        summary=(
+            "Uso del carbono sobrante como carga/refuerzo y redes/filtros como mallas."
+        ),
+        steps=[
+            Step(
+                "Clasificar carbono y meshes",
+                "Separar granulometrías; reservar mallas metálicas/poliméricas para "
+                "refuerzo superficial.",
+            ),
+            Step(
+                "Mezcla con polímeros disponibles",
+                "Añadir 5–20% carbono en laminado/compactación; o sinter con MGS-1 para "
+                "piezas rígidas.",
+            ),
+            Step(
+                "Protección frente a polvo",
+                "Preferir procesos indoor; sellos perimetrales posproceso.",
+            ),
+            Step(
+                "Checklist de seguridad",
+                "Evitar generadores de humo; registrar cualquier residuo fino en filtros "
+                "HEPA.",
+            ),
+        ],
+    ),
 }


### PR DESCRIPTION
## Summary
- normalize the formatting of the scenario playbook definitions and ensure commas separate each entry
- wrap long summary strings for readability while keeping the underlying data unchanged

## Testing
- python -m compileall app/modules/scenarios.py
- python - <<'PY'
import importlib
import app.modules.scenarios
print('Imported playbooks:', len(app.modules.scenarios.PLAYBOOKS))
PY

------
https://chatgpt.com/codex/tasks/task_e_68dac9cf3fa88331a8e51bed296609c7