### PR TITLE
Refactor reveal animation bootstrap

### DIFF
--- a/app/Home.py
+++ b/app/Home.py
@@ -20,7 +20,7 @@ from app.modules.luxe_components import (
 )
 from app.modules.ml_models import get_model_registry
 from app.modules.navigation import set_active_step
-from app.modules.ui_blocks import futuristic_button, load_theme
+from app.modules.ui_blocks import enable_reveal_animation, futuristic_button, load_theme
 
 st.set_page_config(
     page_title="Rex-AI • Mission Copilot",
@@ -666,24 +666,7 @@ orbital_timeline(
     ]
 )
 # ──────────── Animación de aparición por scroll ────────────
-st.markdown(
-    """
-    <script>
-      const observer = new IntersectionObserver((entries) => {
-        entries.forEach(entry => {
-          if (entry.isIntersecting) {
-            entry.target.classList.add('is-visible');
-          }
-        });
-      }, {threshold: 0.2});
-
-      document.querySelectorAll('.reveal').forEach((element) => {
-        observer.observe(element);
-      });
-    </script>
-    """,
-    unsafe_allow_html=True,
-)
+enable_reveal_animation()
 MetricGalaxy(
     metrics=hero_scene.metric_items(),
     density="cozy",

--- a/app/_bootstrap.py
+++ b/app/_bootstrap.py
@@ -9,6 +9,7 @@ if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
 _MICROINTERACTIONS_PATH = PROJECT_ROOT / "app" / "static" / "microinteractions.js"
+_INTERACTIONS_PATH = PROJECT_ROOT / "app" / "static" / "interactions.js"
 
 
 def load_microinteractions_script() -> str:
@@ -20,7 +21,20 @@ def load_microinteractions_script() -> str:
         return ""
 
 
-__all__ = ["PROJECT_ROOT", "load_microinteractions_script"]
+def load_interactions_script() -> str:
+    """Return shared UI interaction helpers stored in ``app/static``."""
+
+    try:
+        return _INTERACTIONS_PATH.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return ""
+
+
+__all__ = [
+    "PROJECT_ROOT",
+    "load_microinteractions_script",
+    "load_interactions_script",
+]
 try:
     from app.modules.visual_theme import apply_global_visual_theme
 except Exception:  # pragma: no cover - theme setup should not break imports

--- a/app/static/interactions.js
+++ b/app/static/interactions.js
@@ -1,0 +1,114 @@
+(function () {
+  const GLOBAL_KEY = "RexAIInteractions";
+  const FLAG_ATTR = "data-rexai-interactions";
+  const REVEAL_TOKEN = "reveal";
+  const TARGET_SELECTOR = ".reveal";
+
+  const existing = window[GLOBAL_KEY] || {};
+  if (existing.__revealBootstrapLoaded) {
+    return;
+  }
+
+  existing.__revealBootstrapLoaded = true;
+  window[GLOBAL_KEY] = existing;
+
+  function tokenized(value) {
+    return (value || "")
+      .split(/\s+/)
+      .map((token) => token.trim())
+      .filter(Boolean);
+  }
+
+  function hasRevealFlag() {
+    const nodes = document.querySelectorAll(`[${FLAG_ATTR}]`);
+    for (const node of nodes) {
+      if (tokenized(node.getAttribute(FLAG_ATTR)).includes(REVEAL_TOKEN)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  function observeRevealTargets(observer, root) {
+    const scope = root || document;
+    scope.querySelectorAll(TARGET_SELECTOR).forEach((element) => {
+      observer.observe(element);
+    });
+  }
+
+  function createRevealObserver() {
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            entry.target.classList.add("is-visible");
+            observer.unobserve(entry.target);
+          }
+        });
+      },
+      { threshold: 0.2 }
+    );
+    observeRevealTargets(observer, document);
+    return observer;
+  }
+
+  function watchNewRevealTargets(observer) {
+    if (!document.body) {
+      return;
+    }
+    const watcher = new MutationObserver((mutations) => {
+      mutations.forEach((mutation) => {
+        mutation.addedNodes.forEach((node) => {
+          if (!(node instanceof HTMLElement)) {
+            return;
+          }
+          if (node.matches(TARGET_SELECTOR)) {
+            observer.observe(node);
+          }
+          node
+            .querySelectorAll?.(TARGET_SELECTOR)
+            .forEach((child) => observer.observe(child));
+        });
+      });
+    });
+    watcher.observe(document.body, { childList: true, subtree: true });
+  }
+
+  function enableReveal() {
+    if (existing.revealInitialized) {
+      return;
+    }
+
+    existing.revealInitialized = true;
+
+    const start = () => {
+      const observer = createRevealObserver();
+      watchNewRevealTargets(observer);
+    };
+
+    if (document.readyState === "loading") {
+      document.addEventListener("DOMContentLoaded", start, { once: true });
+    } else {
+      start();
+    }
+  }
+
+  existing.enableReveal = enableReveal;
+
+  function checkAndEnable() {
+    if (hasRevealFlag()) {
+      enableReveal();
+    }
+  }
+
+  const flagObserver = new MutationObserver(checkAndEnable);
+  flagObserver.observe(document.documentElement, {
+    subtree: true,
+    attributes: true,
+    attributeFilter: [FLAG_ATTR],
+    childList: true,
+  });
+
+  document.addEventListener("DOMContentLoaded", checkAndEnable);
+  checkAndEnable();
+})();

--- a/tests/ui/test_bootstrap_scripts.py
+++ b/tests/ui/test_bootstrap_scripts.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from importlib import import_module
+
+import pytest
+
+pytest.importorskip("streamlit")
+
+from pytest_streamlit import StreamlitRunner
+
+
+def _bootstrap_app() -> None:
+    import streamlit as st
+
+    from app.modules.ui_blocks import enable_reveal_animation, load_theme
+
+    load_theme()
+    enable_reveal_animation()
+    load_theme()
+    enable_reveal_animation()
+
+
+def test_interactions_script_injected_once(monkeypatch) -> None:
+    ui_blocks = import_module("app.modules.ui_blocks")
+    import streamlit as st
+
+    original_markdown = ui_blocks.st.markdown
+
+    def _tracking_markdown(body: str, **kwargs: object):
+        if isinstance(body, str) and "IntersectionObserver" in body:
+            st.session_state["__interactions_injections__"] = (
+                st.session_state.get("__interactions_injections__", 0) + 1
+            )
+        return original_markdown(body, **kwargs)
+
+    monkeypatch.setattr(ui_blocks.st, "markdown", _tracking_markdown)
+
+    runner = StreamlitRunner(_bootstrap_app)
+    app = runner.run()
+
+    assert app.session_state.get("__interactions_injections__", 0) == 1
+    assert "__rexai_interactions_hash__" in app.session_state


### PR DESCRIPTION
## Summary
- add a shared interactions.js asset and expose a loader in the bootstrap helper
- extend ui_blocks to inject the interactions bundle once and provide an enable_reveal_animation helper
- add a regression test that ensures the interactions script is only injected once per session

## Testing
- pytest tests/ui/test_bootstrap_scripts.py -q

------
https://chatgpt.com/codex/tasks/task_e_68dafebd2b848331bdba08a1c2dd8da9