### PR TITLE
Refactor Home hero to shared TeslaHero component

### DIFF
--- a/app/Home.py
+++ b/app/Home.py
@@ -8,8 +8,6 @@ from textwrap import dedent
 import pandas as pd
 import streamlit as st
 
-import streamlit as st
-
 from app.modules.luxe_components import (
     BriefingCard,
     TimelineMilestone,
@@ -23,9 +21,8 @@ from app.modules.luxe_components import (
     TeslaHero,
 )
 from app.modules.ml_models import get_model_registry
-from app.modules.ui_blocks import load_theme, futuristic_button
 from app.modules.navigation import set_active_step
-from app.modules.ui_blocks import load_theme
+from app.modules.ui_blocks import futuristic_button, load_theme
 
 st.set_page_config(
     page_title="Rex-AI • Mission Copilot",
@@ -48,30 +45,6 @@ def load_inventory_sample() -> pd.DataFrame | None:
         return pd.read_csv(sample_path)
     except Exception:
         return None
-
-
-def tesla_hero(title: str, subtitle: str, chips: list[str], video_url: str) -> None:
-    chip_markup = "".join(f"<span class='chip'>{chip}</span>" for chip in chips)
-    st.markdown(
-        f"""
-        <section class="overview-block reveal" id="overview-cinematic">
-          <div class="tesla-hero">
-            <video class="tesla-hero__bg" autoplay muted loop playsinline>
-              <source src="{video_url}" type="video/mp4" />
-            </video>
-            <div class="tesla-hero__veil"></div>
-            <div class="tesla-hero__content">
-              <h1>{title}</h1>
-              <p>{subtitle}</p>
-              <div class="chip-row">{chip_markup}</div>
-            </div>
-          </div>
-        </section>
-        """,
-        unsafe_allow_html=True,
-    )
-
-
 def format_mass(value: float | int | None) -> str:
     if value is None:
         return "—"
@@ -250,13 +223,13 @@ ready = "✅ Modelo listo" if model_registry.ready else "⚠️ Entrená localme
 # ──────────── Overview cinematográfico ────────────
 hero_col, metrics_col = st.columns([2.8, 1.2], gap="large")
 with hero_col:
-    tesla_hero(
+    TeslaHero(
         title="Rex-AI orquesta el reciclaje orbital y marciano",
         subtitle=(
             "Un loop autónomo que mezcla regolito MGS-1, polímeros EVA y residuos de carga "
             "para fabricar piezas listas para misión. El copiloto gestiona riesgos, "
-            "energía y trazabilidad sin perder contexto.")
-        ,
+            "energía y trazabilidad sin perder contexto."
+        ),
         chips=[
             "RandomForest multisalida",
             "Comparadores XGBoost / Tabular",
@@ -264,7 +237,7 @@ with hero_col:
             "Telemetría NASA · Crew safe",
         ],
         video_url="https://cdn.coverr.co/videos/coverr-into-the-blue-nebula-9071/1080p.mp4",
-    )
+    ).render()
 
 with metrics_col:
     st.markdown(

--- a/app/modules/luxe_components.py
+++ b/app/modules/luxe_components.py
@@ -371,6 +371,24 @@ _LUXE_COMPONENT_CSS = """
   animation: heroGlow 14s ease-in-out infinite;
 }
 
+.luxe-hero__video {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  z-index: 0;
+  filter: saturate(1.25) brightness(0.65);
+}
+
+.luxe-hero__veil {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, rgba(15, 23, 42, 0.12) 10%, rgba(2, 6, 23, 0.88) 100%);
+  z-index: 1;
+  pointer-events: none;
+}
+
 .luxe-hero::after {
   content: "";
   position: absolute;
@@ -384,7 +402,7 @@ _LUXE_COMPONENT_CSS = """
 
 .luxe-hero__content {
   position: relative;
-  z-index: 1;
+  z-index: 2;
   max-width: 520px;
 }
 
@@ -413,6 +431,8 @@ _LUXE_COMPONENT_CSS = """
   opacity: 0.5;
   filter: drop-shadow(0 18px 25px rgba(15, 23, 42, 0.45));
   animation: parallaxDrift var(--layer-speed, 18s) ease-in-out infinite;
+  z-index: 1;
+  pointer-events: none;
 }
 
 .luxe-chip-row {
@@ -1247,6 +1267,7 @@ def ChipRow(
 class TeslaHero:
     title: str
     subtitle: str
+    video_url: str | None = None
     chips: Sequence[str | Mapping[str, str]] = field(default_factory=list)
     icon: str | None = None
     gradient: str | None = None
@@ -1284,10 +1305,20 @@ class TeslaHero:
 
         chips_html = ChipRow(self.chips, render=False) if self.chips else ""
         icon_html = f"<div class='luxe-hero__icon'>{self.icon}</div>" if self.icon else ""
+        video_markup = ""
+        if self.video_url:
+            video_markup = (
+                f"<video class='luxe-hero__video' autoplay muted loop playsinline>"
+                f"<source src='{self.video_url}' type='video/mp4' />"
+                "</video>"
+                "<div class='luxe-hero__veil'></div>"
+            )
+        layers_html = "".join(layers)
 
         html = f"""
         <div class='luxe-hero' style='{_merge_styles(hero_style, {})}'>
-          {''.join(layers)}
+          {video_markup}
+          {layers_html}
           <div class='luxe-hero__content'>
             {icon_html}
             <h1>{self.title}</h1>


### PR DESCRIPTION
## Summary
- replace the Home overview hero helper with the shared TeslaHero component and tidy redundant imports
- extend TeslaHero with optional background video support and corresponding CSS updates

## Testing
- pytest tests/test_data_sources.py

------
https://chatgpt.com/codex/tasks/task_e_68daf237b1f08331ba8e2e4d5e028905