### PR TITLE
Add accessible theme HUD and contrast regression tests

### DIFF
--- a/app/Home.py
+++ b/app/Home.py
@@ -39,24 +39,24 @@ st.markdown(
     .chip-row {display:flex; gap:8px; margin-top: 18px; flex-wrap:wrap;}
     .chip {
       padding:6px 14px; border-radius:999px; font-size:0.82rem; font-weight:600;
-      background: rgba(15,23,42,0.6); border: 1px solid rgba(96,165,250,0.35); color: var(--ink);
+      background: var(--chip-bg); border: 1px solid var(--chip-border); color: var(--chip-ink);
     }
     .ghost-card {
       margin-top: 38px; display:grid; gap:18px; grid-template-columns: repeat(auto-fit,minmax(260px,1fr));
     }
     .ghost-card > div {
-      padding:20px 22px; border-radius:20px; border:1px solid var(--stroke);
-      background: var(--card); color: var(--ink);
+      padding:20px 22px; border-radius:20px; border:1px solid var(--border-soft);
+      background: var(--surface-card); color: var(--ink);
     }
     .ghost-card h3 {margin-bottom:6px; font-size:1.05rem;}
     .ghost-card p {color: var(--muted); font-size:0.94rem; margin:0;}
     .stepper {display:grid; grid-template-columns: repeat(auto-fit,minmax(180px,1fr)); gap:14px; margin: 32px 0 18px;}
-    .step {border-radius:18px; border:1px solid var(--stroke); padding:16px 18px; background: rgba(13,17,23,0.6);}
-    .step span {display:inline-flex; width:32px; height:32px; border-radius:999px; align-items:center; justify-content:center; background: rgba(96,165,250,0.24); color: var(--ink); font-weight:700; margin-bottom:10px;}
+    .step {border-radius:18px; border:1px solid var(--step-border); padding:16px 18px; background: var(--step-bg);}
+    .step span {display:inline-flex; width:32px; height:32px; border-radius:999px; align-items:center; justify-content:center; background: var(--step-icon-bg); color: var(--ink); font-weight:700; margin-bottom:10px;}
     .step h4 {margin:0 0 6px 0;}
     .step p {color: var(--muted); font-size:0.9rem; margin:0;}
     .metric-grid {display:grid; grid-template-columns: repeat(auto-fit,minmax(210px,1fr)); gap:16px; margin-top: 18px;}
-    .metric {border-radius:18px; padding:18px 20px; background:rgba(15,23,42,0.6); border:1px solid var(--stroke); color:var(--ink);}
+    .metric {border-radius:18px; padding:18px 20px; background:var(--metric-bg); border:1px solid var(--metric-border); color:var(--ink); box-shadow: var(--metric-shadow);}
     .metric h5 {margin:0; font-size:0.92rem; color:var(--muted);}
     .metric strong {font-size:1.4rem; display:block; margin-top:6px;}
     .timeline {margin-top: 28px;}

--- a/app/modules/luxe_components.py
+++ b/app/modules/luxe_components.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from typing import Iterable, Literal
+
+import streamlit as st
+
+_THEME_STATE_KEY = "hud_theme"
+_COLORBLIND_STATE_KEY = "hud_colorblind"
+
+
+def _current_theme() -> str:
+    return st.session_state.get(_THEME_STATE_KEY, "dark")
+
+
+def _is_high_contrast() -> bool:
+    return "high-contrast" in _current_theme()
+
+
+def _is_colorblind_mode() -> bool:
+    return st.session_state.get(_COLORBLIND_STATE_KEY, "normal") != "normal"
+
+
+def _class_names(*tokens: Iterable[str]) -> str:
+    classes: list[str] = []
+    for token in tokens:
+        if isinstance(token, str):
+            classes.append(token)
+        else:
+            classes.extend(t for t in token if t)
+    return " ".join(cls for cls in classes if cls)
+
+
+def render_card(title: str, body: str = "") -> str:
+    classes = ["card"]
+    if _is_high_contrast():
+        classes.append("card-flat")
+
+    body_html = f'<div class="small">{body}</div>' if body else ""
+    return f'<div class="{_class_names(classes)}"><h4>{title}</h4>{body_html}</div>'
+
+
+def render_pill(label: str, kind: Literal["ok", "warn", "risk"] = "ok") -> str:
+    tone_map = {
+        "ok": ("ok",),
+        "warn": ("warn", "med"),
+        "risk": ("risk", "bad"),
+    }
+    classes = ["pill", *tone_map.get(kind, ("ok",))]
+    if _is_colorblind_mode():
+        classes.append("pill-solid")
+    return f'<span class="{_class_names(classes)}">{label}</span>'

--- a/app/modules/ui_blocks.py
+++ b/app/modules/ui_blocks.py
@@ -1,44 +1,164 @@
+from __future__ import annotations
+
+import hashlib
 from pathlib import Path
 from typing import Literal
 
 import streamlit as st
 
-_THEME_KEY = "__rexai_theme_loaded__"
+from . import luxe_components as luxe
+
+_THEME_HASH_KEY = "__rexai_theme_hash__"
+_THEME_STATE_KEY = "hud_theme"
+_FONT_STATE_KEY = "hud_font"
+_COLORBLIND_STATE_KEY = "hud_colorblind"
+
+_THEME_LABELS = {
+    "dark": "Oscuro",
+    "dark-high-contrast": "Oscuro · Alto contraste",
+    "light": "Claro",
+    "light-high-contrast": "Claro · Alto contraste",
+    "solarized": "Solarized",
+}
+
+_FONT_LABELS = {
+    "base": "Base",
+    "large": "Grande",
+    "xlarge": "XL",
+}
+
+_COLORBLIND_LABELS = {
+    "normal": "Sin ajustes",
+    "safe": "Daltonismo (paleta segura)",
+}
+
+
+def _static_path(filename: str) -> Path:
+    return Path(__file__).resolve().parents[1] / "static" / filename
 
 
 def _theme_path() -> Path:
-    return Path(__file__).resolve().parents[1] / "static" / "theme.css"
+    return _static_path("theme.css")
 
 
-def load_theme() -> None:
-    """Inject the shared Rex-AI theme CSS once per Streamlit session."""
+def _tokens_path() -> Path:
+    return _static_path("design_tokens.css")
 
-    if st.session_state.get(_THEME_KEY):
+
+def _ensure_defaults() -> None:
+    st.session_state.setdefault(_THEME_STATE_KEY, "dark")
+    st.session_state.setdefault(_FONT_STATE_KEY, "base")
+    st.session_state.setdefault(_COLORBLIND_STATE_KEY, "normal")
+
+
+def _read_css_bundle() -> str:
+    css_parts: list[str] = []
+    for path in (_tokens_path(), _theme_path()):
+        try:
+            css_parts.append(path.read_text(encoding="utf-8"))
+        except FileNotFoundError:
+            continue
+    return "\n".join(css_parts)
+
+
+def _inject_css_once(css: str) -> None:
+    if not css:
         return
 
-    theme_file = _theme_path()
-    try:
-        css = theme_file.read_text(encoding="utf-8")
-    except FileNotFoundError:
+    css_hash = hashlib.sha256(css.encode("utf-8")).hexdigest()
+    if st.session_state.get(_THEME_HASH_KEY) == css_hash:
         return
 
     st.markdown(f"<style>{css}</style>", unsafe_allow_html=True)
-    st.session_state[_THEME_KEY] = True
+    st.session_state[_THEME_HASH_KEY] = css_hash
 
 
-def inject_css():
+def _apply_runtime_theme() -> None:
+    theme = st.session_state.get(_THEME_STATE_KEY, "dark")
+    font = st.session_state.get(_FONT_STATE_KEY, "base")
+    colorblind = st.session_state.get(_COLORBLIND_STATE_KEY, "normal")
+
+    script = f"""
+    <script>
+    const doc = window.parent?.document ?? document;
+    const body = doc.body;
+    if (body) {{
+      body.setAttribute('data-rexai-theme', '{theme}');
+      body.setAttribute('data-rexai-font', '{font}');
+      body.setAttribute('data-rexai-colorblind', '{colorblind}');
+    }}
+    const appRoot = doc.querySelector('.stApp');
+    if (appRoot) {{
+      appRoot.setAttribute('data-rexai-theme', '{theme}');
+      appRoot.setAttribute('data-rexai-font', '{font}');
+      appRoot.setAttribute('data-rexai-colorblind', '{colorblind}');
+    }}
+    </script>
+    """
+    st.markdown(script, unsafe_allow_html=True)
+
+
+def _render_hud() -> None:
+    hud_container = st.container()
+    with hud_container:
+        st.markdown('<div class="rexai-hud">', unsafe_allow_html=True)
+        st.markdown('<div class="rexai-hud__title">HUD · Accesibilidad</div>', unsafe_allow_html=True)
+        cols = st.columns(3)
+        with cols[0]:
+            st.selectbox(
+                "Tema",
+                options=list(_THEME_LABELS.keys()),
+                format_func=lambda value: _THEME_LABELS.get(value, value),
+                key=_THEME_STATE_KEY,
+                help="Ajustá contraste y estética base.",
+            )
+        with cols[1]:
+            st.radio(
+                "Tipografía",
+                options=list(_FONT_LABELS.keys()),
+                format_func=lambda value: _FONT_LABELS.get(value, value),
+                key=_FONT_STATE_KEY,
+                horizontal=True,
+                help="Escala de fuente para lectura cómoda.",
+            )
+        with cols[2]:
+            st.selectbox(
+                "Modo daltónico",
+                options=list(_COLORBLIND_LABELS.keys()),
+                format_func=lambda value: _COLORBLIND_LABELS.get(value, value),
+                key=_COLORBLIND_STATE_KEY,
+                help="Paleta optimizada para protanopia/deuteranopia.",
+            )
+        st.markdown('</div>', unsafe_allow_html=True)
+
+
+def load_theme(*, show_hud: bool = True) -> None:
+    """Inject shared CSS and expose HUD toggles for the Rex-AI theme."""
+
+    _ensure_defaults()
+    css_bundle = _read_css_bundle()
+    _inject_css_once(css_bundle)
+    _apply_runtime_theme()
+
+    if show_hud:
+        _render_hud()
+
+
+def inject_css(show_hud: bool = False) -> None:
     """Backward-compatible alias for legacy code paths."""
 
-    load_theme()
+    load_theme(show_hud=show_hud)
 
-def card(title:str, body:str=""):
-    st.markdown(f"""<div class="card"><h4>{title}</h4><div class="small">{body}</div></div>""", unsafe_allow_html=True)
 
-def pill(label:str, kind:Literal["ok","warn","risk"]="ok"):
-    klass = {"ok":"badge-ok","warn":"badge-warn","risk":"badge-risk"}[kind]
-    st.markdown(f"""<span class="pill {klass}">{label}</span>""", unsafe_allow_html=True)
+def card(title: str, body: str = "") -> None:
+    st.markdown(luxe.render_card(title, body), unsafe_allow_html=True)
 
-def section(title:str, subtitle:str=""):
+
+def pill(label: str, kind: Literal["ok", "warn", "risk"] = "ok") -> None:
+    st.markdown(luxe.render_pill(label, kind), unsafe_allow_html=True)
+
+
+def section(title: str, subtitle: str = "") -> None:
     st.subheader(title)
     if subtitle:
         st.caption(subtitle)

--- a/app/static/design_tokens.css
+++ b/app/static/design_tokens.css
@@ -1,0 +1,299 @@
+:root {
+  color-scheme: dark;
+  --bg: #0b0d12;
+  --surface-panel: #101724;
+  --surface-card: #141c2a;
+  --card: #141c2a;
+  --surface-ghost: #1c2636;
+  --stroke: #1f2a3c;
+  --bd: #243042;
+  --border-soft: #243042;
+  --border-strong: #31405a;
+  --accent: #5aa9ff;
+  --accent-soft: #93c5fd;
+  --ink: #f8fafc;
+  --muted: #b8c3d5;
+  --hero-background: linear-gradient(135deg, rgba(59,130,246,0.22), rgba(59,130,246,0.05)), linear-gradient(180deg, rgba(15,23,42,0.9), rgba(15,23,42,0.72));
+  --hero-border: #3b82f6;
+  --chip-bg: #16243a;
+  --chip-border: #243a5f;
+  --chip-ink: #f1f5ff;
+  --step-bg: #101a2a;
+  --step-border: #223551;
+  --step-icon-bg: rgba(90, 169, 255, 0.24);
+  --metric-bg: #101a2a;
+  --metric-border: #223551;
+  --metric-shadow: 0 18px 32px rgba(4, 8, 20, 0.45);
+  --shadow-card: 0 24px 48px rgba(4, 8, 20, 0.45);
+  --shadow-flat: none;
+  --tone-ok-bg: #123829;
+  --tone-ok-fg: #63f0a5;
+  --tone-ok-border: #1f6141;
+  --tone-warn-bg: #3f2a0f;
+  --tone-warn-fg: #f2c057;
+  --tone-warn-border: #7a5b1f;
+  --tone-risk-bg: #3d1518;
+  --tone-risk-fg: #f18882;
+  --tone-risk-border: #7a2b36;
+  --badge-ok: #2dd4bf;
+  --badge-warn: #f59e0b;
+  --badge-risk: #fb7185;
+  --pill-bg: transparent;
+}
+
+body {
+  --font-scale: 1;
+}
+
+body[data-rexai-theme="dark"],
+.stApp[data-rexai-theme="dark"] {
+  color-scheme: dark;
+  --bg: #0b0d12;
+  --surface-panel: #101724;
+  --surface-card: #141c2a;
+  --card: #141c2a;
+  --surface-ghost: #1c2636;
+  --stroke: #1f2a3c;
+  --bd: #243042;
+  --border-soft: #243042;
+  --border-strong: #31405a;
+  --accent: #5aa9ff;
+  --accent-soft: #93c5fd;
+  --ink: #f8fafc;
+  --muted: #b8c3d5;
+  --hero-background: linear-gradient(135deg, rgba(59,130,246,0.22), rgba(59,130,246,0.05)), linear-gradient(180deg, rgba(15,23,42,0.9), rgba(15,23,42,0.72));
+  --hero-border: #3b82f6;
+  --chip-bg: #16243a;
+  --chip-border: #243a5f;
+  --chip-ink: #f1f5ff;
+  --step-bg: #101a2a;
+  --step-border: #223551;
+  --step-icon-bg: rgba(90, 169, 255, 0.24);
+  --metric-bg: #101a2a;
+  --metric-border: #223551;
+  --metric-shadow: 0 18px 32px rgba(4, 8, 20, 0.45);
+  --shadow-card: 0 24px 48px rgba(4, 8, 20, 0.45);
+  --shadow-flat: none;
+  --tone-ok-bg: #123829;
+  --tone-ok-fg: #63f0a5;
+  --tone-ok-border: #1f6141;
+  --tone-warn-bg: #3f2a0f;
+  --tone-warn-fg: #f2c057;
+  --tone-warn-border: #7a5b1f;
+  --tone-risk-bg: #3d1518;
+  --tone-risk-fg: #f18882;
+  --tone-risk-border: #7a2b36;
+  --badge-ok: #2dd4bf;
+  --badge-warn: #f59e0b;
+  --badge-risk: #fb7185;
+  --pill-bg: transparent;
+}
+
+body[data-rexai-theme="dark-high-contrast"],
+.stApp[data-rexai-theme="dark-high-contrast"] {
+  color-scheme: dark;
+  --bg: #010409;
+  --surface-panel: #060b14;
+  --surface-card: #0a1220;
+  --card: #0a1220;
+  --surface-ghost: #0f1b2c;
+  --stroke: #3b82f6;
+  --bd: #3b82f6;
+  --border-soft: #3b82f6;
+  --border-strong: #60a5fa;
+  --accent: #1ea7ff;
+  --accent-soft: #82d3ff;
+  --ink: #ffffff;
+  --muted: #dbe6ff;
+  --hero-background: linear-gradient(135deg, rgba(59,130,246,0.22), rgba(59,130,246,0.05)), linear-gradient(180deg, rgba(15,23,42,0.9), rgba(15,23,42,0.72));
+  --hero-border: #3b82f6;
+  --chip-bg: #16243a;
+  --chip-border: #243a5f;
+  --chip-ink: #f1f5ff;
+  --step-bg: #101a2a;
+  --step-border: #223551;
+  --step-icon-bg: rgba(90, 169, 255, 0.24);
+  --metric-bg: #101a2a;
+  --metric-border: #223551;
+  --metric-shadow: none;
+  --shadow-card: none;
+  --shadow-flat: none;
+  --tone-ok-bg: #083d2b;
+  --tone-ok-fg: #7fffd4;
+  --tone-ok-border: #34d399;
+  --tone-warn-bg: #4a2a00;
+  --tone-warn-fg: #fbbf24;
+  --tone-warn-border: #f59e0b;
+  --tone-risk-bg: #470011;
+  --tone-risk-fg: #ff7b89;
+  --tone-risk-border: #fb7185;
+  --badge-ok: #34d399;
+  --badge-warn: #f59e0b;
+  --badge-risk: #fb7185;
+  --pill-bg: transparent;
+}
+
+body[data-rexai-theme="light"],
+.stApp[data-rexai-theme="light"] {
+  color-scheme: light;
+  --bg: #f4f7fb;
+  --surface-panel: #ffffff;
+  --surface-card: #ffffff;
+  --card: #ffffff;
+  --surface-ghost: #eef2ff;
+  --stroke: #d7def1;
+  --bd: #cfd7ef;
+  --border-soft: #cfd7ef;
+  --border-strong: #94a3b8;
+  --accent: #2563eb;
+  --accent-soft: #93c5fd;
+  --ink: #0f172a;
+  --muted: #4a5a7d;
+  --hero-background: linear-gradient(135deg, rgba(96,165,250,0.25), rgba(96,165,250,0.05)), linear-gradient(180deg, rgba(255,255,255,0.9), rgba(236,244,255,0.78));
+  --hero-border: #60a5fa;
+  --chip-bg: #e2e8f9;
+  --chip-border: #c3d4fb;
+  --chip-ink: #1e293b;
+  --step-bg: #e9effd;
+  --step-border: #c3d4fb;
+  --step-icon-bg: rgba(37, 99, 235, 0.18);
+  --metric-bg: #f1f4fc;
+  --metric-border: #cbd5f5;
+  --metric-shadow: 0 16px 32px rgba(15, 23, 42, 0.1);
+  --shadow-card: 0 24px 48px rgba(15, 23, 42, 0.12);
+  --shadow-flat: none;
+  --tone-ok-bg: #c6f6d5;
+  --tone-ok-fg: #1f5136;
+  --tone-ok-border: #38a169;
+  --tone-warn-bg: #fef3c7;
+  --tone-warn-fg: #854d0e;
+  --tone-warn-border: #f59e0b;
+  --tone-risk-bg: #fee2e2;
+  --tone-risk-fg: #991b1b;
+  --tone-risk-border: #f87171;
+  --badge-ok: #047857;
+  --badge-warn: #c2410c;
+  --badge-risk: #dc2626;
+  --pill-bg: transparent;
+}
+
+body[data-rexai-theme="light-high-contrast"],
+.stApp[data-rexai-theme="light-high-contrast"] {
+  color-scheme: light;
+  --bg: #ffffff;
+  --surface-panel: #f5faff;
+  --surface-card: #f5faff;
+  --card: #f5faff;
+  --surface-ghost: #e2ecff;
+  --stroke: #1e40af;
+  --bd: #1d4ed8;
+  --border-soft: #1d4ed8;
+  --border-strong: #1d4ed8;
+  --accent: #0f4cd6;
+  --accent-soft: #5f8dff;
+  --ink: #0b1526;
+  --muted: #1f2937;
+  --hero-background: linear-gradient(135deg, rgba(96,165,250,0.25), rgba(96,165,250,0.05)), linear-gradient(180deg, rgba(255,255,255,0.9), rgba(236,244,255,0.78));
+  --hero-border: #60a5fa;
+  --chip-bg: #e0ecff;
+  --chip-border: #1d4ed8;
+  --chip-ink: #0f172a;
+  --step-bg: #e9effd;
+  --step-border: #c3d4fb;
+  --step-icon-bg: rgba(15, 76, 214, 0.16);
+  --metric-bg: #f1f4fc;
+  --metric-border: #cbd5f5;
+  --metric-shadow: none;
+  --shadow-card: none;
+  --shadow-flat: none;
+  --tone-ok-bg: #bbf7d0;
+  --tone-ok-fg: #166534;
+  --tone-ok-border: #15803d;
+  --tone-warn-bg: #fde68a;
+  --tone-warn-fg: #92400e;
+  --tone-warn-border: #b45309;
+  --tone-risk-bg: #fecaca;
+  --tone-risk-fg: #7f1d1d;
+  --tone-risk-border: #b91c1c;
+  --badge-ok: #15803d;
+  --badge-warn: #b45309;
+  --badge-risk: #b91c1c;
+  --pill-bg: transparent;
+}
+
+body[data-rexai-theme="solarized"],
+.stApp[data-rexai-theme="solarized"] {
+  color-scheme: light;
+  --bg: #fdf6e3;
+  --surface-panel: #fefbf3;
+  --surface-card: #fefcf6;
+  --card: #fefcf6;
+  --surface-ghost: #f2e5c7;
+  --stroke: #e7dcbf;
+  --bd: #d9caa6;
+  --border-soft: #d9caa6;
+  --border-strong: #b5a273;
+  --accent: #268bd2;
+  --accent-soft: #2aa198;
+  --ink: #073642;
+  --muted: #596a72;
+  --hero-background: linear-gradient(135deg, rgba(38,139,210,0.2), rgba(38,139,210,0.05)), linear-gradient(180deg, rgba(253,246,227,0.92), rgba(249,240,213,0.78));
+  --hero-border: #268bd2;
+  --chip-bg: #ece3c5;
+  --chip-border: #d7c69a;
+  --chip-ink: #073642;
+  --step-bg: #f2e7c9;
+  --step-border: #d7c69a;
+  --step-icon-bg: rgba(38, 139, 210, 0.18);
+  --metric-bg: #f5ebd3;
+  --metric-border: #d7c69a;
+  --metric-shadow: 0 12px 24px rgba(7, 54, 66, 0.12);
+  --shadow-card: 0 20px 36px rgba(7, 54, 66, 0.18);
+  --shadow-flat: none;
+  --tone-ok-bg: #c8f1dc;
+  --tone-ok-fg: #1d5c3a;
+  --tone-ok-border: #3a9d6a;
+  --tone-warn-bg: #fee6b4;
+  --tone-warn-fg: #7c5416;
+  --tone-warn-border: #d48b1f;
+  --tone-risk-bg: #f9c0c0;
+  --tone-risk-fg: #8f1d2d;
+  --tone-risk-border: #d2565d;
+  --badge-ok: #2aa198;
+  --badge-warn: #cb4b16;
+  --badge-risk: #dc322f;
+  --pill-bg: transparent;
+}
+
+body[data-rexai-font="base"],
+.stApp[data-rexai-font="base"] {
+  --font-scale: 1;
+}
+
+body[data-rexai-font="large"],
+.stApp[data-rexai-font="large"] {
+  --font-scale: 1.12;
+}
+
+body[data-rexai-font="xlarge"],
+.stApp[data-rexai-font="xlarge"] {
+  --font-scale: 1.24;
+}
+
+body[data-rexai-colorblind="safe"],
+.stApp[data-rexai-colorblind="safe"] {
+  --accent: #0f7fb0;
+  --accent-soft: #5cb6d8;
+  --badge-ok: #20897a;
+  --badge-warn: #d9822b;
+  --badge-risk: #c4476d;
+  --tone-ok-bg: #1b4d3a;
+  --tone-ok-fg: #a4e9c0;
+  --tone-ok-border: #2c7a58;
+  --tone-warn-bg: #4a3b16;
+  --tone-warn-fg: #f2c14e;
+  --tone-warn-border: #b98020;
+  --tone-risk-bg: #4a2633;
+  --tone-risk-fg: #f29cb5;
+  --tone-risk-border: #a8516e;
+}

--- a/app/static/design_tokens.scss
+++ b/app/static/design_tokens.scss
@@ -1,0 +1,275 @@
+$theme-dark: (
+  color-scheme: dark,
+  bg: #0b0d12,
+  surface-panel: #101724,
+  surface-card: #141c2a,
+  card: #141c2a,
+  surface-ghost: #1c2636,
+  stroke: #1f2a3c,
+  bd: #243042,
+  border-soft: #243042,
+  border-strong: #31405a,
+  accent: #5aa9ff,
+  accent-soft: #93c5fd,
+  ink: #f8fafc,
+  muted: #b8c3d5,
+  hero-background: unquote("linear-gradient(135deg, rgba(59,130,246,0.22), rgba(59,130,246,0.05)), linear-gradient(180deg, rgba(15,23,42,0.9), rgba(15,23,42,0.72))"),
+  hero-border: #3b82f6,
+  chip-bg: #16243a,
+  chip-border: #243a5f,
+  chip-ink: #f1f5ff,
+  step-bg: #101a2a,
+  step-border: #223551,
+  step-icon-bg: rgba(90,169,255,0.24),
+  metric-bg: #101a2a,
+  metric-border: #223551,
+  metric-shadow: 0 18px 32px rgba(4,8,20,0.45),
+  shadow-card: 0 24px 48px rgba(4,8,20,0.45),
+  shadow-flat: none,
+  tone-ok-bg: #123829,
+  tone-ok-fg: #63f0a5,
+  tone-ok-border: #1f6141,
+  tone-warn-bg: #3f2a0f,
+  tone-warn-fg: #f2c057,
+  tone-warn-border: #7a5b1f,
+  tone-risk-bg: #3d1518,
+  tone-risk-fg: #f18882,
+  tone-risk-border: #7a2b36,
+  badge-ok: #2dd4bf,
+  badge-warn: #f59e0b,
+  badge-risk: #fb7185,
+  pill-bg: transparent
+);
+
+$theme-dark-high-contrast: map-merge(
+  $theme-dark,
+  (
+    bg: #010409,
+    surface-panel: #060b14,
+    surface-card: #0a1220,
+    card: #0a1220,
+    surface-ghost: #0f1b2c,
+    stroke: #3b82f6,
+    bd: #3b82f6,
+    border-soft: #3b82f6,
+    border-strong: #60a5fa,
+    accent: #1ea7ff,
+    accent-soft: #82d3ff,
+    ink: #ffffff,
+    muted: #dbe6ff,
+    metric-shadow: none,
+    shadow-card: none,
+    tone-ok-bg: #083d2b,
+    tone-ok-fg: #7fffd4,
+    tone-ok-border: #34d399,
+    tone-warn-bg: #4a2a00,
+    tone-warn-fg: #fbbf24,
+    tone-warn-border: #f59e0b,
+    tone-risk-bg: #470011,
+    tone-risk-fg: #ff7b89,
+    tone-risk-border: #fb7185,
+    badge-ok: #34d399,
+    badge-warn: #f59e0b,
+    badge-risk: #fb7185
+  )
+);
+
+$theme-light: (
+  color-scheme: light,
+  bg: #f4f7fb,
+  surface-panel: #ffffff,
+  surface-card: #ffffff,
+  card: #ffffff,
+  surface-ghost: #eef2ff,
+  stroke: #d7def1,
+  bd: #cfd7ef,
+  border-soft: #cfd7ef,
+  border-strong: #94a3b8,
+  accent: #2563eb,
+  accent-soft: #93c5fd,
+  ink: #0f172a,
+  muted: #4a5a7d,
+  hero-background: unquote("linear-gradient(135deg, rgba(96,165,250,0.25), rgba(96,165,250,0.05)), linear-gradient(180deg, rgba(255,255,255,0.9), rgba(236,244,255,0.78))"),
+  hero-border: #60a5fa,
+  chip-bg: #e2e8f9,
+  chip-border: #c3d4fb,
+  chip-ink: #1e293b,
+  step-bg: #e9effd,
+  step-border: #c3d4fb,
+  step-icon-bg: rgba(37,99,235,0.18),
+  metric-bg: #f1f4fc,
+  metric-border: #cbd5f5,
+  metric-shadow: 0 16px 32px rgba(15,23,42,0.1),
+  shadow-card: 0 24px 48px rgba(15,23,42,0.12),
+  shadow-flat: none,
+  tone-ok-bg: #c6f6d5,
+  tone-ok-fg: #1f5136,
+  tone-ok-border: #38a169,
+  tone-warn-bg: #fef3c7,
+  tone-warn-fg: #854d0e,
+  tone-warn-border: #f59e0b,
+  tone-risk-bg: #fee2e2,
+  tone-risk-fg: #991b1b,
+  tone-risk-border: #f87171,
+  badge-ok: #047857,
+  badge-warn: #c2410c,
+  badge-risk: #dc2626,
+  pill-bg: transparent
+);
+
+$theme-light-high-contrast: map-merge(
+  $theme-light,
+  (
+    bg: #ffffff,
+    surface-panel: #f5faff,
+    surface-card: #f5faff,
+    card: #f5faff,
+    surface-ghost: #e2ecff,
+    stroke: #1e40af,
+    bd: #1d4ed8,
+    border-soft: #1d4ed8,
+    border-strong: #1d4ed8,
+    accent: #0f4cd6,
+    accent-soft: #5f8dff,
+    ink: #0b1526,
+    muted: #1f2937,
+    chip-bg: #e0ecff,
+    chip-border: #1d4ed8,
+    chip-ink: #0f172a,
+    step-icon-bg: rgba(15,76,214,0.16),
+    metric-shadow: none,
+    shadow-card: none,
+    tone-ok-bg: #bbf7d0,
+    tone-ok-fg: #166534,
+    tone-ok-border: #15803d,
+    tone-warn-bg: #fde68a,
+    tone-warn-fg: #92400e,
+    tone-warn-border: #b45309,
+    tone-risk-bg: #fecaca,
+    tone-risk-fg: #7f1d1d,
+    tone-risk-border: #b91c1c,
+    badge-ok: #15803d,
+    badge-warn: #b45309,
+    badge-risk: #b91c1c
+  )
+);
+
+$theme-solarized: (
+  color-scheme: light,
+  bg: #fdf6e3,
+  surface-panel: #fefbf3,
+  surface-card: #fefcf6,
+  card: #fefcf6,
+  surface-ghost: #f2e5c7,
+  stroke: #e7dcbf,
+  bd: #d9caa6,
+  border-soft: #d9caa6,
+  border-strong: #b5a273,
+  accent: #268bd2,
+  accent-soft: #2aa198,
+  ink: #073642,
+  muted: #596a72,
+  hero-background: unquote("linear-gradient(135deg, rgba(38,139,210,0.2), rgba(38,139,210,0.05)), linear-gradient(180deg, rgba(253,246,227,0.92), rgba(249,240,213,0.78))"),
+  hero-border: #268bd2,
+  chip-bg: #ece3c5,
+  chip-border: #d7c69a,
+  chip-ink: #073642,
+  step-bg: #f2e7c9,
+  step-border: #d7c69a,
+  step-icon-bg: rgba(38,139,210,0.18),
+  metric-bg: #f5ebd3,
+  metric-border: #d7c69a,
+  metric-shadow: 0 12px 24px rgba(7,54,66,0.12),
+  shadow-card: 0 20px 36px rgba(7,54,66,0.18),
+  shadow-flat: none,
+  tone-ok-bg: #c8f1dc,
+  tone-ok-fg: #1d5c3a,
+  tone-ok-border: #3a9d6a,
+  tone-warn-bg: #fee6b4,
+  tone-warn-fg: #7c5416,
+  tone-warn-border: #d48b1f,
+  tone-risk-bg: #f9c0c0,
+  tone-risk-fg: #8f1d2d,
+  tone-risk-border: #d2565d,
+  badge-ok: #2aa198,
+  badge-warn: #cb4b16,
+  badge-risk: #dc322f,
+  pill-bg: transparent
+);
+
+$themes: (
+  dark: $theme-dark,
+  "dark-high-contrast": $theme-dark-high-contrast,
+  light: $theme-light,
+  "light-high-contrast": $theme-light-high-contrast,
+  solarized: $theme-solarized
+);
+
+$font-scales: (
+  base: 1,
+  large: 1.12,
+  xlarge: 1.24
+);
+
+$colorblind-safe: (
+  accent: #0f7fb0,
+  accent-soft: #5cb6d8,
+  badge-ok: #20897a,
+  badge-warn: #d9822b,
+  badge-risk: #c4476d,
+  tone-ok-bg: #1b4d3a,
+  tone-ok-fg: #a4e9c0,
+  tone-ok-border: #2c7a58,
+  tone-warn-bg: #4a3b16,
+  tone-warn-fg: #f2c14e,
+  tone-warn-border: #b98020,
+  tone-risk-bg: #4a2633,
+  tone-risk-fg: #f29cb5,
+  tone-risk-border: #a8516e
+);
+
+$colorblind-modes: (
+  normal: (),
+  safe: $colorblind-safe
+);
+
+@mixin emit-token-map($map) {
+  @each $key, $value in $map {
+    @if $key == color-scheme {
+      color-scheme: #{$value};
+    } @else {
+      --#{$key}: #{$value};
+    }
+  }
+}
+
+:root {
+  @include emit-token-map(map-get($themes, dark));
+}
+
+body {
+  --font-scale: 1;
+}
+
+@each $theme-name, $tokens in $themes {
+  body[data-rexai-theme="#{$theme-name}"],
+  .stApp[data-rexai-theme="#{$theme-name}"] {
+    @include emit-token-map($tokens);
+  }
+}
+
+@each $size, $scale in $font-scales {
+  body[data-rexai-font="#{$size}"],
+  .stApp[data-rexai-font="#{$size}"] {
+    --font-scale: #{$scale};
+  }
+}
+
+@each $mode, $tokens in $colorblind-modes {
+  @if length($tokens) > 0 {
+    body[data-rexai-colorblind="#{$mode}"],
+    .stApp[data-rexai-colorblind="#{$mode}"] {
+      @include emit-token-map($tokens);
+    }
+  }
+}

--- a/app/static/theme.css
+++ b/app/static/theme.css
@@ -1,131 +1,258 @@
 :root {
   --bg: #0b0d12;
-  --card: rgba(18, 21, 29, 0.72);
-  --stroke: rgba(255, 255, 255, 0.08);
-  --accent: #60a5fa;
   --ink: #f8fafc;
-  --muted: rgba(226, 232, 240, 0.68);
-  --bd: rgba(140, 140, 160, 0.28);
-  --hero-background: radial-gradient(900px 260px at 25% -10%, rgba(80, 120, 255, 0.10), transparent);
+  --muted: #b8c3d5;
+  --border-soft: #243042;
+  --border-strong: #31405a;
+  --card: #141c2a;
+  --shadow-card: 0 24px 48px rgba(4, 8, 20, 0.45);
+  --shadow-flat: none;
+  --hero-background: radial-gradient(900px 260px at 25% -10%, rgba(80, 120, 255, 0.1), transparent);
+  --hero-border: #3b82f6;
+  --chip-bg: #16243a;
+  --chip-border: #243a5f;
+  --chip-ink: #f1f5ff;
+  --step-bg: #101a2a;
+  --step-border: #223551;
+  --metric-bg: #101a2a;
+  --metric-border: #223551;
+  --metric-shadow: 0 18px 32px rgba(4, 8, 20, 0.45);
+  --tone-ok-bg: #123829;
+  --tone-ok-fg: #63f0a5;
+  --tone-ok-border: #1f6141;
+  --tone-warn-bg: #3f2a0f;
+  --tone-warn-fg: #f2c057;
+  --tone-warn-border: #7a5b1f;
+  --tone-risk-bg: #3d1518;
+  --tone-risk-fg: #f18882;
+  --tone-risk-border: #7a2b36;
+  --badge-ok: #2dd4bf;
+  --badge-warn: #f59e0b;
+  --badge-risk: #fb7185;
+  --pill-bg: transparent;
+  --font-scale: 1;
+  --transition-quick: 140ms;
 }
 
 body {
   background: var(--bg);
+  color: var(--ink);
+  font-size: calc(1rem * var(--font-scale, 1));
+  transition: background-color var(--transition-quick, 140ms) ease, color var(--transition-quick, 140ms) ease;
+}
+
+body, .stApp {
+  font-feature-settings: "liga" on;
+}
+
+.stApp {
+  background: transparent;
 }
 
 .block-container {
   padding: 2.6rem 3rem 3rem 3rem;
 }
 
-.hero {
-  border: 1px solid var(--bd);
+.rexai-hud {
   border-radius: 18px;
-  padding: 18px;
+  border: 1px solid var(--border-soft);
+  background: var(--surface-card, var(--card));
+  box-shadow: var(--shadow-card);
+  padding: 0.75rem 1.3rem 0.6rem;
+  margin-bottom: 1.2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+body[data-rexai-theme*="high-contrast"] .rexai-hud,
+.stApp[data-rexai-theme*="high-contrast"] .rexai-hud {
+  box-shadow: none;
+  border-color: var(--border-strong);
+}
+
+.rexai-hud__title {
+  font-size: 0.82rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  font-weight: 700;
+  color: var(--muted);
+}
+
+.rexai-hud__columns {
+  display: flex;
+  gap: 1.2rem;
+  flex-wrap: wrap;
+}
+
+.rexai-hud__column {
+  flex: 1 1 220px;
+}
+
+.rexai-hud__column label {
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--muted);
+  font-weight: 600;
+}
+
+.rexai-hud__column .stRadio > label {
+  width: 100%;
+}
+
+.rexai-hud__column .stRadio [data-baseweb="radio"] label {
+  color: var(--ink);
+}
+
+.hero {
+  border: 1px solid var(--hero-border, var(--border-soft));
+  border-radius: 22px;
+  padding: 20px 22px;
   background: var(--hero-background);
+  box-shadow: var(--shadow-card);
+  transition: background var(--transition-quick) ease, border-color var(--transition-quick) ease;
 }
 
 .block {
-  border: 1px solid var(--bd);
+  border: 1px solid var(--border-soft);
   border-radius: 16px;
   padding: 16px;
+  background: var(--surface-panel, transparent);
 }
 
 .card {
-  background: #151a21;
-  border: 1px solid #242c37;
+  background: var(--card, var(--surface-card));
+  border: 1px solid var(--border-soft);
   border-radius: 16px;
   padding: 18px;
   margin-bottom: 12px;
+  box-shadow: var(--shadow-card);
+  transition: background var(--transition-quick) ease, border-color var(--transition-quick) ease, box-shadow var(--transition-quick) ease;
+}
+
+.card.card-flat {
+  box-shadow: var(--shadow-flat, none);
+  border-color: var(--border-strong);
+}
+
+.kpi,
+.metric {
+  border: 1px solid var(--metric-border, var(--border-soft));
+  border-radius: 18px;
+  padding: 18px;
+  background: var(--metric-bg, var(--surface-card));
+  box-shadow: var(--metric-shadow, var(--shadow-card));
+  transition: background var(--transition-quick) ease, border-color var(--transition-quick) ease, box-shadow var(--transition-quick) ease;
 }
 
 .kpi {
-  border: 1px solid var(--bd);
-  border-radius: 14px;
-  padding: 14px;
   margin-bottom: 10px;
 }
 
-.kpi h3 {
+.kpi h3,
+.metric h5 {
   margin: 0 0 6px 0;
-  font-size: 0.95rem;
-  opacity: 0.8;
+  font-size: calc(0.92rem * var(--font-scale, 1));
+  color: var(--muted);
 }
 
 .kpi .v {
-  font-size: 1.6rem;
+  font-size: calc(1.6rem * var(--font-scale, 1));
   font-weight: 800;
   letter-spacing: 0.2px;
 }
 
 .kpi .hint {
-  font-size: 0.85rem;
-  opacity: 0.75;
+  font-size: calc(0.85rem * var(--font-scale, 1));
+  color: var(--muted);
 }
 
 .pill {
-  display: inline-block;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
   padding: 4px 10px;
   border-radius: 999px;
   font-weight: 700;
-  font-size: 0.78rem;
-  border: 1px solid var(--bd);
+  font-size: calc(0.78rem * var(--font-scale, 1));
+  border: 1px solid var(--border-soft);
   margin-right: 6px;
+  background: var(--pill-bg, transparent);
+  color: var(--ink);
+  transition: background var(--transition-quick) ease, border-color var(--transition-quick) ease, color var(--transition-quick) ease;
 }
 
 .pill.ok {
-  background: #e8f7ee;
-  color: #136c3a;
-  border-color: #b3e2c4;
-}
-
-.pill.info {
-  background: #e7f1ff;
-  color: #174ea6;
-  border-color: #c6dcff;
+  background: var(--tone-ok-bg);
+  color: var(--tone-ok-fg);
+  border-color: var(--tone-ok-border);
 }
 
 .pill.warn,
 .pill.med {
-  background: #fff3cd;
-  color: #8a6d1d;
-  border-color: #ffe69b;
+  background: var(--tone-warn-bg);
+  color: var(--tone-warn-fg);
+  border-color: var(--tone-warn-border);
 }
 
-.pill.bad {
-  background: #fdeceb;
-  color: #8b1b13;
-  border-color: #f5c2c0;
+.pill.bad,
+.pill.risk {
+  background: var(--tone-risk-bg);
+  color: var(--tone-risk-fg);
+  border-color: var(--tone-risk-border);
 }
 
-.small {
-  font-size: 0.92rem;
-  opacity: 0.9;
+.pill.pill-solid {
+  border-width: 2px;
 }
 
+.small,
 .legend {
-  font-size: 0.9rem;
-  opacity: 0.8;
+  font-size: calc(0.9rem * var(--font-scale, 1));
+  color: var(--muted);
 }
 
 hr {
   border: none;
   height: 1px;
-  background: var(--bd);
+  background: var(--border-soft);
   margin: 8px 0 16px 0;
 }
 
 table {
-  font-size: 0.95rem;
+  font-size: calc(0.95rem * var(--font-scale, 1));
 }
 
 .badge-ok {
-  color: #0fd68b;
+  color: var(--badge-ok);
 }
 
 .badge-warn {
-  color: #f39c12;
+  color: var(--badge-warn);
 }
 
 .badge-risk {
-  color: #e74c3c;
+  color: var(--badge-risk);
+}
+
+body[data-rexai-font="large"],
+body[data-rexai-font="xlarge"],
+.stApp[data-rexai-font="large"],
+.stApp[data-rexai-font="xlarge"] {
+  line-height: 1.55;
+}
+
+body[data-rexai-theme*="high-contrast"] .card,
+body[data-rexai-theme*="high-contrast"] .kpi,
+body[data-rexai-theme*="high-contrast"] .metric,
+.stApp[data-rexai-theme*="high-contrast"] .card,
+.stApp[data-rexai-theme*="high-contrast"] .kpi,
+.stApp[data-rexai-theme*="high-contrast"] .metric {
+  box-shadow: none;
+}
+
+body[data-rexai-colorblind="safe"] .pill,
+.stApp[data-rexai-colorblind="safe"] .pill {
+  filter: saturate(0.92);
 }

--- a/tests/test_accessibility.py
+++ b/tests/test_accessibility.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Dict, Tuple
+
+CSS_PATH = Path(__file__).resolve().parents[1] / "app" / "static" / "design_tokens.css"
+
+THEME_KEYS = {
+    "bg",
+    "surface-card",
+    "accent",
+    "ink",
+    "muted",
+}
+
+
+def _relative_luminance(rgb: Tuple[int, int, int]) -> float:
+    def channel(c: int) -> float:
+        c = c / 255
+        return c / 12.92 if c <= 0.03928 else ((c + 0.055) / 1.055) ** 2.4
+
+    r, g, b = (channel(x) for x in rgb)
+    return 0.2126 * r + 0.7152 * g + 0.0722 * b
+
+
+def _contrast_ratio(rgb1: Tuple[int, int, int], rgb2: Tuple[int, int, int]) -> float:
+    l1 = _relative_luminance(rgb1)
+    l2 = _relative_luminance(rgb2)
+    lighter, darker = max(l1, l2), min(l1, l2)
+    return (lighter + 0.05) / (darker + 0.05)
+
+
+def _parse_color(value: str) -> Tuple[int, int, int]:
+    value = value.strip()
+    if value.startswith("#"):
+        hex_value = value[1:]
+        if len(hex_value) == 3:
+            hex_value = "".join(ch * 2 for ch in hex_value)
+        if len(hex_value) != 6:
+            raise ValueError(f"Unsupported hex color: {value}")
+        return tuple(int(hex_value[i : i + 2], 16) for i in range(0, 6, 2))  # type: ignore[misc]
+    if value.startswith("rgb"):
+        parts = re.findall(r"[0-9]+", value)
+        if len(parts) < 3:
+            raise ValueError(f"Unsupported rgb color: {value}")
+        return tuple(int(parts[i]) for i in range(3))  # type: ignore[misc]
+    raise ValueError(f"Unsupported color format: {value}")
+
+
+def _extract_blocks(pattern: str, css: str) -> Dict[str, Dict[str, str]]:
+    compiled = re.compile(pattern, re.MULTILINE | re.DOTALL)
+    result: Dict[str, Dict[str, str]] = {}
+    for match in compiled.finditer(css):
+        name = match.group("name")
+        body = match.group("body")
+        declarations: Dict[str, str] = {}
+        for line in body.split(";"):
+            if not line.strip():
+                continue
+            if ":" not in line:
+                continue
+            key, raw_value = line.split(":", 1)
+            key = key.strip()
+            value = raw_value.strip()
+            if key.startswith("--"):
+                declarations[key[2:]] = value
+        result[name] = declarations
+    return result
+
+
+def _load_css() -> str:
+    if not CSS_PATH.exists():
+        raise FileNotFoundError(f"CSS tokens not found at {CSS_PATH}")
+    return CSS_PATH.read_text(encoding="utf-8")
+
+
+def test_theme_tokens_have_contrast() -> None:
+    css = _load_css()
+    themes = _extract_blocks(r'body\[data-rexai-theme="(?P<name>[^"]+)"[^\{]*\{(?P<body>[^}]*)\}', css)
+    assert themes, "No theme tokens found"
+
+    for theme_name, tokens in themes.items():
+        missing = THEME_KEYS - tokens.keys()
+        assert not missing, f"Theme '{theme_name}' missing tokens: {missing}"
+
+        bg = _parse_color(tokens["bg"])
+        ink = _parse_color(tokens["ink"])
+        surface = _parse_color(tokens.get("surface-card", tokens["bg"]))
+        accent = _parse_color(tokens["accent"])
+
+        base_ratio = _contrast_ratio(bg, ink)
+        surface_ratio = _contrast_ratio(surface, ink)
+        accent_ratio = _contrast_ratio(accent, bg)
+
+        min_base = 7.0 if "high-contrast" in theme_name else 4.5
+        min_surface = 4.5 if "high-contrast" in theme_name else 3.0
+        min_accent = 4.5 if "high-contrast" in theme_name else 3.0
+
+        assert base_ratio >= min_base, f"Theme '{theme_name}' background/text contrast {base_ratio:.2f} < {min_base}"
+        assert surface_ratio >= min_surface, f"Theme '{theme_name}' surface/text contrast {surface_ratio:.2f} < {min_surface}"
+        assert accent_ratio >= min_accent, f"Theme '{theme_name}' accent/background contrast {accent_ratio:.2f} < {min_accent}"
+
+
+def test_colorblind_accent_remains_distinct() -> None:
+    css = _load_css()
+    themes = _extract_blocks(r'body\[data-rexai-theme="(?P<name>[^"]+)"[^\{]*\{(?P<body>[^}]*)\}', css)
+    overrides = _extract_blocks(r'body\[data-rexai-colorblind="(?P<name>[^"]+)"[^\{]*\{(?P<body>[^}]*)\}', css)
+
+    safe = overrides.get("safe")
+    assert safe, "Colorblind safe mode overrides not found"
+    assert "accent" in safe, "Colorblind safe mode must override accent"
+
+    accent_override = _parse_color(safe["accent"])
+    for theme_name, tokens in themes.items():
+        bg = _parse_color(tokens["bg"])
+        ratio = _contrast_ratio(accent_override, bg)
+        assert ratio >= 3.0, f"Colorblind accent contrast too low for theme '{theme_name}': {ratio:.2f}"


### PR DESCRIPTION
## Summary
- expand the Rex-AI design tokens to include dark, light, solarized and high-contrast variants with color-blind overrides
- refresh the shared theme CSS and component helpers to respond to HUD toggles for theme, font scale and daltonic mode
- add automated contrast checks to guard the new palettes

## Testing
- pytest tests/test_accessibility.py

------
https://chatgpt.com/codex/tasks/task_e_68dad62f4fe48331aa713ed51f032651