### PR TITLE
Resolve Altair dependency conflict for Streamlit deployment

### DIFF
--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -1,4 +1,4 @@
-altair==5.3.0
+altair==4.2.2
 annotated-types==0.7.0
 attrs==25.3.0
 black==25.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ pandas==2.2.3
 polars[pyarrow]==1.12.0
 plotly==5.22.0
 networkx==3.3
-altair==5.3.0
+altair==4.2.2
 pyarrow==18.0.0
 pydantic==2.9.2
 deltalake==0.17.4


### PR DESCRIPTION
## Summary
- Pin Altair to version 4.2.2 to satisfy the requirement enforced by `streamlit-aggrid` and restore compatibility with Streamlit 1.38.
- Update the dependency lock file to keep it in sync with the new Altair version.

## Testing
- `pip install -r requirements.txt`


------
https://chatgpt.com/codex/tasks/task_e_68daf8a4c2f0833190e2ca251bb60c5d