### PR TITLE
Refactor UI pages to use luxe components

### DIFF
--- a/app/Home.py
+++ b/app/Home.py
@@ -2,7 +2,16 @@
 import _bootstrap  # noqa: F401
 
 from datetime import datetime
+
 import streamlit as st
+
+from app.modules.luxe_components import (
+    GlassCard,
+    GlassStack,
+    MetricGalaxy,
+    MetricItem,
+    TeslaHero,
+)
 from app.modules.ml_models import get_model_registry
 from app.modules.ui_blocks import load_theme
 
@@ -15,59 +24,6 @@ st.set_page_config(
 load_theme()
 
 model_registry = get_model_registry()
-
-# ──────────── Estilos (oscuro, cards y métricas) ────────────
-st.markdown(
-    """
-    <style>
-    .hero {
-      border-radius: 28px;
-      padding: 36px 42px;
-      background: linear-gradient(135deg, rgba(59,130,246,0.22), rgba(59,130,246,0.05)),
-                  linear-gradient(180deg, rgba(15,23,42,0.9), rgba(15,23,42,0.72));
-      border: 1px solid rgba(96,165,250,0.32);
-      color: var(--ink);
-      position: relative;
-      overflow: hidden;
-    }
-    .hero:after {
-      content:""; position:absolute; inset:-120px; background: radial-gradient(circle at top right, rgba(96,165,250,0.35), transparent 55%);
-      pointer-events:none;
-    }
-    .hero h1 {font-size: 2.25rem; margin-bottom: 12px; letter-spacing: 0.02em;}
-    .hero p {font-size: 1.04rem; max-width: 720px; color: var(--muted);}
-    .chip-row {display:flex; gap:8px; margin-top: 18px; flex-wrap:wrap;}
-    .chip {
-      padding:6px 14px; border-radius:999px; font-size:0.82rem; font-weight:600;
-      background: rgba(15,23,42,0.6); border: 1px solid rgba(96,165,250,0.35); color: var(--ink);
-    }
-    .ghost-card {
-      margin-top: 38px; display:grid; gap:18px; grid-template-columns: repeat(auto-fit,minmax(260px,1fr));
-    }
-    .ghost-card > div {
-      padding:20px 22px; border-radius:20px; border:1px solid var(--stroke);
-      background: var(--card); color: var(--ink);
-    }
-    .ghost-card h3 {margin-bottom:6px; font-size:1.05rem;}
-    .ghost-card p {color: var(--muted); font-size:0.94rem; margin:0;}
-    .stepper {display:grid; grid-template-columns: repeat(auto-fit,minmax(180px,1fr)); gap:14px; margin: 32px 0 18px;}
-    .step {border-radius:18px; border:1px solid var(--stroke); padding:16px 18px; background: rgba(13,17,23,0.6);}
-    .step span {display:inline-flex; width:32px; height:32px; border-radius:999px; align-items:center; justify-content:center; background: rgba(96,165,250,0.24); color: var(--ink); font-weight:700; margin-bottom:10px;}
-    .step h4 {margin:0 0 6px 0;}
-    .step p {color: var(--muted); font-size:0.9rem; margin:0;}
-    .metric-grid {display:grid; grid-template-columns: repeat(auto-fit,minmax(210px,1fr)); gap:16px; margin-top: 18px;}
-    .metric {border-radius:18px; padding:18px 20px; background:rgba(15,23,42,0.6); border:1px solid var(--stroke); color:var(--ink);}
-    .metric h5 {margin:0; font-size:0.92rem; color:var(--muted);}
-    .metric strong {font-size:1.4rem; display:block; margin-top:6px;}
-    .timeline {margin-top: 28px;}
-    .timeline h3 {margin-bottom: 12px;}
-    .timeline ul {list-style:none; padding:0; margin:0;}
-    .timeline li {margin-bottom: 14px; padding-left: 18px; position:relative; color:var(--muted);}
-    .timeline li::before {content:"•"; position:absolute; left:0; color: var(--accent); font-size:1.3rem;}
-    </style>
-    """,
-    unsafe_allow_html=True,
-)
 
 # ──────────── Lectura segura de metadata del modelo ────────────
 trained_at_raw = model_registry.metadata.get("trained_at")
@@ -99,69 +55,125 @@ model_name = model_registry.metadata.get("model_name", "rexai-rf-ensemble")
 feature_count = len(getattr(model_registry, "feature_names", []) or [])
 
 # ──────────── Hero ────────────
-st.markdown(
-    """
-    <div class="hero">
-      <h1>Rex-AI es tu copiloto de reciclaje en Marte</h1>
-      <p>
-        Convierte flujos de basura no-metabólica y regolito MGS-1 en hardware útil.
-        La plataforma guía a la tripulación paso a paso, combinando datos reales con
-        modelos que priorizan seguridad, trazabilidad y eficiencia.
-      </p>
-      <div class="chip-row">
-        <span class="chip">RandomForest multisalida</span>
-        <span class="chip">Comparadores: XGBoost / Tabular</span>
-        <span class="chip">Bandas de confianza 95%</span>
-        <span class="chip">Trazabilidad completa</span>
-      </div>
-    </div>
-    """,
-    unsafe_allow_html=True,
-)
+TeslaHero(
+    title="Rex-AI es tu copiloto de reciclaje en Marte",
+    subtitle=(
+        "Convierte flujos de basura no-metabólica y regolito MGS-1 en hardware útil. "
+        "La plataforma guía a la tripulación paso a paso, combinando datos reales "
+        "con modelos que priorizan seguridad, trazabilidad y eficiencia."
+    ),
+    chips=[
+        {"label": "RandomForest multisalida", "tone": "accent"},
+        {"label": "Comparadores: XGBoost / Tabular", "tone": "info"},
+        {"label": "Bandas de confianza 95%", "tone": "accent"},
+        {"label": "Trazabilidad completa", "tone": "info"},
+    ],
+    icon="🛰️",
+    gradient="linear-gradient(135deg, rgba(59,130,246,0.28), rgba(14,165,233,0.08))",
+    glow="rgba(96,165,250,0.45)",
+    density="roomy",
+    parallax_icons=[
+        {"icon": "🛰️", "top": "8%", "left": "74%", "size": "4.8rem", "speed": "22s"},
+        {"icon": "🪐", "top": "62%", "left": "80%", "size": "5.2rem", "speed": "28s"},
+        {"icon": "✨", "top": "20%", "left": "12%", "size": "3.2rem", "speed": "18s"},
+    ],
+).render()
 
 # ──────────── Ruta guiada ────────────
 st.markdown("### Ruta de misión (guided flow)")
-st.markdown(
-    """
-    <div class="stepper">
-      <div class="step"><span>1</span><h4>Inventario</h4><p>Normalizá residuos y marcá flags problemáticos (multilayer, EVA, nitrilo).</p></div>
-      <div class="step"><span>2</span><h4>Target</h4><p>Elegí producto final y límites de agua, energía y crew.</p></div>
-      <div class="step"><span>3</span><h4>Generador</h4><p>Rex-AI mezcla ítems, sugiere proceso y explica cada predicción.</p></div>
-      <div class="step"><span>4</span><h4>Resultados</h4><p>Trade-offs, confianza 95%, comparación heurística vs IA y export.</p></div>
-    </div>
-    """,
-    unsafe_allow_html=True,
-)
+GlassStack(
+    cards=[
+        GlassCard(
+            title="1 · Inventario",
+            body="Normalizá residuos y marcá flags problemáticos (multilayer, EVA, nitrilo).",
+            icon="🧱",
+            footer="Dataset NASA + crew flags",
+        ),
+        GlassCard(
+            title="2 · Target",
+            body="Elegí producto final y límites de agua, energía y crew para la misión.",
+            icon="🎯",
+            footer="Presets o límites manuales",
+        ),
+        GlassCard(
+            title="3 · Generador",
+            body="Rex-AI mezcla ítems, sugiere proceso y explica cada predicción en vivo.",
+            icon="🤖",
+            footer="ML + heurística cooperativa",
+        ),
+        GlassCard(
+            title="4 · Resultados",
+            body="Trade-offs, confianza 95%, comparación heurística vs IA y export final.",
+            icon="📊",
+            footer="Listo para experimentos",
+        ),
+    ],
+    columns_min="15rem",
+    density="compact",
+).render()
 
 # ──────────── Pila/estado del modelo ────────────
 st.markdown("### Estado del modelo Rex-AI")
 ready = "✅ Modelo listo" if model_registry.ready else "⚠️ Entrená localmente"
 
-st.markdown(
-    f"""
-    <div class="metric-grid">
-      <div class="metric"><h5>Estado</h5><strong>{ready}</strong><p>Nombre: {model_name}</p></div>
-      <div class="metric"><h5>Entrenado</h5><strong>{trained_at_display}</strong><p>Procedencia: {trained_label_value}</p><p>Muestras: {n_samples or '—'}</p></div>
-      <div class="metric"><h5>Feature space</h5><strong>{feature_count}</strong><p>Ingeniería fisicoquímica + proceso</p></div>
-      <div class="metric"><h5>Incertidumbre</h5><strong>{model_registry.uncertainty_label()}</strong><p>CI 95% en UI</p></div>
-    </div>
-    """,
-    unsafe_allow_html=True,
-)
+MetricGalaxy(
+    metrics=[
+        MetricItem(
+            label="Estado",
+            value=ready,
+            caption=f"Nombre: {model_name}",
+            icon="🛰️",
+        ),
+        MetricItem(
+            label="Entrenado",
+            value=trained_at_display,
+            caption=f"Procedencia: {trained_label_value} · Muestras: {n_samples or '—'}",
+            icon="🧪",
+        ),
+        MetricItem(
+            label="Feature space",
+            value=str(feature_count),
+            caption="Ingeniería fisicoquímica + proceso",
+            icon="🧬",
+        ),
+        MetricItem(
+            label="Incertidumbre",
+            value=model_registry.uncertainty_label(),
+            caption="CI 95% expuesta en UI",
+            icon="📈",
+        ),
+    ],
+    density="cozy",
+).render()
 
 # ──────────── Cómo navegar ────────────
 st.markdown("### Cómo navegar ahora")
-st.markdown(
-    """
-    <div class="ghost-card">
-      <div><h3>1. Inventario NASA</h3><p>Trabajá sobre <code>data/waste_inventory_sample.csv</code> o subí tu CSV normalizado.</p></div>
-      <div><h3>2. Objetivo</h3><p>Usá presets (container, utensil, tool, interior) o definí límites manuales.</p></div>
-      <div><h3>3. Generador con IA</h3><p>Revisá contribuciones de features y compara heurística vs modelo.</p></div>
-      <div><h3>4. Reportar</h3><p>Exportá recetas, Sankey y feedback/impact para seguir entrenando Rex-AI.</p></div>
-    </div>
-    """,
-    unsafe_allow_html=True,
-)
+GlassStack(
+    cards=[
+        GlassCard(
+            title="1. Inventario NASA",
+            body="Trabajá sobre <code>data/waste_inventory_sample.csv</code> o subí tu CSV normalizado.",
+            icon="📦",
+        ),
+        GlassCard(
+            title="2. Objetivo",
+            body="Usá presets (container, utensil, tool, interior) o definí límites manuales.",
+            icon="🎛️",
+        ),
+        GlassCard(
+            title="3. Generador con IA",
+            body="Revisá contribuciones de features y compará heurística vs modelo.",
+            icon="🤝",
+        ),
+        GlassCard(
+            title="4. Reportar",
+            body="Exportá recetas, Sankey y feedback/impact para seguir entrenando Rex-AI.",
+            icon="📤",
+        ),
+    ],
+    columns_min="15rem",
+    density="cozy",
+).render()
 
 # ──────────── CTA navegación ────────────
 st.markdown("### Siguiente acción")
@@ -181,17 +193,21 @@ with c4:
 
 # ──────────── Qué demuestra hoy ────────────
 st.markdown("---")
-st.markdown(
-    """
-    <div class="timeline">
-      <h3>¿Qué demuestra esta demo hoy?</h3>
-      <ul>
-        <li>Pipeline reproducible: <code>python -m app.modules.model_training</code> genera dataset y el RandomForest multisalida.</li>
-        <li>Predicciones con trazabilidad: cada receta incluye IDs, categorías, flags y metadatos de entrenamiento.</li>
-        <li>Explicabilidad integrada: contribuciones por feature y bandas de confianza 95%.</li>
-        <li>Comparación heurística vs IA y export listo para experimentación.</li>
-      </ul>
-    </div>
-    """,
-    unsafe_allow_html=True,
-)
+GlassStack(
+    cards=[
+        GlassCard(
+            title="¿Qué demuestra esta demo hoy?",
+            body=(
+                "<ul>"
+                "<li>Pipeline reproducible: <code>python -m app.modules.model_training</code> genera dataset y el RandomForest multisalida.</li>"
+                "<li>Predicciones con trazabilidad: cada receta incluye IDs, categorías, flags y metadatos de entrenamiento.</li>"
+                "<li>Explicabilidad integrada: contribuciones por feature y bandas de confianza 95%.</li>"
+                "<li>Comparación heurística vs IA y export listo para experimentación.</li>"
+                "</ul>"
+            ),
+            icon="🛰️",
+        ),
+    ],
+    columns_min="26rem",
+    density="roomy",
+).render()

--- a/app/modules/luxe_components.py
+++ b/app/modules/luxe_components.py
@@ -1,0 +1,495 @@
+"""High fidelity UI components for the Rex-AI Streamlit app.
+
+This module centralises visually rich components (hero, metrics, glass cards)
+so that pages can consume declarative helpers instead of raw HTML blocks.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Mapping, Sequence
+
+import streamlit as st
+
+
+# ---------------------------------------------------------------------------
+# CSS bootstrap
+# ---------------------------------------------------------------------------
+_LUXE_CSS = """
+<style>
+:root {
+  --luxe-surface: rgba(12, 17, 27, 0.78);
+  --luxe-border: rgba(148, 163, 184, 0.32);
+  --luxe-border-strong: rgba(148, 163, 184, 0.48);
+  --luxe-ink: #e9f0ff;
+  --luxe-muted: rgba(226, 232, 240, 0.76);
+  --luxe-accent: #60a5fa;
+  --luxe-positive: #34d399;
+  --luxe-warning: #f59e0b;
+  --luxe-danger: #f87171;
+}
+
+@keyframes heroGlow {
+  0% { box-shadow: 0 25px 70px rgba(96, 165, 250, 0.24); }
+  50% { box-shadow: 0 35px 110px rgba(56, 189, 248, 0.45); }
+  100% { box-shadow: 0 25px 70px rgba(96, 165, 250, 0.24); }
+}
+
+@keyframes parallaxDrift {
+  0% { transform: translate3d(0, 0, 0) scale(1); opacity: 0.45; }
+  50% { transform: translate3d(12px, -10px, 0) scale(1.05); opacity: 0.75; }
+  100% { transform: translate3d(0, 0, 0) scale(1); opacity: 0.45; }
+}
+
+@keyframes sparkleShift {
+  0% { background-position: 0% 50%; }
+  50% { background-position: 100% 50%; }
+  100% { background-position: 0% 50%; }
+}
+
+.luxe-hero {
+  position: relative;
+  overflow: hidden;
+  border-radius: 32px;
+  border: 1px solid var(--luxe-border);
+  background: var(--hero-gradient, linear-gradient(135deg, rgba(59, 130, 246, 0.16), rgba(14, 165, 233, 0.06)));
+  padding: var(--hero-padding, 2.6rem 3.1rem);
+  color: var(--luxe-ink);
+  isolation: isolate;
+  backdrop-filter: blur(18px);
+  box-shadow: 0 24px 60px rgba(8, 15, 35, 0.45);
+  animation: heroGlow 14s ease-in-out infinite;
+}
+
+.luxe-hero::after {
+  content: "";
+  position: absolute;
+  inset: -30%;
+  background: radial-gradient(circle at 20% 20%, var(--hero-glow, rgba(96, 165, 250, 0.4)), transparent 62%);
+  z-index: -2;
+  filter: blur(2px);
+  animation: sparkleShift 28s ease infinite;
+}
+
+.luxe-hero__layer {
+  position: absolute;
+  pointer-events: none;
+  opacity: 0.55;
+  font-size: var(--layer-size, 4rem);
+  animation: parallaxDrift var(--layer-speed, 18s) ease-in-out infinite;
+  mix-blend-mode: screen;
+}
+
+.luxe-hero__content {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+}
+
+.luxe-hero__icon {
+  font-size: 2.2rem;
+  align-self: flex-start;
+  filter: drop-shadow(0 0 10px rgba(148, 163, 184, 0.45));
+}
+
+.luxe-hero h1 {
+  font-size: clamp(2.15rem, 4vw, 2.9rem);
+  margin: 0;
+  letter-spacing: 0.015em;
+}
+
+.luxe-hero p {
+  margin: 0;
+  color: var(--luxe-muted);
+  font-size: 1.05rem;
+  max-width: 46rem;
+}
+
+.luxe-chip-row {
+  display: flex;
+  gap: var(--chip-gap, 0.6rem);
+  flex-wrap: wrap;
+  margin-top: var(--chip-margin-top, 0.6rem);
+}
+
+.luxe-chip {
+  border-radius: 999px;
+  padding: var(--chip-padding, 0.38rem 0.9rem);
+  border: 1px solid var(--chip-border, rgba(148, 163, 184, 0.35));
+  background: var(--chip-bg, rgba(15, 23, 42, 0.55));
+  color: var(--chip-ink, var(--luxe-ink));
+  font-size: var(--chip-size, 0.82rem);
+  font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  backdrop-filter: blur(6px);
+}
+
+.luxe-chip[data-tone="accent"] { background: rgba(96, 165, 250, 0.16); border-color: rgba(125, 211, 252, 0.45); }
+.luxe-chip[data-tone="info"] { background: rgba(14, 165, 233, 0.16); border-color: rgba(56, 189, 248, 0.5); }
+.luxe-chip[data-tone="positive"] { background: rgba(52, 211, 153, 0.14); border-color: rgba(52, 211, 153, 0.45); }
+.luxe-chip[data-tone="warning"] { background: rgba(245, 158, 11, 0.12); border-color: rgba(245, 158, 11, 0.45); }
+
+.luxe-metric-galaxy {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(var(--metric-min, 13rem), 1fr));
+  gap: var(--metric-gap, 1rem);
+}
+
+.luxe-metric {
+  border-radius: 22px;
+  border: 1px solid var(--luxe-border);
+  background: rgba(13, 17, 23, 0.76);
+  padding: var(--metric-padding, 1.2rem 1.4rem);
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.1), 0 18px 40px rgba(8, 15, 35, 0.38);
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  position: relative;
+  overflow: hidden;
+}
+
+.luxe-metric[data-glow="true"]::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 15% 20%, rgba(96, 165, 250, 0.24), transparent 65%);
+  opacity: 0.85;
+  z-index: 0;
+  pointer-events: none;
+}
+
+.luxe-metric__icon {
+  font-size: 1.15rem;
+  opacity: 0.7;
+}
+
+.luxe-metric__label {
+  font-size: 0.78rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  opacity: 0.72;
+}
+
+.luxe-metric__value {
+  font-size: 1.48rem;
+  font-weight: 700;
+}
+
+.luxe-metric__delta {
+  font-size: 0.82rem;
+  opacity: 0.75;
+}
+
+.luxe-metric__caption {
+  font-size: 0.82rem;
+  color: var(--luxe-muted);
+}
+
+.luxe-stack {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(var(--stack-min, 16rem), 1fr));
+  gap: var(--stack-gap, 1.1rem);
+  margin: var(--stack-margin, 1.6rem 0 0);
+}
+
+.luxe-card {
+  position: relative;
+  border-radius: 22px;
+  border: 1px solid var(--luxe-border);
+  background: rgba(12, 17, 27, 0.72);
+  padding: var(--card-padding, 1.3rem 1.4rem);
+  box-shadow: 0 18px 40px rgba(8, 15, 35, 0.35);
+  overflow: hidden;
+  backdrop-filter: blur(18px);
+  color: var(--luxe-ink);
+}
+
+.luxe-card::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(135deg, rgba(96, 165, 250, 0.14), transparent 55%);
+  opacity: 0.75;
+  pointer-events: none;
+}
+
+.luxe-card__icon {
+  font-size: 1.4rem;
+  margin-bottom: 0.4rem;
+}
+
+.luxe-card__title {
+  font-size: 1.05rem;
+  margin: 0 0 0.45rem 0;
+}
+
+.luxe-card__body {
+  font-size: 0.92rem;
+  color: var(--luxe-muted);
+}
+
+.luxe-card__footer {
+  margin-top: 0.7rem;
+  font-size: 0.8rem;
+  color: rgba(226, 232, 240, 0.64);
+}
+</style>
+"""
+
+
+def _inject_css() -> None:
+  """Inject the shared CSS rules once per session."""
+  if st.session_state.get("_luxe_css_injected"):
+      return
+  st.markdown(_LUXE_CSS, unsafe_allow_html=True)
+  st.session_state["_luxe_css_injected"] = True
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+def _merge_styles(base: Mapping[str, str], extra: Mapping[str, str] | None = None) -> str:
+  merged: dict[str, str] = dict(base)
+  if extra:
+      merged.update({k: v for k, v in extra.items() if v is not None})
+  return "; ".join(f"{k}: {v}" for k, v in merged.items())
+
+
+def ChipRow(
+    chips: Sequence[str | Mapping[str, str]],
+    *,
+    tone: str | None = None,
+    size: str = "md",
+    render: bool = True,
+    gap: str | None = None,
+) -> str:
+  """Render a reusable pill row.
+
+  Parameters
+  ----------
+  chips:
+      Sequence with either plain strings or dicts containing ``label`` and
+      optional ``icon``/``tone`` overrides.
+  tone:
+      Base tone applied to chips (``accent``, ``info``, ``positive``...).
+  size:
+      ``"sm"``, ``"md"`` or ``"lg"``; controls padding and font size.
+  render:
+      When ``True`` the HTML is pushed to Streamlit, otherwise only returned.
+  gap:
+      Optional override for the spacing between chips.
+  """
+  _inject_css()
+
+  size_map: Mapping[str, tuple[str, str]] = {
+      "sm": ("0.32rem 0.8rem", "0.74rem"),
+      "md": ("0.38rem 0.9rem", "0.82rem"),
+      "lg": ("0.45rem 1.05rem", "0.92rem"),
+  }
+  padding, font_size = size_map.get(size, size_map["md"])
+  row_style = {
+      "--chip-padding": padding,
+      "--chip-size": font_size,
+  }
+  if gap:
+      row_style["--chip-gap"] = gap
+
+  html = [f"<div class='luxe-chip-row' style='{_merge_styles(row_style, {})}'>"]
+  for item in chips:
+      if isinstance(item, Mapping):
+          label = item.get("label", "")
+          icon = item.get("icon")
+          chip_tone = item.get("tone", tone)
+      else:
+          label = str(item)
+          icon = None
+          chip_tone = tone
+      icon_fragment = f"<span>{icon}</span>" if icon else ""
+      html.append(
+          f"<span class='luxe-chip' data-tone='{chip_tone or ''}'>"
+          f"{icon_fragment}<span>{label}</span>"
+          "</span>"
+      )
+  html.append("</div>")
+  html_markup = "".join(html)
+  if render:
+      st.markdown(html_markup, unsafe_allow_html=True)
+  return html_markup
+
+
+# ---------------------------------------------------------------------------
+# TeslaHero
+# ---------------------------------------------------------------------------
+@dataclass
+class TeslaHero:
+  title: str
+  subtitle: str
+  chips: Sequence[str | Mapping[str, str]] = field(default_factory=list)
+  icon: str | None = None
+  gradient: str | None = None
+  glow: str | None = None
+  density: str = "cozy"
+  parallax_icons: Sequence[Mapping[str, str]] = field(default_factory=list)
+
+  def render(self) -> None:
+      _inject_css()
+      padding_map = {
+          "compact": "1.9rem 2.2rem",
+          "cozy": "2.5rem 2.9rem",
+          "roomy": "3.1rem 3.4rem",
+      }
+      padding = padding_map.get(self.density, padding_map["cozy"])
+      hero_style = {
+          "--hero-padding": padding,
+      }
+      if self.gradient:
+          hero_style["--hero-gradient"] = self.gradient
+      if self.glow:
+          hero_style["--hero-glow"] = self.glow
+
+      layers = []
+      for idx, layer in enumerate(self.parallax_icons):
+          icon = layer.get("icon", "✦")
+          top = layer.get("top", f"{10 + idx * 12}%")
+          left = layer.get("left", f"{55 + idx * 8}%")
+          size = layer.get("size", "4rem")
+          speed = layer.get("speed", f"{16 + idx * 4}s")
+          layers.append(
+              f"<span class='luxe-hero__layer' style='top:{top};left:{left};--layer-size:{size};--layer-speed:{speed};'>"
+              f"{icon}</span>"
+          )
+
+      chips_html = ChipRow(self.chips, render=False) if self.chips else ""
+      icon_html = f"<div class='luxe-hero__icon'>{self.icon}</div>" if self.icon else ""
+
+      html = f"""
+      <div class='luxe-hero' style='{_merge_styles(hero_style, {})}'>
+        {''.join(layers)}
+        <div class='luxe-hero__content'>
+          {icon_html}
+          <h1>{self.title}</h1>
+          <p>{self.subtitle}</p>
+          {chips_html}
+        </div>
+      </div>
+      """
+      st.markdown(html, unsafe_allow_html=True)
+
+
+# ---------------------------------------------------------------------------
+# MetricGalaxy
+# ---------------------------------------------------------------------------
+@dataclass
+class MetricItem:
+  label: str
+  value: str
+  caption: str | None = None
+  delta: str | None = None
+  icon: str | None = None
+  tone: str | None = None
+
+
+@dataclass
+class MetricGalaxy:
+  metrics: Sequence[MetricItem]
+  glow: bool = True
+  density: str = "cozy"
+  min_width: str = "13rem"
+
+  def render(self) -> None:
+      _inject_css()
+      padding_map = {
+          "compact": "1rem 1.15rem",
+          "cozy": "1.2rem 1.4rem",
+          "roomy": "1.45rem 1.65rem",
+      }
+      gap_map = {
+          "compact": "0.8rem",
+          "cozy": "1rem",
+          "roomy": "1.3rem",
+      }
+      style = {
+          "--metric-padding": padding_map.get(self.density, padding_map["cozy"]),
+          "--metric-gap": gap_map.get(self.density, gap_map["cozy"]),
+          "--metric-min": self.min_width,
+      }
+      html = [f"<div class='luxe-metric-galaxy' style='{_merge_styles(style, {})}'>"]
+      for metric in self.metrics:
+          tone = metric.tone or ("positive" if (metric.delta and metric.delta.startswith("+")) else "")
+          icon_html = f"<div class='luxe-metric__icon'>{metric.icon}</div>" if metric.icon else ""
+          delta_html = f"<div class='luxe-metric__delta'>{metric.delta}</div>" if metric.delta else ""
+          caption_html = f"<div class='luxe-metric__caption'>{metric.caption}</div>" if metric.caption else ""
+          html.append(
+              f"<div class='luxe-metric' data-glow='{str(self.glow).lower()}' data-tone='{tone}'>"
+              f"{icon_html}"
+              f"<div class='luxe-metric__label'>{metric.label}</div>"
+              f"<div class='luxe-metric__value'>{metric.value}</div>"
+              f"{delta_html}"
+              f"{caption_html}"
+              "</div>"
+          )
+      html.append("</div>")
+      st.markdown("".join(html), unsafe_allow_html=True)
+
+
+# ---------------------------------------------------------------------------
+# GlassStack
+# ---------------------------------------------------------------------------
+@dataclass
+class GlassCard:
+  title: str
+  body: str
+  icon: str | None = None
+  footer: str | None = None
+
+
+@dataclass
+class GlassStack:
+  cards: Sequence[GlassCard]
+  columns_min: str = "16rem"
+  density: str = "cozy"
+
+  def render(self) -> None:
+      _inject_css()
+      padding_map = {
+          "compact": "1.05rem 1.15rem",
+          "cozy": "1.3rem 1.4rem",
+          "roomy": "1.6rem 1.75rem",
+      }
+      gap_map = {
+          "compact": "0.9rem",
+          "cozy": "1.1rem",
+          "roomy": "1.45rem",
+      }
+      style = {
+          "--card-padding": padding_map.get(self.density, padding_map["cozy"]),
+          "--stack-gap": gap_map.get(self.density, gap_map["cozy"]),
+          "--stack-min": self.columns_min,
+      }
+      html = [f"<div class='luxe-stack' style='{_merge_styles(style, {})}'>"]
+      for card in self.cards:
+          icon_html = f"<div class='luxe-card__icon'>{card.icon}</div>" if card.icon else ""
+          footer_html = f"<div class='luxe-card__footer'>{card.footer}</div>" if card.footer else ""
+          html.append(
+              f"<div class='luxe-card'>"
+              f"{icon_html}"
+              f"<h3 class='luxe-card__title'>{card.title}</h3>"
+              f"<div class='luxe-card__body'>{card.body}</div>"
+              f"{footer_html}"
+              "</div>"
+          )
+      html.append("</div>")
+      st.markdown("".join(html), unsafe_allow_html=True)
+
+
+__all__ = [
+  "TeslaHero",
+  "MetricGalaxy",
+  "MetricItem",
+  "GlassStack",
+  "GlassCard",
+  "ChipRow",
+]

--- a/app/pages/3_Generator.py
+++ b/app/pages/3_Generator.py
@@ -12,37 +12,11 @@ from app.modules.ml_models import get_model_registry
 from app.modules.process_planner import choose_process
 from app.modules.safety import check_safety, safety_badge
 from app.modules.ui_blocks import load_theme
+from app.modules.luxe_components import TeslaHero, ChipRow
 
 st.set_page_config(page_title="Rex-AI • Generador", page_icon="🤖", layout="wide")
 
 load_theme()
-
-# ----------------------------- CSS local -----------------------------
-st.markdown(
-    """
-    <style>
-    .layout {display:flex; flex-direction:column; gap:1.6rem;}
-    .pane {background: rgba(15,18,26,0.75); border:1px solid rgba(148,163,184,0.18); padding:22px 24px; border-radius:20px;}
-    .pane h3 {margin-bottom:0.6rem;}
-    .hero-gen {padding:28px 30px; border-radius:26px; background: linear-gradient(135deg, rgba(59,130,246,0.18), rgba(14,165,233,0.08)); border:1px solid rgba(59,130,246,0.32);}
-    .hero-gen h1 {margin-bottom:0.4rem;}
-    .hero-gen p {margin:0; opacity:0.82; max-width:760px;}
-    .chipline {display:flex; gap:10px; margin-top:14px; flex-wrap:wrap;}
-    .chipline span {padding:5px 12px; border-radius:999px; border:1px solid rgba(148,163,184,0.26); font-size:0.8rem; opacity:0.85;}
-    .candidate {border-radius:20px; border:1px solid rgba(148,163,184,0.2); padding:20px 22px; margin-bottom:16px; background: rgba(13,17,23,0.7);}
-    .candidate h4 {margin-bottom:0.4rem;}
-    .candidate-grid {display:grid; grid-template-columns: repeat(auto-fit,minmax(180px,1fr)); gap:12px; margin:12px 0;}
-    .candidate-grid div {background:rgba(148,163,184,0.12); border-radius:14px; padding:12px;}
-    .candidate-grid strong {display:block; font-size:1.2rem;}
-    .confidence {font-size:0.86rem; opacity:0.8; margin-top:4px;}
-    .badge-ai {display:inline-flex; align-items:center; gap:6px; padding:4px 10px; border-radius:999px; border:1px solid rgba(148,163,184,0.25); font-size:0.78rem;}
-    .delta {font-size:0.82rem; opacity:0.8;}
-    .hr-micro {height:1px; background:rgba(148,163,184,0.25); margin:14px 0;}
-    .badge {padding:4px 10px; border-radius:999px; font-size:0.78rem; background:rgba(96,165,250,0.16); color:#e6eefc; margin-right:6px; border:1px solid rgba(148,163,184,0.25);}
-    </style>
-    """,
-    unsafe_allow_html=True,
-)
 
 # ----------------------------- Helpers -----------------------------
 TARGET_DISPLAY = {
@@ -86,21 +60,27 @@ def _format_label_summary(summary: dict[str, dict[str, float]] | None) -> str:
     return " · ".join(parts)
 
 # ----------------------------- Hero -----------------------------
-st.markdown(
-    """
-    <div class="hero-gen">
-      <h1>🤖 Generador asistido por IA</h1>
-      <p>Rex-AI explora combinaciones de residuos NASA, optimiza parámetros y explica cada predicción con bandas de confianza e importancias de features.</p>
-      <div class="chipline">
-        <span>RandomForest + XGBoost (alternativo)</span>
-        <span>Confianza 95%</span>
-        <span>Comparación heurística vs IA</span>
-        <span>Trazabilidad NASA + MGS-1</span>
-      </div>
-    </div>
-    """,
-    unsafe_allow_html=True,
-)
+TeslaHero(
+    title="Generador asistido por IA",
+    subtitle=(
+        "Rex-AI explora combinaciones de residuos NASA, optimiza parámetros y "
+        "explica cada predicción con bandas de confianza e importancias de features."
+    ),
+    chips=[
+        {"label": "RandomForest + XGBoost (alternativo)", "tone": "accent"},
+        {"label": "Confianza 95%", "tone": "info"},
+        {"label": "Comparación heurística vs IA", "tone": "accent"},
+        {"label": "Trazabilidad NASA + MGS-1", "tone": "info"},
+    ],
+    icon="🤖",
+    gradient="linear-gradient(135deg, rgba(59,130,246,0.2), rgba(14,165,233,0.08))",
+    glow="rgba(56,189,248,0.45)",
+    density="cozy",
+    parallax_icons=[
+        {"icon": "🛰️", "top": "18%", "left": "75%", "size": "4rem", "speed": "20s"},
+        {"icon": "🧪", "top": "64%", "left": "82%", "size": "3.5rem", "speed": "26s"},
+    ],
+).render()
 
 # ----------------------------- Pre-condición: target -----------------------------
 target = st.session_state.get("target")
@@ -227,7 +207,7 @@ if run:
     st.session_state["optimizer_history"] = history_df
 
 # ----------------------------- Si no hay candidatos aún -----------------------------
-st.markdown('<div class="hr-micro"></div>', unsafe_allow_html=True)
+st.divider()
 cands = st.session_state.get("candidates", [])
 history_df = st.session_state.get("optimizer_history", pd.DataFrame())
 
@@ -329,7 +309,7 @@ for i, c in enumerate(cands):
             if risk_label:
                 badges.append(f"🏷️ Riesgo {risk_label}")
         if badges:
-            st.markdown(" ".join([f'<span class="badge">{b}</span>' for b in badges]), unsafe_allow_html=True)
+            ChipRow([{ "label": badge } for badge in badges], tone="accent")
 
         pred_error = c.get("prediction_error")
         if pred_error:

--- a/app/pages/4_Results_and_Tradeoffs.py
+++ b/app/pages/4_Results_and_Tradeoffs.py
@@ -6,6 +6,14 @@ import plotly.graph_objects as go
 import streamlit as st
 
 from app.modules.ui_blocks import load_theme
+from app.modules.luxe_components import (
+    GlassCard,
+    GlassStack,
+    MetricGalaxy,
+    MetricItem,
+    TeslaHero,
+    ChipRow,
+)
 
 from app.modules.data_sources import (
     load_regolith_granulometry,
@@ -47,37 +55,34 @@ def _load_regolith_context():
         "thermal": load_regolith_thermal_profiles(),
     }
 
-st.markdown(
-    """
-    <style>
-    .hero-res {padding:28px 30px; border-radius:26px; background: linear-gradient(135deg, rgba(20,184,166,0.18), rgba(14,165,233,0.08)); border:1px solid rgba(45,212,191,0.32);}
-    .hero-res h1 {margin-bottom:0.2rem;}
-    .hero-res p {margin:0; opacity:0.82; max-width:720px;}
-    .metrics {display:grid; grid-template-columns: repeat(auto-fit,minmax(190px,1fr)); gap:14px; margin:18px 0;}
-    .metrics div {background:rgba(13,17,23,0.68); border:1px solid rgba(148,163,184,0.22); border-radius:18px; padding:14px 16px;}
-    .metrics span {display:block; font-size:0.8rem; opacity:0.7;}
-    .metrics strong {display:block; font-size:1.35rem; margin-top:4px;}
-    .delta {font-size:0.82rem; opacity:0.75; margin-top:4px;}
-    .card {background:rgba(13,17,23,0.65); border:1px solid rgba(148,163,184,0.22); border-radius:20px; padding:20px 22px; margin-top:18px;}
-    .badge {display:inline-flex; gap:6px; align-items:center; padding:5px 12px; border-radius:999px; border:1px solid rgba(148,163,184,0.28); font-size:0.78rem;}
-    .chips {display:flex; flex-wrap:wrap; gap:8px; margin-top:8px;}
-    .chips span {padding:4px 10px; border-radius:999px; border:1px solid rgba(148,163,184,0.25); font-size:0.78rem;}
-    </style>
-    """,
-    unsafe_allow_html=True,
-)
+TeslaHero(
+    title=f"Resultado seleccionado · Score {score:.3f}",
+    subtitle=(
+        f"Proceso {cand['process_id']} · {cand['process_name']}. "
+        "La IA Rex-AI proporciona predicciones con trazabilidad NASA, bandas de confianza y comparación contra heurísticas originales."
+    ),
+    chips=[
+        {"label": f"Target: {target.get('name', '—')}", "tone": "accent"},
+        {"label": f"Crew priority: {'baja' if target.get('crew_time_low') else 'balance'}", "tone": "info"},
+    ],
+    icon="📊",
+    gradient="linear-gradient(135deg, rgba(20,184,166,0.22), rgba(14,165,233,0.08))",
+    glow="rgba(45,212,191,0.42)",
+    density="cozy",
+    parallax_icons=[
+        {"icon": "🧪", "top": "18%", "left": "78%", "size": "3.6rem", "speed": "21s"},
+        {"icon": "🛰️", "top": "60%", "left": "84%", "size": "4.2rem", "speed": "27s"},
+    ],
+).render()
 
-st.markdown(
-    f"""
-    <div class="hero-res">
-      <h1>📊 Resultado seleccionado · Score {score:.3f}</h1>
-      <p>Proceso <strong>{cand['process_id']} · {cand['process_name']}</strong>. La IA Rex-AI proporciona predicciones con trazabilidad NASA, bandas de confianza y comparación contra heurísticas originales.</p>
-    </div>
-    """,
-    unsafe_allow_html=True,
-)
-
-cols = st.columns(5)
+icon_map = {
+    "Rigidez": "🧱",
+    "Estanqueidad": "💧",
+    "Energía (kWh)": "⚡",
+    "Agua (L)": "🚰",
+    "Crew (min)": "🧑‍🚀",
+}
+metric_items: list[MetricItem] = []
 labels = [
     ("Rigidez", props.rigidity, heur.rigidity, ci.get("rigidez")),
     ("Estanqueidad", props.tightness, heur.tightness, ci.get("estanqueidad")),
@@ -85,12 +90,25 @@ labels = [
     ("Agua (L)", props.water_l, heur.water_l, ci.get("water_l")),
     ("Crew (min)", props.crew_min, heur.crew_min, ci.get("crew_min")),
 ]
-for col, (label, val_ml, val_h, interval) in zip(cols, labels):
-    with col:
-        st.markdown("<div class='metrics'><div><span>{}</span><strong>{:.3f}</strong></div></div>".format(label, val_ml), unsafe_allow_html=True)
-        st.markdown(f"<div class='delta'>Heurística: {val_h:.3f} · Δ {val_ml - val_h:+.3f}</div>", unsafe_allow_html=True)
-        if interval:
-            st.caption(f"CI 95%: [{interval[0]:.3f}, {interval[1]:.3f}]")
+for label, val_ml, val_h, interval in labels:
+    delta_value = val_ml - val_h
+    caption_bits = [f"Heurística: {val_h:.3f}"]
+    if interval:
+        try:
+            caption_bits.append(f"CI 95% [{interval[0]:.3f}, {interval[1]:.3f}]")
+        except (TypeError, ValueError, IndexError):
+            pass
+    metric_items.append(
+        MetricItem(
+            label=label,
+            value=f"{val_ml:.3f}",
+            delta=f"Δ {delta_value:+.3f}",
+            caption=" · ".join(caption_bits),
+            icon=icon_map.get(label),
+        )
+    )
+
+MetricGalaxy(metrics=metric_items, density="compact").render()
 if uncertainty:
     st.caption("Desviaciones modelo: " + ", ".join(f"{k} {v:.3f}" for k, v in uncertainty.items()))
 
@@ -133,30 +151,48 @@ st.altair_chart(chart_parts, use_container_width=True)
 with st.container():
     st.markdown("### 🛰️ Contexto y trazabilidad")
     context_data = _load_regolith_context()
-    st.markdown(
-        """
-        <div class="card">
-          <div class="chips">
-            <span>Seguridad: {safety}</span>
-            <span>Regolito MGS-1: {regolith}%</span>
-            <span>Entrenado: {trained}</span>
-            <span>Muestras: {samples}</span>
-          </div>
-          <p style="margin-top:12px;">Materiales: {materials}</p>
-          <p>Fuente IDs NASA: {ids}</p>
-          <p>Latent vector (autoencoder): {latent}</p>
-        </div>
-        """.format(
-            safety=f"{safety['level']} · {safety['detail']}",
-            regolith=int(regolith_pct * 100),
-            trained=metadata.get("trained_at", "—"),
-            samples=metadata.get("n_samples", "—"),
-            materials=", ".join(materials),
-            ids=", ".join(cand.get("source_ids", [])),
-            latent=", ".join(f"{v:.2f}" for v in latent[:8]) if latent else "—",
-        ),
-        unsafe_allow_html=True,
+    chips_html = ChipRow(
+        [
+            {
+                "label": f"Seguridad: {safety['level']} · {safety['detail']}",
+                "tone": "info",
+            },
+            {
+                "label": f"Regolito MGS-1: {int(regolith_pct * 100)}%",
+                "tone": "accent",
+            },
+            {
+                "label": f"Entrenado: {metadata.get('trained_at', '—')}",
+                "tone": "info",
+            },
+            {
+                "label": f"Muestras: {metadata.get('n_samples', '—')}",
+                "tone": "info",
+            },
+        ],
+        render=False,
     )
+    materials_text = ", ".join(materials) if materials else "—"
+    ids_text = ", ".join(cand.get("source_ids", [])) or "—"
+    latent_text = (
+        ", ".join(f"{v:.2f}" for v in latent[:8]) if latent else "—"
+    )
+    GlassStack(
+        cards=[
+            GlassCard(
+                title="Trazabilidad Rex-AI",
+                body=(
+                    f"{chips_html}"
+                    f"<p style='margin-top:12px;'>Materiales: {materials_text}</p>"
+                    f"<p>Fuente IDs NASA: {ids_text}</p>"
+                    f"<p>Latent vector (autoencoder): {latent_text}</p>"
+                ),
+                icon="🛰️",
+            )
+        ],
+        columns_min="22rem",
+        density="cozy",
+    ).render()
     src = getattr(props, "source", "heuristic")
     if src.startswith("rexai"):
         trained_at = metadata.get("trained_at", "?")

--- a/app/pages/6_Pareto_and_Export.py
+++ b/app/pages/6_Pareto_and_Export.py
@@ -12,6 +12,7 @@ from app.modules.analytics import pareto_front
 from app.modules.exporters import candidate_to_json, candidate_to_csv
 from app.modules.safety import check_safety  # recalcular badge al seleccionar
 from app.modules.ui_blocks import load_theme
+from app.modules.luxe_components import TeslaHero, MetricGalaxy, MetricItem
 
 # ⚠️ PRIMERA llamada
 st.set_page_config(page_title="Pareto & Export", page_icon="📤", layout="wide")
@@ -27,32 +28,27 @@ if not cands or not target:
     st.warning("Generá opciones en **3) Generador** primero.")
     st.stop()
 
-# ======== estilos (NASA/SpaceX-like) ========
-st.markdown(
-    """
-    <style>
-    .hero {border-radius:16px; padding:18px 18px 8px; background: radial-gradient(1200px 380px at 20% -10%, rgba(80,120,255,.08), transparent);}
-    .section-title{margin-top:6px; margin-bottom:6px}
-    </style>
-    """,
-    unsafe_allow_html=True,
-)
-
 # ======== HERO ========
-st.markdown("""
-<div class="hero">
-  <h1 style="margin:0 0 6px 0">📤 Pareto & Export</h1>
-  <div class="small" style="margin-bottom:10px">
-    Explorá el trade-off **Energía ↔ Agua ↔ Crew** con datos reales de tus candidatos.
-    Elegí uno y exportá el plan. Todo conectado al objetivo definido en <b>2) Target</b>.
-  </div>
-  <div class="legend">
-    <span class="pill info">Paso 1 — Explorar</span>
-    <span class="pill info">Paso 2 — Seleccionar</span>
-    <span class="pill ok">Paso 3 — Exportar</span>
-  </div>
-</div>
-""", unsafe_allow_html=True)
+TeslaHero(
+    title="Pareto & Export",
+    subtitle=(
+        "Explorá el trade-off Energía ↔ Agua ↔ Crew con datos reales de tus candidatos. "
+        "Elegí uno y exportá el plan enlazado al objetivo definido en 2) Target."
+    ),
+    chips=[
+        {"label": "Paso 1 — Explorar", "tone": "info"},
+        {"label": "Paso 2 — Seleccionar", "tone": "info"},
+        {"label": "Paso 3 — Exportar", "tone": "accent"},
+    ],
+    icon="📤",
+    gradient="linear-gradient(135deg, rgba(80,120,255,0.22), rgba(14,165,233,0.08))",
+    glow="rgba(99,102,241,0.42)",
+    density="cozy",
+    parallax_icons=[
+        {"icon": "🛰️", "top": "20%", "left": "76%", "size": "4rem", "speed": "20s"},
+        {"icon": "📦", "top": "62%", "left": "83%", "size": "3.6rem", "speed": "26s"},
+    ],
+).render()
 
 # ======== tabla base (derivada de candidates reales) ========
 df_raw = compare_table(cands, target, crew_time_low=target.get("crew_time_low", False)).copy()
@@ -82,11 +78,20 @@ if "Materiales" in df_raw:
 df_plot = df_raw.dropna(subset=["Energía (kWh)","Agua (L)","Crew (min)","Score"]).copy()
 
 # ======== KPIs ========
-colA, colB, colC, colD = st.columns(4)
-with colA: st.markdown(f'<div class="kpi"><h3>Opciones válidas</h3><div class="v">{len(df_plot)}</div></div>', unsafe_allow_html=True)
-with colB: st.markdown(f'<div class="kpi"><h3>Score máximo</h3><div class="v">{df_plot["Score"].max():.2f}</div></div>', unsafe_allow_html=True)
-with colC: st.markdown(f'<div class="kpi"><h3>Mín. Agua</h3><div class="v">{df_plot["Agua (L)"].min():.2f} L</div></div>', unsafe_allow_html=True)
-with colD: st.markdown(f'<div class="kpi"><h3>Mín. Energía</h3><div class="v">{df_plot["Energía (kWh)"].min():.2f} kWh</div></div>', unsafe_allow_html=True)
+kpi_items = []
+if not df_plot.empty:
+    kpi_items = [
+        MetricItem(label="Opciones válidas", value=str(len(df_plot)), icon="🪐"),
+        MetricItem(label="Score máximo", value=f"{df_plot['Score'].max():.2f}", icon="🌟"),
+        MetricItem(label="Mín. Agua", value=f"{df_plot['Agua (L)'].min():.2f} L", icon="💧"),
+        MetricItem(label="Mín. Energía", value=f"{df_plot['Energía (kWh)'].min():.2f} kWh", icon="⚡"),
+    ]
+else:
+    kpi_items = [
+        MetricItem(label="Opciones válidas", value="0", icon="🪐"),
+    ]
+
+MetricGalaxy(metrics=kpi_items, density="compact").render()
 
 # ======== What-If de límites ========
 st.markdown("### 🎛️ What-If (filtro visual)")

--- a/docs/ui-components.md
+++ b/docs/ui-components.md
@@ -1,0 +1,113 @@
+# UI Components Library
+
+La librería `app.modules.luxe_components` concentra los bloques visuales premium que usamos en la demo de Rex-AI. Cada componente inyecta automáticamente estilos (parallax, glassmorphism, brillo dinámico) y expone parámetros declarativos para adaptar el branding sin duplicar CSS.
+
+## Componentes disponibles
+
+### `TeslaHero`
+Hero translúcido con capas parallax y chips animados.
+
+```python
+from app.modules.luxe_components import TeslaHero
+
+TeslaHero(
+    title="Generador asistido por IA",
+    subtitle="Rex-AI explora combinaciones y explica cada predicción.",
+    chips=[
+        {"label": "RandomForest multisalida", "tone": "accent"},
+        {"label": "Confianza 95%", "tone": "info"},
+    ],
+    icon="🤖",
+    gradient="linear-gradient(135deg, rgba(59,130,246,0.24), rgba(14,165,233,0.08))",
+    glow="rgba(56,189,248,0.45)",
+    density="cozy",
+    parallax_icons=[
+        {"icon": "🛰️", "top": "20%", "left": "75%", "size": "4rem"},
+        {"icon": "🧪", "top": "60%", "left": "82%", "size": "3.4rem"},
+    ],
+).render()
+```
+
+Parámetros clave:
+- **`gradient`**: define el fondo principal (acepta cualquier expresión CSS `linear-gradient`/`radial-gradient`).
+- **`glow`**: color de brillo dinámico aplicado al halo radial.
+- **`density`**: `"compact"`, `"cozy"` o `"roomy"` para ajustar paddings.
+- **`parallax_icons`**: lista de capas decorativas (emoji/SVG) con control de posición, tamaño y velocidad.
+
+### `ChipRow`
+Hilera de chips glassmórficos reutilizables.
+
+```python
+from app.modules.luxe_components import ChipRow
+
+ChipRow([
+    {"label": "Paso 1 — Explorar", "tone": "info"},
+    {"label": "Paso 2 — Seleccionar", "tone": "info"},
+    {"label": "Paso 3 — Exportar", "tone": "accent"},
+])
+```
+
+- `tone` soporta `accent`, `info`, `positive`, `warning` o `None` para el estilo neutro.
+- `size` (`"sm"`, `"md"`, `"lg"`) controla tipografía y padding.
+- Con `render=False` devuelve el HTML para incrustarlo dentro de otro componente (por ejemplo en un `GlassCard`).
+
+### `MetricGalaxy`
+Cuadrícula de métricas con brillo dinámico.
+
+```python
+from app.modules.luxe_components import MetricGalaxy, MetricItem
+
+MetricGalaxy(
+    metrics=[
+        MetricItem(label="Score máximo", value="0.92", icon="🌟"),
+        MetricItem(label="Mín. Agua", value="12.5 L", icon="💧", caption="Heurística: 14.3 L", delta="Δ -1.8"),
+    ],
+    density="compact",
+).render()
+```
+
+- Cada `MetricItem` acepta `label`, `value`, `icon`, `caption` y `delta`.
+- El `delta` se renderiza en un subtítulo pequeño; usalo para diferencias heurística/ML.
+- `min_width` controla el ancho mínimo de cada tarjeta dentro de la grilla.
+
+### `GlassStack`
+Stack responsivo de tarjetas glassmórficas.
+
+```python
+from app.modules.luxe_components import GlassStack, GlassCard
+
+GlassStack(
+    cards=[
+        GlassCard(
+            title="Ruta de misión",
+            body="Normalizá residuos, fijá límites y generá recetas.",
+            icon="🧭",
+            footer="Dataset NASA + crew flags",
+        ),
+        GlassCard(
+            title="Export",
+            body="Descargá JSON/CSV con trazabilidad completa.",
+            icon="📦",
+        ),
+    ],
+    columns_min="15rem",
+    density="cozy",
+).render()
+```
+
+- `columns_min` define el ancho mínimo de cada tarjeta (el layout salta de 1 a N columnas según el viewport).
+- `density` comparte semántica con el resto de componentes (`compact`/`cozy`/`roomy`).
+
+## Lineamientos de branding
+
+- **Gradientes**: mantené combinaciones deep-space (`rgba(59,130,246,…)`, `rgba(14,165,233,…)`, `rgba(45,212,191,…)`) para conservar la identidad Rex-AI. Los héroes secundarios pueden usar matices turquesa/azules; reservá violetas (`rgba(99,102,241,…)`) para secciones de export o analítica.
+- **Íconos**: priorizá emojis nativos relacionados con espacio/ingeniería (🛰️, 🧪, 🧑‍🚀). El hero puede mezclar iconos grandes en `parallax_icons` para storytelling; mantené 2‑3 capas máximo para evitar ruido visual.
+- **Densidad**: usá `compact` para dashboards densos (Pareto), `cozy` para flujos de operación y `roomy` para la Home/hero principal.
+- **Chips**: combiná tonos `accent` y `info` para destacar features; `positive`/`warning` quedan reservados a mensajes de estado (seguridad, alertas).
+- **Accesibilidad**: los textos dentro de los componentes deben ser breves y contrastantes; evitá párrafos largos dentro de `GlassCard`. Para contenido extendido, usar `st.markdown` debajo del componente.
+
+## Buenas prácticas
+
+1. Reutilizá siempre los componentes antes de escribir HTML crudo. Si falta alguna variante, ampliá `luxe_components` para mantener consistencia.
+2. Inyectá chips/metricas desde datos dinámicos: formateá strings antes de pasarlas al componente para que la lógica de presentación se mantenga declarativa.
+3. Para combinar con controles de Streamlit (`st.button`, `st.slider`), renderizá el componente y luego añadí los widgets. El CSS ya incluye `backdrop-filter` y sombras, así que evitá anidar `st.container` con estilos propios.


### PR DESCRIPTION
## Summary
- introduce `luxe_components` module with TeslaHero, MetricGalaxy, GlassStack and ChipRow glassmorphism layouts
- refactor Home, Generator, Results and Pareto pages to consume the new declarative components
- document usage patterns and branding guidance in docs/ui-components.md

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dad5e86aa08331ad7f93e025debb92