### PR TITLE
Refactor Home page to use luxe component abstractions

### DIFF
--- a/app/Home.py
+++ b/app/Home.py
@@ -2,21 +2,25 @@
 import _bootstrap  # noqa: F401
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Mapping, Sequence
 
 import pandas as pd
 import streamlit as st
 
 from app.modules.luxe_components import (
+    ActionCard,
+    ActionDeck,
     BriefingCard,
+    CarouselItem,
+    CarouselRail,
+    GlassCard,
+    GlassStack,
     HeroFlowStage,
+    MetricGalaxy,
+    MissionMetrics,
+    TeslaHero,
     TimelineMilestone,
     guided_demo,
     orbital_timeline,
-    GlassCard,
-    GlassStack,
-    MetricGalaxy,
-    TeslaHero,
 )
 from app.modules.ml_models import get_model_registry
 from app.modules.navigation import set_active_step
@@ -49,35 +53,6 @@ def format_mass(value: float | int | None) -> str:
     if value >= 1000:
         return f"{value/1000:.1f} t"
     return f"{value:.0f} kg"
-
-
-def render_metric_panel_html(
-    metrics: Sequence[Mapping[str, Any]], highlight_key: str | None
-) -> str:
-    cards = []
-    for metric in metrics:
-        classes = "metric highlight" if metric.get("stage_key") == highlight_key else "metric"
-        details_html = "".join(
-            f"<p>{detail}</p>" for detail in metric.get("details", [])
-        )
-        cards.append(
-            f"""
-            <div class="{classes}">
-              <h5>{metric.get('label', '')}</h5>
-              <strong>{metric.get('value', '')}</strong>
-              {details_html}
-            </div>
-            """
-        )
-
-    return (
-        """
-        <aside class="sticky-panel reveal" id="sticky-metrics">
-          <h3>Panel de misión</h3>
-        """
-        + "".join(cards)
-        + "\n        </aside>"
-    )
 
 
 # ──────────── Lectura segura de metadata del modelo ────────────
@@ -258,8 +233,12 @@ with metrics_col:
     metrics_placeholder = st.empty()
 
 mission_metric_payload = hero_scene.metrics_payload()
+mission_metrics_component = MissionMetrics.from_payload(
+    mission_metric_payload,
+    title="Panel de misión",
+)
 metrics_placeholder.markdown(
-    render_metric_panel_html(mission_metric_payload, None),
+    mission_metrics_component.markup(),
     unsafe_allow_html=True,
 )
 
@@ -276,7 +255,7 @@ st.markdown(
 
 inventory_df = load_inventory_sample()
 
-category_cards = ""
+category_items = []
 if inventory_df is not None and not inventory_df.empty:
     category_summary = (
         inventory_df.groupby("category")[["mass_kg", "volume_l"]]
@@ -285,23 +264,16 @@ if inventory_df is not None and not inventory_df.empty:
         .head(6)
     )
     for category, row in category_summary.iterrows():
-        category_cards += (
-            f"<div class='carousel-card'>"
-            f"<h4>{category}</h4>"
-            f"<div class='value'>{format_mass(row['mass_kg'])}</div>"
-            f"<p>Volumen: {row['volume_l']:.0f} L</p>"
-            f"</div>"
+        category_items.append(
+            CarouselItem(
+                title=category,
+                value=format_mass(row["mass_kg"]),
+                description=f"Volumen: {row['volume_l']:.0f} L",
+            )
         )
 
-if category_cards:
-    st.markdown(
-        f"""
-        <div class="carousel reveal" data-carousel="categorias">
-          {category_cards}
-        </div>
-        """,
-        unsafe_allow_html=True,
-    )
+if category_items:
+    CarouselRail(items=category_items, data_track="categorias").render()
 
 col_lab_a, col_lab_b = st.columns([1.6, 1], gap="large")
 
@@ -374,7 +346,7 @@ active_stage_key = (
     else None
 )
 metrics_placeholder.markdown(
-    render_metric_panel_html(mission_metric_payload, active_stage_key),
+    mission_metrics_component.markup(highlight_key=active_stage_key),
     unsafe_allow_html=True,
 )
 
@@ -414,78 +386,81 @@ st.markdown(
 
 cta_col1, cta_col2 = st.columns(2, gap="large")
 with cta_col1:
-    st.markdown(
-        """
-        <div class="cta-grid">
-          <div class="cta-card reveal">
-            <span class="icon">📤</span>
-            <strong>Exportar receta y telemetría</strong>
-            <p>Descargá reportes con Sankey, contribuciones y feedback para seguimiento.</p>
-          </div>
-        </div>
-        """,
-        unsafe_allow_html=True,
-    )
+    ActionDeck(
+        cards=[
+            ActionCard(
+                title="Exportar receta y telemetría",
+                body="Descargá reportes con Sankey, contribuciones y feedback para seguimiento.",
+                icon="📤",
+            )
+        ],
+        columns_min="18rem",
+    ).render()
     if st.button("📤 Exportar", use_container_width=True):
         st.switch_page("pages/4_Results_and_Tradeoffs.py")
-
-metric_grid_html = "".join(
-    f"""
-    <div class='metric{' highlight' if metric.get('stage_key') == active_stage_key else ''}'>
-        <h5>{metric.get('label', '')}</h5>
-        <strong>{metric.get('value', '')}</strong>
-        {''.join(f'<p>{detail}</p>' for detail in metric.get('details', [])[:2])}
-    </div>
-    """
-    for metric in mission_metric_payload
-)
-
-st.markdown(
-    f"""
-    <div class="metric-grid">
-      {metric_grid_html}
-    </div>
-    """,
-    unsafe_allow_html=True,
-)
 with cta_col2:
-    st.markdown(
-        """
-        <div class="cta-grid">
-          <div class="cta-card reveal">
-            <span class="icon">🧮</span>
-            <strong>Simular escenarios</strong>
-            <p>Prueba configuraciones de energía, crew y materiales para stress tests.</p>
-          </div>
-        </div>
-        """,
-        unsafe_allow_html=True,
-    )
+    ActionDeck(
+        cards=[
+            ActionCard(
+                title="Simular escenarios",
+                body="Prueba configuraciones de energía, crew y materiales para stress tests.",
+                icon="🧮",
+            )
+        ],
+        columns_min="18rem",
+    ).render()
     if st.button("🧮 Simular escenarios", use_container_width=True):
         st.switch_page("pages/2_Target_Designer.py")
 
 st.markdown(
-    """
-    <div class="mission-grid">
-      <div><h3>1. Inventario NASA</h3><p>Trabajá sobre <code>data/waste_inventory_sample.csv</code> o subí tu CSV normalizado.</p></div>
-      <div><h3>2. Objetivo</h3><p>Usá presets (container, utensil, tool, interior) o definí límites manuales.</p></div>
-      <div><h3>3. Generador con IA</h3><p>Revisá contribuciones de features y compará heurística vs modelo.</p></div>
-      <div><h3>4. Reportar</h3><p>Exportá recetas, Sankey y feedback/impact para seguir entrenando Rex-AI.</p></div>
-    <div class="cta-grid" style="margin-top: 12px;">
-      <div class="cta-card reveal">
-        <span class="icon">🧱</span>
-        <strong>Construir inventario</strong>
-        <p>Normalizá residuos NASA y etiquetá flags EVA, multilayer y nitrilo.</p>
-      </div>
-      <div class="cta-card reveal">
-        <span class="icon">🤖</span>
-        <strong>Generador IA vs heurística</strong>
-        <p>Compara recetas propuestas, trade-offs y bandas de confianza.</p>
-      </div>
-    </div>
-    """,
+    mission_metrics_component.markup(
+        layout="grid",
+        highlight_key=active_stage_key,
+        detail_limit=2,
+        show_title=False,
+    ),
     unsafe_allow_html=True,
 )
+
+ActionDeck(
+    cards=[
+        ActionCard(
+            title="1. Inventario NASA",
+            body="Trabajá sobre <code>data/waste_inventory_sample.csv</code> o subí tu CSV normalizado.",
+        ),
+        ActionCard(
+            title="2. Objetivo",
+            body="Usá presets (container, utensil, tool, interior) o definí límites manuales.",
+        ),
+        ActionCard(
+            title="3. Generador con IA",
+            body="Revisá contribuciones de features y compará heurística vs modelo.",
+        ),
+        ActionCard(
+            title="4. Reportar",
+            body="Exportá recetas, Sankey y feedback/impact para seguir entrenando Rex-AI.",
+        ),
+    ],
+    columns_min="15rem",
+    density="cozy",
+).render()
+
+ActionDeck(
+    cards=[
+        ActionCard(
+            title="Construir inventario",
+            body="Normalizá residuos NASA y etiquetá flags EVA, multilayer y nitrilo.",
+            icon="🧱",
+        ),
+        ActionCard(
+            title="Generador IA vs heurística",
+            body="Compara recetas propuestas, trade-offs y bandas de confianza.",
+            icon="🤖",
+        ),
+    ],
+    columns_min="14rem",
+    density="cozy",
+).render()
 
 # ──────────── CTA navegación ────────────
 st.markdown("### Siguiente acción")

--- a/app/modules/luxe_components.py
+++ b/app/modules/luxe_components.py
@@ -536,6 +536,194 @@ _LUXE_COMPONENT_CSS = """
   color: var(--luxe-muted);
 }
 
+.luxe-mission-panel {
+  position: sticky;
+  top: 84px;
+  border-radius: 22px;
+  border: 1px solid color-mix(in srgb, var(--border-soft) 72%, transparent);
+  padding: var(--mission-panel-padding, 24px 26px);
+  background: color-mix(in srgb, var(--surface-panel) 92%, transparent);
+  backdrop-filter: blur(18px);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.luxe-mission-panel__title {
+  margin: 0;
+}
+
+.luxe-mission-panel__metrics {
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+}
+
+.luxe-mission-metric {
+  border-radius: 16px;
+  border: 1px solid color-mix(in srgb, var(--border-soft) 60%, transparent);
+  background: color-mix(in srgb, var(--surface-card) 85%, transparent);
+  padding: var(--mission-metric-padding, 14px 16px);
+  transition: border 280ms ease, box-shadow 280ms ease;
+  display: grid;
+  gap: 0.35rem;
+}
+
+.luxe-mission-metric.is-active {
+  border-color: color-mix(in srgb, var(--accent) 60%, transparent);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent) 18%, transparent);
+}
+
+.luxe-mission-metric__icon {
+  width: 32px;
+  height: 32px;
+  border-radius: 999px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: color-mix(in srgb, var(--accent) 18%, transparent);
+  color: var(--accent);
+  font-size: 1.1rem;
+  margin-bottom: 2px;
+}
+
+.luxe-mission-metric h5 {
+  margin: 0;
+  font-size: 0.82rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: color-mix(in srgb, var(--muted) 90%, transparent);
+}
+
+.luxe-mission-metric strong {
+  font-size: 1.32rem;
+}
+
+.luxe-mission-metric p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
+.luxe-mission-metric__caption {
+  margin: 0;
+  color: color-mix(in srgb, var(--muted) 85%, transparent);
+  font-size: 0.8rem;
+}
+
+.luxe-mission-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(var(--mission-grid-min, 14rem), 1fr));
+  gap: var(--mission-grid-gap, 1rem);
+  margin-top: 1.5rem;
+}
+
+.luxe-mission-grid .luxe-mission-metric {
+  border-radius: 18px;
+  padding: var(--mission-grid-card-padding, 18px 20px);
+  background: var(--metric-bg, color-mix(in srgb, var(--surface-panel) 88%, transparent));
+  border: 1px solid var(--metric-border, color-mix(in srgb, var(--border-soft) 65%, transparent));
+}
+
+.luxe-carousel {
+  display: flex;
+  gap: var(--carousel-gap, 1rem);
+  overflow-x: auto;
+  padding-bottom: 0.5rem;
+  scroll-snap-type: x mandatory;
+}
+
+.luxe-carousel::-webkit-scrollbar {
+  height: 6px;
+}
+
+.luxe-carousel::-webkit-scrollbar-thumb {
+  background: color-mix(in srgb, var(--accent) 45%, transparent);
+  border-radius: 999px;
+}
+
+.luxe-carousel-card {
+  min-width: var(--carousel-min, 15rem);
+  scroll-snap-align: start;
+  border-radius: 18px;
+  border: 1px solid color-mix(in srgb, var(--border-soft) 64%, transparent);
+  padding: var(--carousel-card-padding, 18px);
+  background: color-mix(in srgb, var(--surface-card) 82%, transparent);
+  display: grid;
+  gap: 0.4rem;
+}
+
+.luxe-carousel-card h4 {
+  margin: 0;
+  font-size: 1.02rem;
+}
+
+.luxe-carousel-card__value {
+  font-size: 1.3rem;
+  font-weight: 700;
+}
+
+.luxe-carousel-card__description {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.luxe-carousel-card__icon {
+  font-size: 1.4rem;
+  opacity: 0.75;
+}
+
+.luxe-action-deck {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(var(--action-min, 16rem), 1fr));
+  gap: var(--action-gap, 1.1rem);
+}
+
+.luxe-action-card {
+  position: relative;
+  border-radius: 22px;
+  border: 1px solid color-mix(in srgb, var(--accent) 28%, transparent);
+  padding: var(--action-card-padding, 22px 24px);
+  background: linear-gradient(160deg, color-mix(in srgb, var(--accent) 16%, transparent), color-mix(in srgb, var(--surface-panel) 78%, transparent));
+  color: var(--ink);
+  box-shadow: 0 24px 48px -32px rgba(15, 23, 42, 0.55);
+  overflow: hidden;
+}
+
+.luxe-action-card__icon {
+  position: absolute;
+  top: 16px;
+  right: 18px;
+  font-size: 1.4rem;
+  opacity: 0.85;
+}
+
+.luxe-action-card__title {
+  margin: 0 0 0.5rem 0;
+  font-size: 1.16rem;
+}
+
+.luxe-action-card__body {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.94rem;
+}
+
+.luxe-action-card__tag {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.32rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  background: color-mix(in srgb, var(--accent) 18%, transparent);
+  color: color-mix(in srgb, var(--accent) 90%, transparent);
+  margin-bottom: 0.8rem;
+}
+
 .luxe-stack {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(var(--stack-min, 16rem), 1fr));
@@ -1606,6 +1794,297 @@ class MetricGalaxy:
 
 
 @dataclass
+class MissionMetric:
+    key: str
+    label: str
+    value: str
+    details: Sequence[str] = field(default_factory=tuple)
+    caption: str | None = None
+    icon: str | None = None
+    stage_key: str | None = None
+
+    @classmethod
+    def from_mapping(cls, payload: Mapping[str, Any]) -> "MissionMetric":
+        details: Sequence[str] | str | None = payload.get("details")
+        if details is None:
+            normalized: Sequence[str] = ()
+        elif isinstance(details, str):
+            normalized = (details,)
+        else:
+            normalized = tuple(str(item) for item in details)
+        return cls(
+            key=str(payload.get("key", payload.get("stage_key", ""))),
+            label=str(payload.get("label", "")),
+            value=str(payload.get("value", "")),
+            details=normalized,
+            caption=payload.get("caption"),
+            icon=payload.get("icon"),
+            stage_key=payload.get("stage_key"),
+        )
+
+
+@dataclass
+class MissionMetrics:
+    metrics: Sequence[MissionMetric]
+    title: str = "Panel de misión"
+    panel_density: str = "cozy"
+    grid_density: str = "cozy"
+    columns_min: str = "14rem"
+    animate: bool = True
+
+    @classmethod
+    def from_payload(
+        cls,
+        payload: Sequence[Mapping[str, Any]],
+        *,
+        title: str = "Panel de misión",
+        panel_density: str = "cozy",
+        grid_density: str = "cozy",
+        columns_min: str = "14rem",
+        animate: bool = True,
+    ) -> "MissionMetrics":
+        metrics = [MissionMetric.from_mapping(item) for item in payload]
+        return cls(
+            metrics=metrics,
+            title=title,
+            panel_density=panel_density,
+            grid_density=grid_density,
+            columns_min=columns_min,
+            animate=animate,
+        )
+
+    def markup(
+        self,
+        *,
+        highlight_key: str | None = None,
+        layout: Literal["panel", "grid"] = "panel",
+        detail_limit: int | None = None,
+        show_title: bool | None = None,
+    ) -> str:
+        variant = layout
+        highlight = highlight_key
+        limit = max(detail_limit, 0) if detail_limit is not None else None
+
+        def metric_markup(metric: MissionMetric) -> str:
+            classes = ["luxe-mission-metric"]
+            if highlight and metric.stage_key == highlight:
+                classes.append("is-active")
+            icon_html = (
+                f"<span class='luxe-mission-metric__icon'>{metric.icon}</span>"
+                if metric.icon
+                else ""
+            )
+            details = metric.details
+            if limit is not None:
+                details = tuple(details)[:limit]
+            detail_html = "".join(f"<p>{text}</p>" for text in details)
+            caption_html = (
+                f"<p class='luxe-mission-metric__caption'>{metric.caption}</p>"
+                if metric.caption and limit is None
+                else ""
+            )
+            return (
+                f"<div class='{_class_names(classes)}' data-key='{metric.key}'>"
+                f"{icon_html}"
+                f"<h5>{metric.label}</h5>"
+                f"<strong>{metric.value}</strong>"
+                f"{detail_html}"
+                f"{caption_html}"
+                "</div>"
+            )
+
+        if variant == "grid":
+            gap_map = {"compact": "0.85rem", "cozy": "1rem", "roomy": "1.3rem"}
+            padding_map = {"compact": "16px 18px", "cozy": "18px 20px", "roomy": "20px 22px"}
+            style = {
+                "--mission-grid-min": self.columns_min,
+                "--mission-grid-gap": gap_map.get(self.grid_density, gap_map["cozy"]),
+                "--mission-grid-card-padding": padding_map.get(
+                    self.grid_density, padding_map["cozy"]
+                ),
+            }
+            classes = ["luxe-mission-grid"]
+            if self.animate:
+                classes.append("reveal")
+            metrics_html = "".join(metric_markup(metric) for metric in self.metrics)
+            return (
+                f"<div class='{_class_names(classes)}' style='{_merge_styles(style, {})}'>"
+                f"{metrics_html}"
+                "</div>"
+            )
+
+        padding_map = {"compact": "20px 22px", "cozy": "24px 26px", "roomy": "28px 30px"}
+        metric_padding_map = {"compact": "12px 14px", "cozy": "14px 16px", "roomy": "16px 18px"}
+        style = {
+            "--mission-panel-padding": padding_map.get(self.panel_density, padding_map["cozy"]),
+            "--mission-metric-padding": metric_padding_map.get(
+                self.panel_density, metric_padding_map["cozy"]
+            ),
+        }
+        classes = ["luxe-mission-panel"]
+        if self.animate:
+            classes.append("reveal")
+        show_heading = self.title if show_title is None else show_title
+        heading_html = (
+            f"<h3 class='luxe-mission-panel__title'>{self.title}</h3>"
+            if show_heading
+            else ""
+        )
+        metrics_html = "".join(metric_markup(metric) for metric in self.metrics)
+        return (
+            f"<aside class='{_class_names(classes)}' id='sticky-metrics' style='{_merge_styles(style, {})}'>"
+            f"{heading_html}"
+            "<div class='luxe-mission-panel__metrics'>"
+            f"{metrics_html}"
+            "</div>"
+            "</aside>"
+        )
+
+    def render(
+        self,
+        *,
+        highlight_key: str | None = None,
+        layout: Literal["panel", "grid"] = "panel",
+        detail_limit: int | None = None,
+        show_title: bool | None = None,
+    ) -> None:
+        _load_css()
+        st.markdown(
+            self.markup(
+                highlight_key=highlight_key,
+                layout=layout,
+                detail_limit=detail_limit,
+                show_title=show_title,
+            ),
+            unsafe_allow_html=True,
+        )
+
+
+@dataclass
+class CarouselItem:
+    title: str
+    value: str | None = None
+    description: str | None = None
+    icon: str | None = None
+
+    def markup(self) -> str:
+        icon_html = (
+            f"<div class='luxe-carousel-card__icon'>{self.icon}</div>"
+            if self.icon
+            else ""
+        )
+        value_html = (
+            f"<div class='luxe-carousel-card__value'>{self.value}</div>"
+            if self.value
+            else ""
+        )
+        description_html = (
+            f"<p class='luxe-carousel-card__description'>{self.description}</p>"
+            if self.description
+            else ""
+        )
+        return (
+            "<div class='luxe-carousel-card'>"
+            f"{icon_html}"
+            f"<h4>{self.title}</h4>"
+            f"{value_html}"
+            f"{description_html}"
+            "</div>"
+        )
+
+
+@dataclass
+class CarouselRail:
+    items: Sequence[CarouselItem]
+    data_track: str | None = None
+    reveal: bool = True
+    min_width: str = "15rem"
+    density: str = "cozy"
+
+    def markup(self) -> str:
+        gap_map = {"compact": "0.75rem", "cozy": "1rem", "roomy": "1.25rem"}
+        padding_map = {"compact": "16px", "cozy": "18px", "roomy": "20px"}
+        style = {
+            "--carousel-min": self.min_width,
+            "--carousel-gap": gap_map.get(self.density, gap_map["cozy"]),
+            "--carousel-card-padding": padding_map.get(self.density, padding_map["cozy"]),
+        }
+        classes = ["luxe-carousel"]
+        if self.reveal:
+            classes.append("reveal")
+        metrics_html = "".join(item.markup() for item in self.items)
+        data_attr = f" data-carousel='{self.data_track}'" if self.data_track else ""
+        return (
+            f"<div class='{_class_names(classes)}' style='{_merge_styles(style, {})}'{data_attr}>"
+            f"{metrics_html}"
+            "</div>"
+        )
+
+    def render(self) -> None:
+        _load_css()
+        st.markdown(self.markup(), unsafe_allow_html=True)
+
+
+@dataclass
+class ActionCard:
+    title: str
+    body: str
+    icon: str | None = None
+    tag: str | None = None
+
+    def markup(self) -> str:
+        tag_html = (
+            f"<div class='luxe-action-card__tag'>{self.tag}</div>"
+            if self.tag
+            else ""
+        )
+        icon_html = (
+            f"<span class='luxe-action-card__icon'>{self.icon}</span>"
+            if self.icon
+            else ""
+        )
+        return (
+            "<div class='luxe-action-card'>"
+            f"{icon_html}"
+            f"{tag_html}"
+            f"<h3 class='luxe-action-card__title'>{self.title}</h3>"
+            f"<p class='luxe-action-card__body'>{self.body}</p>"
+            "</div>"
+        )
+
+
+@dataclass
+class ActionDeck:
+    cards: Sequence[ActionCard]
+    columns_min: str = "16rem"
+    density: str = "cozy"
+    gap: str | None = None
+    reveal: bool = True
+
+    def markup(self) -> str:
+        gap_map = {"compact": "0.9rem", "cozy": "1.1rem", "roomy": "1.4rem"}
+        padding_map = {"compact": "18px 20px", "cozy": "22px 24px", "roomy": "26px 28px"}
+        style = {
+            "--action-min": self.columns_min,
+            "--action-gap": self.gap or gap_map.get(self.density, gap_map["cozy"]),
+            "--action-card-padding": padding_map.get(self.density, padding_map["cozy"]),
+        }
+        classes = ["luxe-action-deck"]
+        if self.reveal:
+            classes.append("reveal")
+        cards_html = "".join(card.markup() for card in self.cards)
+        return (
+            f"<div class='{_class_names(classes)}' style='{_merge_styles(style, {})}'>"
+            f"{cards_html}"
+            "</div>"
+        )
+
+    def render(self) -> None:
+        _load_css()
+        st.markdown(self.markup(), unsafe_allow_html=True)
+
+
+@dataclass
 class GlassCard:
     title: str
     body: str
@@ -1664,10 +2143,16 @@ __all__ = [
     "render_card",
     "render_pill",
     "ChipRow",
-    "TeslaHero",
+    "TeslaHero", 
     "TeslaHeroBriefingScene",
     "MetricGalaxy",
     "MetricItem",
+    "MissionMetric",
+    "MissionMetrics",
+    "CarouselItem",
+    "CarouselRail",
+    "ActionCard",
+    "ActionDeck",
     "GlassStack",
     "GlassCard",
 ]

--- a/app/static/home.css
+++ b/app/static/home.css
@@ -97,84 +97,6 @@ section {
   margin-bottom: 18px;
 }
 
-.mission-grid {
-  display: grid;
-  gap: 18px;
-  margin-top: 26px;
-  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-}
-
-.mission-grid > div {
-  padding: 22px;
-  border-radius: 22px;
-  border: 1px solid var(--stroke);
-  background: color-mix(in srgb, var(--surface-panel) 88%, transparent);
-  color: var(--ink);
-}
-
-.mission-grid h3 {
-  margin-bottom: 8px;
-  font-size: 1.06rem;
-}
-
-.mission-grid p {
-  margin: 0;
-  color: var(--muted);
-  font-size: 0.94rem;
-}
-
-.metric-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
-  gap: 16px;
-  margin-top: 18px;
-}
-
-.metric {
-  border-radius: 18px;
-  padding: 18px 20px;
-  background: var(--metric-bg);
-  border: 1px solid var(--metric-border);
-  color: var(--ink);
-  box-shadow: var(--metric-shadow);
-  transition: border 300ms ease, box-shadow 300ms ease;
-}
-
-.metric.highlight {
-  border-color: color-mix(in srgb, var(--accent) 60%, transparent);
-  box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent) 18%, transparent);
-}
-
-.metric h5 {
-  margin: 0;
-  font-size: 0.92rem;
-  color: var(--muted);
-}
-
-.metric strong {
-  font-size: 1.4rem;
-  display: block;
-  margin-top: 6px;
-}
-
-.chip-row {
-  display: flex;
-  gap: 8px;
-  margin-top: 18px;
-  flex-wrap: wrap;
-}
-
-.chip {
-  padding: 6px 14px;
-  border-radius: 999px;
-  font-size: 0.82rem;
-  font-weight: 600;
-  background: var(--chip-bg);
-  border: 1px solid var(--chip-border);
-  color: var(--chip-ink);
-  backdrop-filter: blur(12px);
-}
-
 .ghost-card {
   margin-top: 38px;
   display: grid;
@@ -238,52 +160,6 @@ section {
   margin: 0;
 }
 
-.sticky-panel {
-  position: sticky;
-  top: 84px;
-  border-radius: 22px;
-  border: 1px solid color-mix(in srgb, var(--border-soft) 72%, transparent);
-  padding: 24px 26px;
-  background: color-mix(in srgb, var(--surface-panel) 92%, transparent);
-  backdrop-filter: blur(18px);
-}
-
-.sticky-panel h3 {
-  margin-bottom: 18px;
-}
-
-.sticky-panel .metric {
-  border-radius: 16px;
-  padding: 14px 16px;
-  background: color-mix(in srgb, var(--surface-card) 85%, transparent);
-  border: 1px solid color-mix(in srgb, var(--border-soft) 60%, transparent);
-  margin-bottom: 14px;
-}
-
-.sticky-panel .metric:last-child {
-  margin-bottom: 0;
-}
-
-.sticky-panel .metric h5 {
-  margin: 0;
-  font-size: 0.85rem;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  color: color-mix(in srgb, var(--muted) 90%, transparent);
-}
-
-.sticky-panel .metric strong {
-  display: block;
-  margin-top: 4px;
-  font-size: 1.3rem;
-}
-
-.sticky-panel .metric p {
-  margin: 0;
-  color: var(--muted);
-  font-size: 0.85rem;
-}
-
 .section-title {
   display: flex;
   align-items: center;
@@ -307,48 +183,6 @@ section {
   display: grid;
   gap: 24px;
   grid-template-columns: minmax(0, 1fr);
-}
-
-.carousel {
-  display: flex;
-  gap: 16px;
-  overflow-x: auto;
-  padding-bottom: 6px;
-  scroll-snap-type: x mandatory;
-}
-
-.carousel::-webkit-scrollbar {
-  height: 6px;
-}
-
-.carousel::-webkit-scrollbar-thumb {
-  background: color-mix(in srgb, var(--accent) 45%, transparent);
-  border-radius: 999px;
-}
-
-.carousel-card {
-  min-width: 240px;
-  scroll-snap-align: start;
-  border-radius: 18px;
-  border: 1px solid color-mix(in srgb, var(--border-soft) 64%, transparent);
-  padding: 18px;
-  background: color-mix(in srgb, var(--surface-card) 82%, transparent);
-}
-
-.carousel-card h4 {
-  margin: 0 0 6px;
-  font-size: 1.02rem;
-}
-
-.carousel-card .value {
-  font-size: 1.3rem;
-  font-weight: 700;
-}
-
-.carousel-card p {
-  margin: 4px 0 0;
-  font-size: 0.85rem;
-  color: var(--muted);
 }
 
 .drawer {
@@ -380,58 +214,8 @@ section {
   color: var(--muted);
 }
 
-.cta-grid {
-  display: grid;
-  gap: 22px;
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-}
-
-.cta-card {
-  border-radius: 22px;
-  border: 1px solid color-mix(in srgb, var(--accent) 28%, transparent);
-  padding: 22px 24px;
-  background: linear-gradient(160deg, color-mix(in srgb, var(--accent) 16%, transparent), color-mix(in srgb, var(--surface-panel) 78%, transparent));
-  position: relative;
-}
-
-.cta-card strong {
-  display: block;
-  font-size: 1.18rem;
-  margin-bottom: 8px;
-}
-
-.cta-card p {
-  margin: 0;
-  color: var(--muted);
-}
-
-.cta-card button {
-  margin-top: 18px;
-  width: 100%;
-}
-
-.cta-card .icon {
-  position: absolute;
-  top: 16px;
-  right: 18px;
-  font-size: 1.4rem;
-  opacity: 0.8;
-}
-
-.carousel,
-.chip-row {
-  scrollbar-width: thin;
-  scrollbar-color: color-mix(in srgb, var(--accent) 45%, transparent) transparent;
-}
-
 @media (max-width: 992px) {
   .tesla-hero__content {
     padding: 32px 24px;
-  }
-
-  .sticky-panel {
-    position: relative;
-    top: auto;
-    margin-top: 24px;
   }
 }

--- a/docs/ui-components.md
+++ b/docs/ui-components.md
@@ -70,6 +70,88 @@ MetricGalaxy(
 - El `delta` se renderiza en un subtítulo pequeño; usalo para diferencias heurística/ML.
 - `min_width` controla el ancho mínimo de cada tarjeta dentro de la grilla.
 
+### `MissionMetrics`
+Panel pegajoso para KPIs de misión con opción de grilla responsiva.
+
+```python
+from app.modules.luxe_components import MissionMetrics
+
+payload = [
+    {
+        "key": "status",
+        "label": "Estado",
+        "value": "✅ Modelo listo",
+        "details": ["Modelo <code>rexai-rf-ensemble</code>"],
+        "stage_key": "inventory",
+    },
+    {
+        "key": "training",
+        "label": "Entrenamiento",
+        "value": "15 ene 2024",
+        "details": ["Origen: dataset marciano", "Muestras: 1.2k"],
+        "stage_key": "generator",
+    },
+]
+
+mission_metrics = MissionMetrics.from_payload(payload)
+mission_metrics.render(highlight_key="generator")
+
+# Grilla compacta para resúmenes finales
+mission_metrics.render(layout="grid", detail_limit=2, show_title=False)
+```
+
+- `highlight_key` resalta la métrica asociada al paso activo del flujo.
+- `layout="grid"` reutiliza los mismos datos en formato tablero (ideal para secciones de resultados).
+- Ajustá `panel_density`/`grid_density` a `"compact"`, `"cozy"` o `"roomy"` según el espacio disponible.
+
+### `CarouselRail`
+Hilera horizontal scrollable para resúmenes rápidos (categorías, materiales, etc.).
+
+```python
+from app.modules.luxe_components import CarouselItem, CarouselRail
+
+CarouselRail(
+    items=[
+        CarouselItem(title="EVA scraps", value="320 kg", description="Volumen: 450 L"),
+        CarouselItem(title="Metales", value="210 kg", description="Volumen: 180 L"),
+    ],
+    data_track="categorias",
+    density="compact",
+).render()
+```
+
+- `density` controla gap y padding de cada tarjeta.
+- Podés dejar `data_track` vacío o usarlo como `data-*` para analytics.
+- Si necesitás componer dentro de otra tarjeta, usá `CarouselRail(...).markup()` y embébelo manualmente.
+
+### `ActionDeck`
+Grilla declarativa de CTAs o pasos operativos.
+
+```python
+from app.modules.luxe_components import ActionCard, ActionDeck
+
+ActionDeck(
+    cards=[
+        ActionCard(
+            title="Exportar receta",
+            body="Descargá Sankey + trazabilidad completa.",
+            icon="📤",
+        ),
+        ActionCard(
+            title="Simular objetivo",
+            body="Proba presets de energía, crew y materiales.",
+            icon="🧮",
+        ),
+    ],
+    columns_min="16rem",
+    density="cozy",
+).render()
+```
+
+- Usa `ActionDeck(..., reveal=False)` si no necesitás la animación de entrada.
+- `ActionCard.body` acepta HTML ligero (`<code>`, `<strong>`) para destacar datos clave.
+- Podés encadenar varios `ActionDeck` para separar pasos y CTAs secundarios manteniendo el mismo estilo.
+
 ### `GlassStack`
 Stack responsivo de tarjetas glassmórficas.
 

--- a/tests/ui/test_home_components.py
+++ b/tests/ui/test_home_components.py
@@ -1,0 +1,81 @@
+"""Smoke tests for declarative components used on the Home page."""
+
+import sys
+import types
+
+import pytest
+
+pytest.importorskip("numpy")
+pytest.importorskip("plotly")
+
+if "joblib" not in sys.modules:
+    sys.modules["joblib"] = types.ModuleType("joblib")
+
+from app.modules.luxe_components import (
+    ActionCard,
+    ActionDeck,
+    CarouselItem,
+    CarouselRail,
+    MissionMetrics,
+)
+
+
+def test_mission_metrics_markup_variants() -> None:
+    payload = [
+        {
+            "key": "status",
+            "label": "Estado",
+            "value": "✅",
+            "details": ["Modelo rexai"],
+            "stage_key": "inventory",
+        },
+        {
+            "key": "results",
+            "label": "Resultados",
+            "value": "Listo",
+            "details": ["Trade-offs listos"],
+            "stage_key": "results",
+        },
+    ]
+    metrics = MissionMetrics.from_payload(payload, title="Panel de misión")
+
+    panel_html = metrics.markup(highlight_key="results")
+    assert "luxe-mission-panel" in panel_html
+    assert "is-active" in panel_html
+    assert "Trade-offs listos" in panel_html
+
+    grid_html = metrics.markup(layout="grid", detail_limit=1, show_title=False)
+    assert "luxe-mission-grid" in grid_html
+    assert "Panel de misión" not in grid_html
+
+
+def test_carousel_rail_markup() -> None:
+    rail = CarouselRail(
+        items=[
+            CarouselItem(title="EVA scraps", value="320 kg", description="Volumen: 450 L"),
+        ],
+        reveal=False,
+    )
+
+    html = rail.markup()
+    assert "luxe-carousel" in html
+    assert "EVA scraps" in html
+    assert "320 kg" in html
+
+
+def test_action_deck_markup() -> None:
+    deck = ActionDeck(
+        cards=[
+            ActionCard(
+                title="Exportar receta",
+                body="Descargá Sankey + trazabilidad completa.",
+                icon="📤",
+            )
+        ],
+        reveal=False,
+    )
+
+    html = deck.markup()
+    assert "luxe-action-deck" in html
+    assert "📤" in html
+    assert "Descargá Sankey" in html


### PR DESCRIPTION
## Summary
- add MissionMetrics, CarouselRail and ActionDeck abstractions to the luxe components library
- refactor the Home page to render metrics, carousels and CTAs with the new components and remove bespoke CSS
- document the new UI primitives and cover them with lightweight smoke tests

## Testing
- pytest tests/ui/test_home_components.py *(skipped: missing optional numpy/plotly dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68dafb6834608331aa9cde8b48040eb6