### PR TITLE
Upgrade home CTAs with futuristic buttons

### DIFF
--- a/app/Home.py
+++ b/app/Home.py
@@ -453,7 +453,20 @@ with cta_col1:
         """,
         unsafe_allow_html=True,
     )
-    if st.button("📤 Exportar", use_container_width=True):
+    export_state_key = "home_cta_export_state"
+    if st.session_state.get(export_state_key) == "loading":
+        st.session_state[export_state_key] = "success"
+    export_state = st.session_state.setdefault(export_state_key, "idle")
+    if futuristic_button(
+        "Exportar\nreceta y telemetría",
+        key="home_cta_export",
+        icon="📤",
+        state=export_state,
+        loading_label="Generando reporte…",
+        success_label="Reporte enviado",
+        help_text="Descargá Sankey, contribuciones y feedback para seguimiento.",
+    ):
+        st.session_state[export_state_key] = "loading"
         st.switch_page("pages/4_Results_and_Tradeoffs.py")
 
 metric_grid_html = "".join(
@@ -488,7 +501,20 @@ with cta_col2:
         """,
         unsafe_allow_html=True,
     )
-    if st.button("🧮 Simular escenarios", use_container_width=True):
+    sim_state_key = "home_cta_simulation_state"
+    if st.session_state.get(sim_state_key) == "loading":
+        st.session_state[sim_state_key] = "success"
+    sim_state = st.session_state.setdefault(sim_state_key, "idle")
+    if futuristic_button(
+        "Simular\nescenarios",
+        key="home_cta_simulation",
+        icon="🧮",
+        state=sim_state,
+        loading_label="Lanzando simulación…",
+        success_label="Escenarios listos",
+        help_text="Prueba configuraciones de energía, crew y materiales para stress tests.",
+    ):
+        st.session_state[sim_state_key] = "loading"
         st.switch_page("pages/2_Target_Designer.py")
 
 st.markdown(
@@ -579,10 +605,36 @@ with c4:
         st.switch_page("pages/4_Results_and_Tradeoffs.py")
 cta_buttons = st.columns(2)
 with cta_buttons[0]:
-    if st.button("🧱 Abrir inventario", use_container_width=True, key="cta_inventory"):
+    inventory_state_key = "home_cta_inventory_state"
+    if st.session_state.get(inventory_state_key) == "loading":
+        st.session_state[inventory_state_key] = "success"
+    inventory_state = st.session_state.setdefault(inventory_state_key, "idle")
+    if futuristic_button(
+        "Abrir\ninventario",
+        key="cta_inventory",
+        icon="🧱",
+        state=inventory_state,
+        loading_label="Abriendo inventario…",
+        success_label="Inventario listo",
+        width="full",
+    ):
+        st.session_state[inventory_state_key] = "loading"
         st.switch_page("pages/1_Inventory_Builder.py")
 with cta_buttons[1]:
-    if st.button("🤖 Abrir generador", use_container_width=True, key="cta_generator"):
+    generator_state_key = "home_cta_generator_state"
+    if st.session_state.get(generator_state_key) == "loading":
+        st.session_state[generator_state_key] = "success"
+    generator_state = st.session_state.setdefault(generator_state_key, "idle")
+    if futuristic_button(
+        "Abrir\ngenerador",
+        key="cta_generator",
+        icon="🤖",
+        state=generator_state,
+        loading_label="Activando Rex-AI…",
+        success_label="Generador listo",
+        width="full",
+    ):
+        st.session_state[generator_state_key] = "loading"
         st.switch_page("pages/3_Generator.py")
 
 # ──────────── Qué demuestra hoy ────────────

--- a/app/modules/ui_blocks.py
+++ b/app/modules/ui_blocks.py
@@ -105,7 +105,11 @@ _BUTTON_STYLES = """
 .rexai-fx-wrapper[data-state="loading"] .rexai-fx-button{background:linear-gradient(135deg,rgba(59,130,246,0.78),rgba(14,165,233,0.55));box-shadow:0 10px 24px rgba(14,165,233,0.25);cursor:progress;}
 .rexai-fx-wrapper[data-state="success"] .rexai-fx-button{background:linear-gradient(135deg,rgba(16,185,129,0.95),rgba(59,130,246,0.65));box-shadow:0 14px 28px rgba(16,185,129,0.32);}
 .rexai-fx-wrapper[data-state="error"] .rexai-fx-button{background:linear-gradient(135deg,rgba(248,113,113,0.95),rgba(239,68,68,0.75));box-shadow:0 14px 28px rgba(248,113,113,0.35);}
-.rexai-fx-label{position:relative;z-index:2;display:block;text-align:center;letter-spacing:0.01em;}
+.rexai-fx-label{position:relative;z-index:2;display:flex;align-items:center;justify-content:center;gap:10px;text-align:center;letter-spacing:0.01em;flex-wrap:wrap;}
+.rexai-fx-label[data-layout="stack"]{flex-direction:column;gap:6px;}
+.rexai-fx-icon{font-size:1.25rem;line-height:1;filter:drop-shadow(0 0 6px rgba(14,165,233,0.18));}
+.rexai-fx-text{display:flex;flex-direction:column;gap:2px;line-height:1.2;align-items:center;text-align:center;}
+.rexai-fx-line{display:block;}
 .rexai-fx-status{font-size:0.78rem;letter-spacing:0.04em;text-transform:uppercase;color:rgba(148,163,184,0.92);text-align:center;transition:opacity 0.18s ease;opacity:0;height:0;}
 .rexai-fx-status[data-active="true"]{opacity:1;height:auto;}
 .rexai-fx-particles{position:absolute;inset:0;pointer-events:none;overflow:visible;}
@@ -310,6 +314,7 @@ def futuristic_button(
     enable_vibration: bool = False,
     disabled: bool = False,
     status_hints: dict[str, str] | None = None,
+    icon: str | None = None,
 ) -> bool:
     """Render the futuristic CTA microinteraction button and return ``True`` on click."""
 
@@ -338,6 +343,30 @@ def futuristic_button(
     label_current = state_messages.get(state, label)
     button_id = f"rexai-fx-{uuid4().hex}"
 
+    def _label_lines(text: str) -> list[str]:
+        lines = [ln.strip() for ln in text.splitlines() if ln.strip()]
+        if not lines:
+            stripped = text.strip()
+            return [stripped or text]
+        return lines
+
+    label_lines = _label_lines(label_current)
+    line_count = max(1, len(label_lines))
+    layout_mode = "stack" if (len(label_lines) > 1 and not icon) else "inline"
+    icon_html = (
+        f'<span class="rexai-fx-icon" aria-hidden="true">{escape(icon)}</span>'
+        if icon
+        else ""
+    )
+    text_block = "".join(
+        f'<span class="rexai-fx-line">{escape(line)}</span>' for line in label_lines
+    )
+    label_html = (
+        f'<span class="rexai-fx-label" data-layout="{layout_mode}" '
+        f'data-lines="{line_count}">{icon_html}'
+        f'<span class="rexai-fx-text">{text_block}</span></span>'
+    )
+
     config: dict[str, Any] = {
         "state": state,
         "stateMessages": state_messages,
@@ -357,28 +386,30 @@ def futuristic_button(
     script_parts = []
     if _MICRO_JS:
         script_parts.append(_MICRO_JS)
-    script_parts.append(
-        "(function(){",
-        "const styleId='rexai-fx-style';",
-        f"const styleCSS={json.dumps(_BUTTON_STYLES)};",
-        "if(!document.getElementById(styleId)){const style=document.createElement('style');style.id=styleId;style.textContent=styleCSS;document.head.appendChild(style);}",
-        f"const cfg={json.dumps(config)};",
-        f"const wrapperId='{button_id}';",
-        "const Streamlit=window.parent && window.parent.Streamlit;",
-        "if(!Streamlit){return;}",
-        "const wrapper=document.getElementById(wrapperId);",
-        "if(!wrapper){return;}",
-        "Streamlit.setComponentReady();",
-        "const buttonEl=wrapper.querySelector('button');",
-        "if(buttonEl){buttonEl.disabled=cfg.disabled;}",
-        "const statusEl=wrapper.querySelector('.rexai-fx-status');",
-        "if(statusEl){const hint=(cfg.statusHints && cfg.statusHints[cfg.state])||'';statusEl.textContent=hint;statusEl.setAttribute('data-active',hint?'true':'false');}",
-        "if(window.RexAIMicro){const controller=window.RexAIMicro.mount(wrapper,cfg);if(controller){controller.applyState(cfg.state);}}else{wrapper.setAttribute('data-state',cfg.state);}",
-        "const send=(payload)=>Streamlit.setComponentValue(payload);",
-        "if(buttonEl && !cfg.disabled){buttonEl.addEventListener('click',()=>send({event:'click',ts:Date.now()}));}",
-        "const sync=()=>Streamlit.setFrameHeight(document.body.scrollHeight);",
-        "sync();window.addEventListener('resize',sync);",
-        "})();",
+    script_parts.extend(
+        [
+            "(function(){",
+            "const styleId='rexai-fx-style';",
+            f"const styleCSS={json.dumps(_BUTTON_STYLES)};",
+            "if(!document.getElementById(styleId)){const style=document.createElement('style');style.id=styleId;style.textContent=styleCSS;document.head.appendChild(style);}",
+            f"const cfg={json.dumps(config)};",
+            f"const wrapperId='{button_id}';",
+            "const Streamlit=window.parent && window.parent.Streamlit;",
+            "if(!Streamlit){return;}",
+            "const wrapper=document.getElementById(wrapperId);",
+            "if(!wrapper){return;}",
+            "Streamlit.setComponentReady();",
+            "const buttonEl=wrapper.querySelector('button');",
+            "if(buttonEl){buttonEl.disabled=cfg.disabled;}",
+            "const statusEl=wrapper.querySelector('.rexai-fx-status');",
+            "if(statusEl){const hint=(cfg.statusHints && cfg.statusHints[cfg.state])||'';statusEl.textContent=hint;statusEl.setAttribute('data-active',hint?'true':'false');}",
+            "if(window.RexAIMicro){const controller=window.RexAIMicro.mount(wrapper,cfg);if(controller){controller.applyState(cfg.state);}}else{wrapper.setAttribute('data-state',cfg.state);}",
+            "const send=(payload)=>Streamlit.setComponentValue(payload);",
+            "if(buttonEl && !cfg.disabled){buttonEl.addEventListener('click',()=>send({event:'click',ts:Date.now()}));}",
+            "const sync=()=>Streamlit.setFrameHeight(document.body.scrollHeight);",
+            "sync();window.addEventListener('resize',sync);",
+            "})();",
+        ]
     )
     script = "".join(script_parts)
 
@@ -386,7 +417,7 @@ def futuristic_button(
     <div id="{button_id}" class="rexai-fx-wrapper" data-state="{state}" data-width="{container_width}">
       <button type="button" class="rexai-fx-button" {'disabled="disabled"' if disabled else ''}>
         <span class="rexai-fx-particles"></span>
-        <span class="rexai-fx-label">{escape(label_current)}</span>
+        {label_html}
       </button>
       <span class="rexai-fx-status" data-active="{'true' if status_text else 'false'}">{escape(status_text)}</span>
       {help_html}
@@ -394,7 +425,13 @@ def futuristic_button(
     <script>{script}</script>
     """
 
-    result = components_html(html_markup, height=120 if help_text else 100, key=key)
+    base_height = 100 + max(0, line_count - 1) * 8
+    component_kwargs = {"height": base_height + (20 if help_text else 0), "key": key}
+    try:
+        result = components_html(html_markup, **component_kwargs)
+    except TypeError:
+        component_kwargs.pop("key", None)
+        result = components_html(html_markup, **component_kwargs)
     session_key = f"__rexai_fx_ts::{key}"
     if isinstance(result, dict) and result.get("event") == "click":
         ts = result.get("ts")

--- a/pytest_streamlit/__init__.py
+++ b/pytest_streamlit/__init__.py
@@ -1,0 +1,57 @@
+"""Lightweight helpers to drive Streamlit apps in tests.
+
+This local shim emulates the minimal API surface from the external
+``pytest-streamlit`` package that our tests expect.  It is intentionally
+small: we only expose a ``StreamlitRunner`` wrapper built on top of
+``streamlit.testing.v1.AppTest`` so tests can trigger reruns and inspect
+session state without spinning a browser.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Iterable, Mapping
+
+from streamlit.testing.v1 import AppTest
+
+__all__ = ["StreamlitRunner"]
+
+
+@dataclass
+class StreamlitRunner:
+    """Minimal runner to exercise Streamlit apps in pytest.
+
+    Parameters
+    ----------
+    app : Callable
+        A callable that builds the Streamlit UI.
+    args : Iterable[Any] | None
+        Positional arguments forwarded to ``app``.
+    kwargs : Mapping[str, Any] | None
+        Keyword arguments forwarded to ``app``.
+    """
+
+    app: Callable[..., Any]
+    args: Iterable[Any] | None = None
+    kwargs: Mapping[str, Any] | None = None
+
+    def __post_init__(self) -> None:  # pragma: no cover - defensive wiring
+        self._test = AppTest.from_function(
+            self.app,
+            args=tuple(self.args or ()),
+            kwargs=dict(self.kwargs or {}),
+        )
+
+    def run(self) -> AppTest:
+        """Run or rerun the wrapped Streamlit app and return the ``AppTest``."""
+
+        return self._test.run()
+
+    @property
+    def app_test(self) -> AppTest:
+        """Expose the underlying ``AppTest`` instance for advanced usage."""
+
+        return self._test
+
+    def __getattr__(self, item: str) -> Any:  # pragma: no cover - passthrough
+        return getattr(self._test, item)

--- a/tests/ui/test_futuristic_button_usage.py
+++ b/tests/ui/test_futuristic_button_usage.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import re
+import sys
+import types
+from importlib import import_module
+
+from pytest_streamlit import StreamlitRunner
+
+for _missing in ("joblib", "polars", "plotly"):
+    sys.modules.setdefault(_missing, types.ModuleType(_missing))
+sys.modules.setdefault("plotly.graph_objects", types.ModuleType("plotly.graph_objects"))
+
+
+def _fx_demo_app() -> None:
+    import streamlit as st
+
+    from app.modules.ui_blocks import futuristic_button
+
+    if "demo_fx_state" not in st.session_state:
+        st.session_state["demo_fx_state"] = "idle"
+
+    state = st.session_state["demo_fx_state"]
+    if st.button("Activar loading", key="demo_fx_loading"):
+        state = "loading"
+    if st.button("Activar success", key="demo_fx_success"):
+        state = "success"
+
+    st.session_state["demo_fx_state"] = state
+
+    futuristic_button(
+        "Lanzar\nsecuencia orbital",
+        key="demo_fx_cta",
+        icon="🚀",
+        state=state,
+        loading_label="Sincronizando cápsula…",
+        success_label="Órbita establecida",
+        status_hints={
+            "idle": "Listo para despegar",
+            "loading": "Ajustando vector",
+            "success": "Secuencia completada",
+            "error": "Interrupción detectada",
+        },
+    )
+
+
+def _extract_state_markup(html_block: str) -> str:
+    match = re.search(r"data-state=\"(?P<state>[a-z]+)\"", html_block)
+    assert match, f"No state attribute found in markup: {html_block!r}"
+    return match.group("state")
+
+
+def test_futuristic_button_transitions(monkeypatch) -> None:
+    ui_blocks = import_module("app.modules.ui_blocks")
+
+    def _capture_html(markup: str, **kwargs: object) -> dict[str, object]:
+        import streamlit as st
+
+        st.session_state["__fx_markup__"] = markup
+        return {}
+
+    monkeypatch.setattr(ui_blocks, "components_html", _capture_html)
+
+    runner = StreamlitRunner(_fx_demo_app)
+    app = runner.run()
+
+    html_block = app.session_state["__fx_markup__"]
+    assert "rexai-fx-line" in html_block
+    assert _extract_state_markup(html_block) == "idle"
+
+    app = app.button(key="demo_fx_loading").click().run()
+    html_block = app.session_state["__fx_markup__"]
+    assert _extract_state_markup(html_block) == "loading"
+
+    app = app.button(key="demo_fx_success").click().run()
+    html_block = app.session_state["__fx_markup__"]
+    assert _extract_state_markup(html_block) == "success"


### PR DESCRIPTION
## Summary
- replace the Home page action buttons with the futuristic_button component, preserving mission hints and adding inline icon CTAs
- extend futuristic_button to support multiline labels/icons and to fall back when Streamlit components lack key support in tests
- provide a lightweight pytest_streamlit shim plus a smoke test that exercises the button through loading and success states

## Testing
- pytest tests/ui/test_futuristic_button_usage.py

------
https://chatgpt.com/codex/tasks/task_e_68dafbd978f0833186912bb2a07a5f36