### PR TITLE
Fix UI theme injection and add smoke test

### DIFF
--- a/tests/ui/test_ui_blocks_import.py
+++ b/tests/ui/test_ui_blocks_import.py
@@ -1,0 +1,12 @@
+import importlib
+
+
+def test_ui_blocks_smoke() -> None:
+    ui_blocks = importlib.import_module("app.modules.ui_blocks")
+
+    # Should not raise when injecting theme without HUD elements
+    ui_blocks.load_theme(show_hud=False)
+
+    # Surface context manager should be usable without errors
+    with ui_blocks.surface():
+        pass


### PR DESCRIPTION
## Summary
- clean up the UI blocks module to ensure theme CSS is injected once and HUD state keys are consistent
- simplify surface and glass_card context managers so they only manage container markup
- add a smoke test that imports ui_blocks and exercises load_theme and surface

## Testing
- pytest tests/ui/test_ui_blocks_import.py

------
https://chatgpt.com/codex/tasks/task_e_68daeda3b48483318adef31b0fb4e062