### PR TITLE
Add global Mission HUD navigation experience

### DIFF
--- a/app/Home.py
+++ b/app/Home.py
@@ -4,6 +4,7 @@ import _bootstrap  # noqa: F401
 from datetime import datetime
 import streamlit as st
 from app.modules.ml_models import get_model_registry
+from app.modules.navigation import set_active_step
 from app.modules.ui_blocks import load_theme
 
 st.set_page_config(
@@ -11,6 +12,8 @@ st.set_page_config(
     page_icon="🛰️",
     layout="wide",
 )
+
+set_active_step("brief")
 
 load_theme()
 
@@ -164,20 +167,10 @@ st.markdown(
 )
 
 # ──────────── CTA navegación ────────────
-st.markdown("### Siguiente acción")
-c1, c2, c3, c4 = st.columns(4)
-with c1:
-    if st.button("🧱 Inventario", use_container_width=True):
-        st.switch_page("pages/1_Inventory_Builder.py")
-with c2:
-    if st.button("🎯 Target", use_container_width=True):
-        st.switch_page("pages/2_Target_Designer.py")
-with c3:
-    if st.button("🤖 Generador", use_container_width=True):
-        st.switch_page("pages/3_Generator.py")
-with c4:
-    if st.button("📊 Resultados", use_container_width=True):
-        st.switch_page("pages/4_Results_and_Tradeoffs.py")
+st.info(
+    "Usá el **Mission HUD** superior para saltar entre pasos o presioná las teclas `1-9` "
+    "para navegar más rápido por el flujo guiado."
+)
 
 # ──────────── Qué demuestra hoy ────────────
 st.markdown("---")

--- a/app/modules/navigation.py
+++ b/app/modules/navigation.py
@@ -1,0 +1,276 @@
+"""Mission HUD utilities shared across Rex-AI pages."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from functools import lru_cache
+from typing import Sequence
+
+import streamlit as st
+from streamlit.components.v1 import html
+
+from app.modules.ml_models import get_model_registry
+
+
+@dataclass(frozen=True)
+class MissionStep:
+    """Definition of a mission step in the guided flow."""
+
+    key: str
+    label: str
+    icon: str
+    page: str
+    description: str
+
+
+MISSION_STEPS: tuple[MissionStep, ...] = (
+    MissionStep("brief", "Brief", "🛰️", "Home", "Resumen y preparación"),
+    MissionStep("inventory", "Inventario", "🧱", "1_Inventory_Builder", "Normalizar residuos"),
+    MissionStep("target", "Target", "🎯", "2_Target_Designer", "Definir objetivos"),
+    MissionStep("generator", "Generador", "🤖", "3_Generator", "Recetas asistidas"),
+    MissionStep("results", "Resultados", "📊", "4_Results_and_Tradeoffs", "Trade-offs y métricas"),
+    MissionStep("compare", "Comparar", "🧪", "5_Compare_and_Explain", "Explicabilidad"),
+    MissionStep("export", "Export", "📦", "6_Pareto_and_Export", "Pareto y export"),
+    MissionStep("playbooks", "Playbooks", "📚", "7_Scenario_Playbooks", "Escenarios"),
+    MissionStep("feedback", "Feedback", "📝", "8_Feedback_and_Impact", "Impacto y retraining"),
+    MissionStep("capacity", "Capacidad", "⚙️", "9_Capacity_Simulator", "Simulación"),
+)
+
+_HUD_STATE_KEY = "__mission_hud_injected__"
+
+
+def set_active_step(step_key: str) -> None:
+    """Persist the active step so the HUD can highlight it."""
+
+    st.session_state["mission_active_step"] = step_key
+
+
+def _step_from_key(step_key: str | None) -> MissionStep | None:
+    if not step_key:
+        return None
+    for step in MISSION_STEPS:
+        if step.key == step_key:
+            return step
+    return None
+
+
+@lru_cache(maxsize=1)
+def _model_metadata() -> dict[str, str]:
+    """Read lightweight metadata from the model registry once per run."""
+
+    registry = get_model_registry()
+    ready = "✅ Listo" if registry.ready else "⚠️ Requiere entrenamiento"
+    trained_label = registry.metadata.get("trained_label") or registry.metadata.get("trained_on") or "—"
+    trained_at = registry.metadata.get("trained_at") or "sin metadata"
+    return {
+        "status": ready,
+        "model_name": registry.metadata.get("model_name", "rexai-rf-ensemble"),
+        "trained_label": str(trained_label),
+        "trained_at": str(trained_at),
+        "uncertainty": registry.uncertainty_label(),
+    }
+
+
+def _page_url(page: str) -> str:
+    return f"./?page={page}"
+
+
+def _hud_css() -> str:
+    return """
+    <style>
+      .mission-hud {position: sticky; top: 0; z-index: 999; margin-bottom: 1.4rem;}
+      .mission-hud__wrap {backdrop-filter: blur(12px); background: rgba(13,17,23,0.82); border: 1px solid rgba(96,165,250,0.18);
+        border-radius: 20px; padding: 14px 20px; display: grid; grid-template-columns: auto 1fr auto; gap: 18px; align-items: center;}
+      .mission-hud__logo {display: flex; align-items: center; gap: 10px; font-weight: 700; letter-spacing: .02em; color: var(--ink, #e2e8f0); font-size: 1.05rem;}
+      .mission-hud__steps {display: flex; gap: 10px; overflow-x: auto; padding-bottom: 6px;}
+      .mission-hud__step {display: inline-flex; align-items: center; gap: 8px; padding: 6px 12px; border-radius: 999px; border: 1px solid rgba(148,163,184,0.22); color: rgba(226,232,240,0.78); font-size: 0.82rem; transition: all .3s ease; text-decoration: none; white-space: nowrap;}
+      .mission-hud__step:hover {border-color: rgba(96,165,250,0.45); color: #f8fafc; box-shadow: 0 6px 18px rgba(15,118,110,0.18);}
+      .mission-hud__step.is-active {background: linear-gradient(135deg, rgba(59,130,246,0.35), rgba(14,165,233,0.18)); border-color: rgba(96,165,250,0.75); color: #f8fafc;}
+      .mission-hud__status {display: grid; gap: 4px; text-align: right;}
+      .mission-hud__status small {opacity: 0.68; font-size: 0.7rem;}
+      .mission-hud__progress {height: 4px; margin-top: 8px; background: rgba(96,165,250,0.18); border-radius: 99px; overflow: hidden;}
+      .mission-hud__progress-bar {height: 100%; background: linear-gradient(90deg, rgba(59,130,246,1), rgba(14,165,233,1)); transition: width .4s ease;}
+      .mission-hud__ctas {display: flex; gap: 8px; margin-top: 6px; justify-content: flex-end;}
+      .mission-hud__cta {padding: 6px 12px; border-radius: 10px; border: 1px solid rgba(96,165,250,0.4); background: rgba(15,23,42,0.75); color: #e2e8f0; font-size: 0.78rem; text-decoration: none; transition: all .3s ease;}
+      .mission-hud__cta:hover {background: rgba(59,130,246,0.18);}
+      .mission-breadcrumbs {margin-bottom: 1rem; font-size: 0.78rem; display: flex; gap: 6px; align-items: center; color: rgba(226,232,240,0.76);}
+      .mission-breadcrumbs a {color: rgba(148,197,255,0.85); text-decoration: none; font-weight: 600;}
+      .mission-breadcrumbs span {opacity: 0.65;}
+    </style>
+    """
+
+
+def _render_shortcuts_script(step_urls: dict[str, str]) -> None:
+    payload = json.dumps(step_urls)
+    escaped = payload.replace("\\", "\\\\").replace("'", "\\'")
+    html(
+        """
+        <div id="mission-hud-portal"></div>
+        <script>
+        (function() {
+          const initKey = '__missionHudHotkeys';
+          if (window[initKey]) return;
+          const urls = JSON.parse('%s');
+          function goTo(url) {
+            if (!url) return;
+            const base = window.parent?.location ?? window.location;
+            base.href = url;
+          }
+          function onKey(event) {
+            if (event.altKey || event.metaKey || event.ctrlKey) return;
+            const tag = (event.target?.tagName || '').toLowerCase();
+            if (['input','textarea','select'].includes(tag) || event.target?.isContentEditable) return;
+            const url = urls[event.code];
+            if (url) {
+              event.preventDefault();
+              goTo(url);
+            }
+          }
+          function animateSteps() {
+            const attempt = () => {
+              const host = window.parent?.document ?? document;
+              const chips = host.querySelectorAll('.mission-hud__step');
+              if (!chips.length) return;
+              if (!window.framerMotion || !window.framerMotion.animate) return;
+              chips.forEach((chip, idx) => {
+                window.framerMotion.animate(
+                  chip,
+                  { opacity: [0, 1], transform: ['translateY(-6px)', 'translateY(0px)'] },
+                  { duration: 0.6, delay: idx * 0.05, easing: 'easeOut' }
+                );
+              });
+            };
+            if (window.framerMotion) {
+              attempt();
+            } else {
+              const scriptId = 'framer-motion-umd';
+              if (!document.getElementById(scriptId)) {
+                const script = document.createElement('script');
+                script.id = scriptId;
+                script.src = 'https://unpkg.com/framer-motion@10.16.5/dist/framer-motion.umd.js';
+                script.onload = attempt;
+                document.head.appendChild(script);
+              }
+            }
+          }
+          window.addEventListener('keydown', onKey, true);
+          const observer = new MutationObserver(animateSteps);
+          observer.observe(document.body, { childList: true, subtree: true });
+          animateSteps();
+          window[initKey] = true;
+        })();
+        </script>
+        """
+        % escaped,
+        height=0,
+    )
+
+
+def render_mission_hud() -> None:
+    """Render the Mission HUD (logo, steps, model state and CTAs)."""
+
+    st.markdown(_hud_css(), unsafe_allow_html=True)
+
+    if st.session_state.get(_HUD_STATE_KEY):
+        st.session_state[_HUD_STATE_KEY] += 1
+    else:
+        st.session_state[_HUD_STATE_KEY] = 1
+
+    metadata = _model_metadata()
+    active_step = _step_from_key(st.session_state.get("mission_active_step"))
+
+    progress_index = 0
+    steps_markup = []
+    for idx, step in enumerate(MISSION_STEPS, start=1):
+        url = _page_url(step.page)
+        is_active = active_step.key == step.key if active_step else False
+        if is_active:
+            progress_index = idx
+        class_attr = "is-active" if is_active else ""
+        steps_markup.append(
+            (
+                f"<a class='mission-hud__step {class_attr}' href='{url}' title='{step.description}'>"
+                f"<span>{step.icon}</span><strong>{idx} · {step.label}</strong>"
+                "</a>"
+            )
+        )
+
+    progress = (progress_index / len(MISSION_STEPS)) if progress_index else 0.0
+
+    next_step = None
+    prev_step = None
+    if active_step:
+        current_idx = MISSION_STEPS.index(active_step)
+        if current_idx + 1 < len(MISSION_STEPS):
+            next_step = MISSION_STEPS[current_idx + 1]
+        if current_idx - 1 >= 0:
+            prev_step = MISSION_STEPS[current_idx - 1]
+
+    ctas: list[str] = []
+    if prev_step:
+        ctas.append(
+            f'<a class="mission-hud__cta" href="{_page_url(prev_step.page)}">⬅️ {prev_step.label}</a>'
+        )
+    if next_step:
+        ctas.append(
+            f'<a class="mission-hud__cta" href="{_page_url(next_step.page)}">{next_step.label} ➡️</a>'
+        )
+
+    st.markdown(
+        f"""
+        <div class="mission-hud">
+          <div class="mission-hud__wrap">
+            <div class="mission-hud__logo">🛰️ Mission HUD <span style="opacity:0.6;font-weight:500;">Rex-AI</span></div>
+            <div>
+              <div class="mission-hud__steps">{''.join(steps_markup)}</div>
+              <div class="mission-hud__progress"><div class="mission-hud__progress-bar" style="width:{progress*100:.1f}%;"></div></div>
+            </div>
+            <div class="mission-hud__status">
+              <div><strong>{metadata['status']}</strong> · {metadata['model_name']}</div>
+              <small>Entrenado: {metadata['trained_label']} · {metadata['trained_at']} · {metadata['uncertainty']}</small>
+              <div class="mission-hud__ctas">{''.join(ctas)}</div>
+            </div>
+          </div>
+        </div>
+        """,
+        unsafe_allow_html=True,
+    )
+
+    ordered_urls = {
+        ("Digit0" if idx == 10 else f"Digit{idx}"): _page_url(step.page)
+        for idx, step in enumerate(MISSION_STEPS, start=1)
+        if idx <= 10
+    }
+    _render_shortcuts_script(ordered_urls)
+
+
+def render_breadcrumbs(current_step_key: str, extra: Sequence[tuple[str, str]] | None = None) -> None:
+    """Render breadcrumbs using mission steps and optional extra nodes."""
+
+    trail: list[tuple[str, str | None]] = [("Home", _page_url("Home"))]
+    for step in MISSION_STEPS:
+        trail.append((f"{step.icon} {step.label}", _page_url(step.page)))
+        if step.key == current_step_key:
+            break
+
+    if extra:
+        trail.extend((label, url) for label, url in extra)
+
+    if not trail:
+        return
+
+    fragments: list[str] = []
+    for idx, (label, url) in enumerate(trail):
+        if idx:
+            fragments.append('<span>›</span>')
+        if url and idx < len(trail) - 1:
+            fragments.append(f'<a href="{url}">{label}</a>')
+        else:
+            fragments.append(f'<span>{label}</span>')
+
+    st.markdown(
+        f"<nav class='mission-breadcrumbs'>{''.join(fragments)}</nav>",
+        unsafe_allow_html=True,
+    )
+

--- a/app/modules/ui_blocks.py
+++ b/app/modules/ui_blocks.py
@@ -10,20 +10,25 @@ def _theme_path() -> Path:
     return Path(__file__).resolve().parents[1] / "static" / "theme.css"
 
 
-def load_theme() -> None:
-    """Inject the shared Rex-AI theme CSS once per Streamlit session."""
+def load_theme(show_hud: bool = True) -> None:
+    """Inject the shared Rex-AI theme CSS once per Streamlit session and Mission HUD."""
 
-    if st.session_state.get(_THEME_KEY):
-        return
+    theme_loaded = st.session_state.get(_THEME_KEY)
+    if not theme_loaded:
+        theme_file = _theme_path()
+        try:
+            css = theme_file.read_text(encoding="utf-8")
+        except FileNotFoundError:
+            css = ""
 
-    theme_file = _theme_path()
-    try:
-        css = theme_file.read_text(encoding="utf-8")
-    except FileNotFoundError:
-        return
+        if css:
+            st.markdown(f"<style>{css}</style>", unsafe_allow_html=True)
+        st.session_state[_THEME_KEY] = True
 
-    st.markdown(f"<style>{css}</style>", unsafe_allow_html=True)
-    st.session_state[_THEME_KEY] = True
+    if show_hud:
+        from app.modules.navigation import render_mission_hud
+
+        render_mission_hud()
 
 
 def inject_css():

--- a/app/pages/0_Project_Brief.py
+++ b/app/pages/0_Project_Brief.py
@@ -4,12 +4,15 @@ import _bootstrap  # noqa: F401
 import streamlit as st
 from pathlib import Path
 
+from app.modules.navigation import set_active_step
 from app.modules.ui_blocks import load_theme
 
 repo_root = Path(__file__).resolve().parents[2]
 
 # ⚠️ PRIMER comando Streamlit:
 st.set_page_config(page_title="REX-AI Mars — Brief", page_icon="🛰️", layout="wide")
+
+set_active_step("brief")
 
 load_theme()
 
@@ -53,17 +56,10 @@ with c2:
     st.write("Targets:", "✅" if tgt_ok else "❌")
 with c3:
     st.subheader("Navegación")
-    colA, colB = st.columns(2)
-    with colA:
-        if st.button("🧱 1) Inventario"):
-            st.switch_page("pages/1_Inventory_Builder.py")
-        if st.button("⚙️ 3) Generador"):
-            st.switch_page("pages/3_Generator.py")
-    with colB:
-        if st.button("🎯 2) Objetivo"):
-            st.switch_page("pages/2_Target_Designer.py")
-        if st.button("📊 4) Resultados"):
-            st.switch_page("pages/4_Results_and_Tradeoffs.py")
+    st.markdown(
+        "Usá la barra superior **Mission HUD** o las teclas `1-9` para saltar de paso.\n"
+        "También podés abrir la barra lateral estándar de Streamlit para ver todas las páginas."
+    )
 
 st.divider()
 st.info(

--- a/app/pages/1_Inventory_Builder.py
+++ b/app/pages/1_Inventory_Builder.py
@@ -3,6 +3,8 @@ import _bootstrap  # noqa: F401
 import streamlit as st
 import pandas as pd
 from app.modules.io import load_waste_df, save_waste_df
+from app.modules.navigation import set_active_step
+from app.modules.ui_blocks import load_theme
 
 _SAVE_SUCCESS_FLAG = "_inventory_save_success"
 
@@ -16,6 +18,10 @@ def _trigger_rerun() -> None:
 
 # ⚠️ Debe ser la PRIMERA llamada de Streamlit en la página
 st.set_page_config(page_title="Inventario", page_icon="🧱", layout="wide")
+
+set_active_step("inventory")
+
+load_theme()
 
 if st.session_state.pop(_SAVE_SUCCESS_FLAG, False):
     st.success("Inventario guardado.")

--- a/app/pages/2_Target_Designer.py
+++ b/app/pages/2_Target_Designer.py
@@ -6,7 +6,14 @@ import streamlit as st
 st.set_page_config(page_title="Objetivo", page_icon="🎯", layout="wide")
 
 from app.modules.io import load_targets
-from app.modules.ui_blocks import section
+from app.modules.navigation import render_breadcrumbs, set_active_step
+from app.modules.ui_blocks import load_theme, section
+
+set_active_step("target")
+
+load_theme()
+
+render_breadcrumbs("target")
 
 st.title("2) Definir objetivo (TargetSpec)")
 

--- a/app/pages/3_Generator.py
+++ b/app/pages/3_Generator.py
@@ -9,13 +9,18 @@ import streamlit as st
 from app.modules.generator import generate_candidates
 from app.modules.io import load_waste_df, load_process_df  # si tu IO usa load_process_catalog, cámbialo aquí
 from app.modules.ml_models import get_model_registry
+from app.modules.navigation import render_breadcrumbs, set_active_step
 from app.modules.process_planner import choose_process
 from app.modules.safety import check_safety, safety_badge
 from app.modules.ui_blocks import load_theme
 
 st.set_page_config(page_title="Rex-AI • Generador", page_icon="🤖", layout="wide")
 
+set_active_step("generator")
+
 load_theme()
+
+render_breadcrumbs("generator")
 
 # ----------------------------- CSS local -----------------------------
 st.markdown(

--- a/app/pages/4_Results_and_Tradeoffs.py
+++ b/app/pages/4_Results_and_Tradeoffs.py
@@ -5,6 +5,7 @@ import pandas as pd
 import plotly.graph_objects as go
 import streamlit as st
 
+from app.modules.navigation import render_breadcrumbs, set_active_step
 from app.modules.ui_blocks import load_theme
 
 from app.modules.data_sources import (
@@ -16,7 +17,11 @@ from app.modules.explain import score_breakdown
 
 st.set_page_config(page_title="Rex-AI • Resultados", page_icon="📊", layout="wide")
 
+set_active_step("results")
+
 load_theme()
+
+render_breadcrumbs("results")
 
 selected = st.session_state.get("selected")
 target = st.session_state.get("target")

--- a/app/pages/5_Compare_and_Explain.py
+++ b/app/pages/5_Compare_and_Explain.py
@@ -6,12 +6,17 @@ import plotly.express as px
 import plotly.graph_objects as go
 
 from app.modules.explain import compare_table, score_breakdown
+from app.modules.navigation import render_breadcrumbs, set_active_step
 from app.modules.ui_blocks import load_theme
 
 # ⚠️ Debe ser la PRIMERA llamada de Streamlit en la página
 st.set_page_config(page_title="Comparar & Explicar", page_icon="🧪", layout="wide")
 
+set_active_step("compare")
+
 load_theme()
+
+render_breadcrumbs("compare")
 
 # ======== estado requerido ========
 cands  = st.session_state.get("candidates", [])

--- a/app/pages/6_Pareto_and_Export.py
+++ b/app/pages/6_Pareto_and_Export.py
@@ -7,16 +7,21 @@ import pandas as pd
 import plotly.express as px
 import plotly.graph_objects as go
 
-from app.modules.explain import compare_table
 from app.modules.analytics import pareto_front
+from app.modules.explain import compare_table
 from app.modules.exporters import candidate_to_json, candidate_to_csv
+from app.modules.navigation import render_breadcrumbs, set_active_step
 from app.modules.safety import check_safety  # recalcular badge al seleccionar
 from app.modules.ui_blocks import load_theme
 
 # ⚠️ PRIMERA llamada
 st.set_page_config(page_title="Pareto & Export", page_icon="📤", layout="wide")
 
+set_active_step("export")
+
 load_theme()
+
+render_breadcrumbs("export")
 
 # ======== estado requerido ========
 cands  = st.session_state.get("candidates", [])

--- a/app/pages/7_Scenario_Playbooks.py
+++ b/app/pages/7_Scenario_Playbooks.py
@@ -4,13 +4,18 @@ import _bootstrap  # noqa: F401
 import streamlit as st
 import pandas as pd
 
+from app.modules.navigation import render_breadcrumbs, set_active_step
 from app.modules.scenarios import PLAYBOOKS  # dict: {scenario: Playbook(name, summary, steps=[...])}
 from app.modules.ui_blocks import load_theme
 
 # ⚠️ Debe ser la primera llamada
 st.set_page_config(page_title="Scenario Playbooks", page_icon="📚", layout="wide")
 
+set_active_step("playbooks")
+
 load_theme()
+
+render_breadcrumbs("playbooks")
 
 # ======== Estado compartido ========
 target      = st.session_state.get("target", None)

--- a/app/pages/8_Feedback_and_Impact.py
+++ b/app/pages/8_Feedback_and_Impact.py
@@ -3,11 +3,16 @@ import _bootstrap  # noqa: F401
 
 # ⚠️ Debe ser la PRIMERA llamada Streamlit:
 import streamlit as st
+from app.modules.navigation import render_breadcrumbs, set_active_step
 from app.modules.ui_blocks import load_theme
 
 st.set_page_config(page_title="Feedback & Impact", page_icon="📝", layout="wide")
 
+set_active_step("feedback")
+
 load_theme()
+
+render_breadcrumbs("feedback")
 
 import json
 import pandas as pd

--- a/app/pages/9_Capacity_Simulator.py
+++ b/app/pages/9_Capacity_Simulator.py
@@ -3,11 +3,16 @@ import _bootstrap  # noqa: F401
 
 # ⚠️ Debe ser la PRIMERA llamada de Streamlit
 import streamlit as st
+from app.modules.navigation import render_breadcrumbs, set_active_step
 from app.modules.ui_blocks import load_theme
 
 st.set_page_config(page_title="Capacity Simulator", page_icon="🧮", layout="wide")
 
+set_active_step("capacity")
+
 load_theme()
+
+render_breadcrumbs("capacity")
 
 import math
 import numpy as np


### PR DESCRIPTION
## Summary
- implement a reusable Mission HUD module with step progress, model status, contextual CTAs, animations, and keyboard shortcuts
- inject the HUD from the shared theme loader and add breadcrumb helpers so every page highlights the active mission step
- update all mission pages to adopt the HUD navigation and remove redundant button-based navigation in favour of the new experience

## Testing
- python -m compileall app/modules/navigation.py
- python -m compileall app/pages


------
https://chatgpt.com/codex/tasks/task_e_68dad5eb87cc83318fc27226e3cc3521