### PR TITLE
Add bootstrap module for Streamlit entrypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,16 @@ Demo ligera que muestra la lógica del "cerebro de reciclaje" para Marte:
 3) Generación de recetas (combinaciones + proceso)
 4) Resultados y trade-offs (Pareto, Sankey, métricas)
 
+## Ejecución
+
+La entrada recomendada para lanzar la demo es:
+
+```bash
+streamlit run app/Home.py
+```
+
+No se requieren variables de entorno adicionales para el arranque interactivo.
+
 ## Módulos principales
 
 La refactorización de 2025 separó responsabilidades clave para mantener el

--- a/app/Home.py
+++ b/app/Home.py
@@ -1,5 +1,5 @@
 # app/Home.py
-import app  # noqa: F401
+import _bootstrap  # noqa: F401
 
 from datetime import datetime
 import streamlit as st

--- a/app/_bootstrap.py
+++ b/app/_bootstrap.py
@@ -1,0 +1,10 @@
+"""Ensure the project root is available on ``sys.path`` when running from ``app/``."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))

--- a/app/pages/0_Project_Brief.py
+++ b/app/pages/0_Project_Brief.py
@@ -1,11 +1,12 @@
 # app/pages/0_Project_Brief.py
-import app  # noqa: F401
+import _bootstrap  # noqa: F401
 
 import streamlit as st
 from pathlib import Path
 
 from app.modules.ui_blocks import load_theme
-repo_root = Path(app.ROOT)
+
+repo_root = Path(__file__).resolve().parents[2]
 
 # ⚠️ PRIMER comando Streamlit:
 st.set_page_config(page_title="REX-AI Mars — Brief", page_icon="🛰️", layout="wide")

--- a/app/pages/1_Inventory_Builder.py
+++ b/app/pages/1_Inventory_Builder.py
@@ -1,4 +1,4 @@
-import app  # noqa: F401
+import _bootstrap  # noqa: F401
 
 import streamlit as st
 import pandas as pd

--- a/app/pages/2_Target_Designer.py
+++ b/app/pages/2_Target_Designer.py
@@ -1,4 +1,4 @@
-import app  # noqa: F401
+import _bootstrap  # noqa: F401
 
 import streamlit as st
 

--- a/app/pages/3_Generator.py
+++ b/app/pages/3_Generator.py
@@ -1,4 +1,4 @@
-import app  # noqa: F401
+import _bootstrap  # noqa: F401
 
 from datetime import datetime
 

--- a/app/pages/4_Results_and_Tradeoffs.py
+++ b/app/pages/4_Results_and_Tradeoffs.py
@@ -1,4 +1,4 @@
-import app  # noqa: F401
+import _bootstrap  # noqa: F401
 
 import altair as alt
 import pandas as pd

--- a/app/pages/5_Compare_and_Explain.py
+++ b/app/pages/5_Compare_and_Explain.py
@@ -1,4 +1,4 @@
-import app  # noqa: F401
+import _bootstrap  # noqa: F401
 
 import streamlit as st
 import pandas as pd

--- a/app/pages/6_Pareto_and_Export.py
+++ b/app/pages/6_Pareto_and_Export.py
@@ -1,5 +1,5 @@
 # app/pages/6_Pareto_and_Export.py
-import app  # noqa: F401
+import _bootstrap  # noqa: F401
 
 import streamlit as st
 import numpy as np

--- a/app/pages/7_Scenario_Playbooks.py
+++ b/app/pages/7_Scenario_Playbooks.py
@@ -1,5 +1,5 @@
 # app/pages/7_Scenario_Playbooks.py
-import app  # noqa: F401
+import _bootstrap  # noqa: F401
 
 import streamlit as st
 import pandas as pd

--- a/app/pages/8_Feedback_and_Impact.py
+++ b/app/pages/8_Feedback_and_Impact.py
@@ -1,5 +1,5 @@
 # app/pages/8_Feedback_and_Impact.py
-import app  # noqa: F401
+import _bootstrap  # noqa: F401
 
 # ⚠️ Debe ser la PRIMERA llamada Streamlit:
 import streamlit as st

--- a/app/pages/9_Capacity_Simulator.py
+++ b/app/pages/9_Capacity_Simulator.py
@@ -1,5 +1,5 @@
 # app/pages/9_Capacity_Simulator.py
-import app  # noqa: F401
+import _bootstrap  # noqa: F401
 
 # ⚠️ Debe ser la PRIMERA llamada de Streamlit
 import streamlit as st

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -1,3 +1,9 @@
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+
 from app.modules import paths
 
 
@@ -8,3 +14,17 @@ def test_path_constants_align_with_repository_structure() -> None:
     assert paths.MODELS_DIR.is_dir()
     assert paths.LOGS_DIR.is_dir()
     assert paths.LOGS_DIR.parent == paths.DATA_ROOT
+
+
+def test_bootstrap_allows_app_import_from_app_directory(monkeypatch) -> None:
+    """Importing ``_bootstrap`` should make ``app`` available even when cwd is ``app/``."""
+
+    monkeypatch.chdir(Path("app"))
+    monkeypatch.setattr(sys, "path", [str(Path.cwd())])
+    sys.modules.pop("app", None)
+    sys.modules.pop("_bootstrap", None)
+
+    importlib.import_module("_bootstrap")
+    module = importlib.import_module("app")
+
+    assert Path(module.__file__).resolve().name == "__init__.py"


### PR DESCRIPTION
## Summary
- add an app/_bootstrap helper that injects the repository root into sys.path when the app is run from within the app package
- update Streamlit entrypoints to import the bootstrap helper and document the recommended `streamlit run app/Home.py` command in the README
- extend the path smoke test suite to verify that importing `_bootstrap` enables importing `app` while the working directory is `app/`

## Testing
- pytest tests/test_paths.py


------
https://chatgpt.com/codex/tasks/task_e_68dacdf77e288331b5f6c9cf5de0a240