### PR TITLE
Refactor generator layout styling

### DIFF
--- a/app/static/layout.css
+++ b/app/static/layout.css
@@ -12,6 +12,114 @@
   --animation-duration: 680ms;
 }
 
+.layout-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 1.6rem;
+}
+
+.pane {
+  background: color-mix(in srgb, var(--surface-panel) 92%, transparent);
+  border: 1px solid color-mix(in srgb, var(--border-soft) 82%, transparent);
+  padding: 1.4rem 1.5rem;
+  border-radius: 20px;
+  box-shadow: var(--panel-shadow);
+  backdrop-filter: blur(14px);
+}
+
+.pane h3,
+.pane h4 {
+  margin-bottom: 0.6rem;
+}
+
+.chipline {
+  display: flex;
+  gap: 0.6rem;
+  flex-wrap: wrap;
+  margin-top: 0.85rem;
+}
+
+.chipline span {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.38rem 0.8rem;
+  border-radius: 999px;
+  border: 1px solid var(--chip-border);
+  background: color-mix(in srgb, var(--chip-bg) 92%, transparent);
+  color: var(--chip-ink);
+  font-size: 0.8rem;
+  letter-spacing: 0.01em;
+}
+
+.candidate {
+  border-radius: 20px;
+  border: 1px solid color-mix(in srgb, var(--border-soft) 75%, transparent);
+  padding: 1.35rem 1.5rem;
+  margin-bottom: 1.1rem;
+  background: color-mix(in srgb, var(--surface-card) 88%, transparent);
+  box-shadow: var(--panel-shadow-soft);
+}
+
+.candidate-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 0.85rem;
+  margin: 0.75rem 0 0.95rem;
+}
+
+.candidate-grid > div {
+  background: color-mix(in srgb, var(--surface-ghost) 82%, transparent);
+  border-radius: 14px;
+  padding: 0.85rem 1rem;
+  border: 1px solid color-mix(in srgb, var(--border-soft) 68%, transparent);
+}
+
+.candidate-grid strong {
+  display: block;
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.confidence,
+.delta {
+  font-size: 0.86rem;
+  color: var(--muted);
+  margin-top: 0.35rem;
+}
+
+.badge-ai {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  border: 1px solid var(--chip-border);
+  background: color-mix(in srgb, var(--accent) 18%, transparent);
+  color: var(--ink);
+  font-size: 0.78rem;
+}
+
+.hr-micro {
+  height: 1px;
+  margin: 0.9rem 0 1.1rem;
+  background: color-mix(in srgb, var(--border-soft) 68%, transparent);
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  border: 1px solid var(--chip-border);
+  background: color-mix(in srgb, var(--accent) 15%, transparent);
+  color: var(--chip-ink);
+  font-size: 0.78rem;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+
 .layout-grid {
   position: relative;
   display: grid;


### PR DESCRIPTION
## Summary
- move generator page utility classes into the shared layout.css bundle and load them with the theme
- add UI helper wrappers (badge group, micro divider, etc.) for applying shared styles without inline markdown
- update the generator page to consume the helpers and remove duplicated inline layout code

## Testing
- PYTHONPATH=/workspace/space-trash-hack/app streamlit run app/pages/3_Generator.py --server.headless true --server.port 8501


------
https://chatgpt.com/codex/tasks/task_e_68daef1b9b3c833194a5e55f737af020