### PR TITLE
Add smoke tests for UI helper imports

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+testpaths =
+    tests
+    tests/ui
+python_files = test_*.py

--- a/tests/ui/test_ui_imports.py
+++ b/tests/ui/test_ui_imports.py
@@ -1,0 +1,49 @@
+"""Smoke tests for key UI modules to guard against accidental regressions."""
+
+import importlib
+
+
+def _get_module(name: str):
+    """Import *name* and return the module object.
+
+    Keeping this logic in a helper means we get a nicer assertion message if the
+    import fails, while ensuring the import only happens once per test function.
+    """
+
+    module = importlib.import_module(name)
+    return module
+
+
+def test_luxe_components_exports_expected_helpers() -> None:
+    module = _get_module("app.modules.luxe_components")
+
+    expected_symbols = {
+        "TeslaHero",
+        "ChipRow",
+        "mission_briefing",
+        "target_configurator",
+    }
+
+    assert hasattr(module, "__all__"), "luxe_components must define __all__"
+    exported = set(module.__all__)
+
+    missing_from_attributes = [symbol for symbol in expected_symbols if not hasattr(module, symbol)]
+    assert not missing_from_attributes, f"Missing attributes: {missing_from_attributes}"
+
+    missing_from_all = expected_symbols - exported
+    assert not missing_from_all, f"Symbols not listed in __all__: {missing_from_all}"
+
+
+def test_ui_blocks_exposes_primary_helpers() -> None:
+    module = _get_module("app.modules.ui_blocks")
+
+    expected_callables = ["load_theme", "inject_css", "surface", "use_token"]
+
+    for name in expected_callables:
+        value = getattr(module, name, None)
+        assert value is not None, f"ui_blocks missing helper: {name}"
+        assert callable(value), f"{name} should be callable"
+
+    # `surface` is defined via ``@contextmanager`` so calling it should yield a context manager.
+    surface_cm = module.surface()
+    assert hasattr(surface_cm, "__enter__") and hasattr(surface_cm, "__exit__"), "surface() should return a context manager"


### PR DESCRIPTION
## Summary
- add a combined UI smoke test that imports `app.modules.luxe_components` and verifies key helpers remain exported
- assert the `app.modules.ui_blocks` helpers stay callable and that `surface()` yields a context manager
- register the `tests/ui` package in `pytest.ini` so the CI run collects the UI checks

## Testing
- pytest tests/ui/test_ui_imports.py

------
https://chatgpt.com/codex/tasks/task_e_68daf4fc0ff0833180cb8e8c21a75a96