### PR TITLE
Cache model registry access and update tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,18 @@ con la nueva fecha (`trained_at`) y el label de procedencia (`trained_on`, por
 ejemplo `hil_v1` o `hybrid_v2`). La pantalla principal de la app refleja la
 última fecha de reentrenamiento y la mezcla utilizada.
 
+Como la instancia de `ModelRegistry` queda cacheada vía `st.cache_resource`,
+tras copiar artefactos nuevos sin reiniciar la app recordá invalidar esa caché.
+Podés exponer un botón admin en Streamlit que llame a
+`app.modules.ml_models.get_model_registry().clear()` o ejecutar manualmente:
+
+```bash
+python -c "from app.modules.ml_models import get_model_registry; get_model_registry.clear()"
+```
+
+Luego de limpiar la caché, refrescá la página para que la UI vuelva a cargar la
+metadata y los pipelines recién entrenados.
+
 > Nota: la optimización bayesiana con Ax/BoTorch es opcional. El entorno Streamlit
 > detecta automáticamente si `ax-platform` y `botorch` están instalados; en caso
 > contrario utiliza el optimizador heurístico integrado. Para habilitarla basta con

--- a/app/Home.py
+++ b/app/Home.py
@@ -3,7 +3,7 @@ import _bootstrap  # noqa: F401
 
 from datetime import datetime
 import streamlit as st
-from app.modules.ml_models import MODEL_REGISTRY
+from app.modules.ml_models import get_model_registry
 from app.modules.ui_blocks import load_theme
 
 st.set_page_config(
@@ -13,6 +13,8 @@ st.set_page_config(
 )
 
 load_theme()
+
+model_registry = get_model_registry()
 
 # ──────────── Estilos (oscuro, cards y métricas) ────────────
 st.markdown(
@@ -68,10 +70,10 @@ st.markdown(
 )
 
 # ──────────── Lectura segura de metadata del modelo ────────────
-trained_at_raw = MODEL_REGISTRY.metadata.get("trained_at")
+trained_at_raw = model_registry.metadata.get("trained_at")
 trained_label_value = (
-    MODEL_REGISTRY.metadata.get("trained_label")
-    or MODEL_REGISTRY.metadata.get("trained_on")
+    model_registry.metadata.get("trained_label")
+    or model_registry.metadata.get("trained_on")
 )
 
 try:
@@ -83,7 +85,7 @@ trained_at_display = (
     trained_dt.strftime("%d %b %Y %H:%M UTC") if trained_dt else "sin metadata"
 )
 
-trained_combo = MODEL_REGISTRY.trained_label()
+trained_combo = model_registry.trained_label()
 if trained_at_display == "sin metadata" and trained_combo and trained_combo != "—":
     trained_at_display = trained_combo
 
@@ -92,9 +94,9 @@ if not trained_label_value and trained_combo and trained_combo != "—":
 
 trained_label_value = trained_label_value or "—"
 
-n_samples = MODEL_REGISTRY.metadata.get("n_samples")
-model_name = MODEL_REGISTRY.metadata.get("model_name", "rexai-rf-ensemble")
-feature_count = len(getattr(MODEL_REGISTRY, "feature_names", []) or [])
+n_samples = model_registry.metadata.get("n_samples")
+model_name = model_registry.metadata.get("model_name", "rexai-rf-ensemble")
+feature_count = len(getattr(model_registry, "feature_names", []) or [])
 
 # ──────────── Hero ────────────
 st.markdown(
@@ -133,7 +135,7 @@ st.markdown(
 
 # ──────────── Pila/estado del modelo ────────────
 st.markdown("### Estado del modelo Rex-AI")
-ready = "✅ Modelo listo" if MODEL_REGISTRY.ready else "⚠️ Entrená localmente"
+ready = "✅ Modelo listo" if model_registry.ready else "⚠️ Entrená localmente"
 
 st.markdown(
     f"""
@@ -141,7 +143,7 @@ st.markdown(
       <div class="metric"><h5>Estado</h5><strong>{ready}</strong><p>Nombre: {model_name}</p></div>
       <div class="metric"><h5>Entrenado</h5><strong>{trained_at_display}</strong><p>Procedencia: {trained_label_value}</p><p>Muestras: {n_samples or '—'}</p></div>
       <div class="metric"><h5>Feature space</h5><strong>{feature_count}</strong><p>Ingeniería fisicoquímica + proceso</p></div>
-      <div class="metric"><h5>Incertidumbre</h5><strong>{MODEL_REGISTRY.uncertainty_label()}</strong><p>CI 95% en UI</p></div>
+      <div class="metric"><h5>Incertidumbre</h5><strong>{model_registry.uncertainty_label()}</strong><p>CI 95% en UI</p></div>
     </div>
     """,
     unsafe_allow_html=True,

--- a/app/modules/__init__.py
+++ b/app/modules/__init__.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 from importlib import import_module
 from typing import Any
 
-from .ml_models import MODEL_REGISTRY, ModelRegistry, PredictionResult
+from .ml_models import MODEL_REGISTRY, ModelRegistry, PredictionResult, get_model_registry
 from .io import (
     load_waste_df,
     save_waste_df,
@@ -46,6 +46,7 @@ __all__ = [
     "Acquisition",
     # ML
     "MODEL_REGISTRY",
+    "get_model_registry",
     "ModelRegistry",
     "PredictionResult",
     # Entrenamiento (lazy)

--- a/app/modules/latent_optimizer.py
+++ b/app/modules/latent_optimizer.py
@@ -18,7 +18,7 @@ from typing import Any, Callable, Dict, Iterable, List, Mapping, Sequence
 import numpy as np
 import pandas as pd
 
-from app.modules.ml_models import MODEL_REGISTRY, TARGET_COLUMNS, ModelRegistry
+from app.modules.ml_models import TARGET_COLUMNS, ModelRegistry, get_model_registry
 
 
 ScoreFunction = Callable[[Mapping[str, float]], float]
@@ -47,7 +47,12 @@ class LatentSpaceExplorer:
     """High-level API to interact with the Rex-AI autoencoder."""
 
     def __init__(self, registry: ModelRegistry | None = None) -> None:
-        self.registry = registry or MODEL_REGISTRY
+        if registry is None:
+            try:
+                registry = get_model_registry()
+            except Exception:  # pragma: no cover - cache unavailable in minimal envs
+                registry = None
+        self.registry = registry
 
     # ------------------------------------------------------------------
     # Availability & preprocessing helpers

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,26 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
+import pytest
+
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
+
+
+@pytest.fixture(autouse=True)
+def _reset_model_registry_cache():
+    """Ensure the cached model registry does not leak state across tests."""
+
+    try:
+        from app.modules.ml_models import get_model_registry
+    except Exception:
+        yield
+        return
+
+    get_model_registry.clear()
+    try:
+        yield
+    finally:
+        get_model_registry.clear()

--- a/tests/test_latent_optimizer.py
+++ b/tests/test_latent_optimizer.py
@@ -42,7 +42,7 @@ class DummyRegistry:
 def test_available_without_autoencoder(monkeypatch: pytest.MonkeyPatch) -> None:
     explorer = latent_optimizer.LatentSpaceExplorer(registry=None)
     # Force the global registry to None to simulate missing artefact
-    monkeypatch.setattr(latent_optimizer, "MODEL_REGISTRY", None)
+    monkeypatch.setattr(latent_optimizer, "get_model_registry", lambda: None)
     explorer.registry = None
     assert explorer.available() is False
 


### PR DESCRIPTION
## Summary
- wrap the model registry construction in a cached `get_model_registry()` helper and keep a legacy proxy for existing imports
- update the Streamlit pages, generator, and latent optimizer to use the lazy accessor and document cache invalidation in the README
- refresh the test suite with a cache-reset fixture, new stubs, and compatibility updates for the generator helpers

## Testing
- pytest tests/test_ml_models.py tests/test_generator.py tests/test_latent_optimizer.py


------
https://chatgpt.com/codex/tasks/task_e_68dacfed5c548331990c2e4be2311ecd