### PR TITLE
Add ranking cockpit UI for generator page

### DIFF
--- a/app/pages/3_Generator.py
+++ b/app/pages/3_Generator.py
@@ -20,7 +20,7 @@ from app.modules.ui_blocks import (
     load_theme,
     micro_divider,
 )
-from app.modules.luxe_components import TeslaHero, ChipRow
+from app.modules.luxe_components import ChipRow, MetricSpec, RankingCockpit, TeslaHero
 from app.modules.visualizations import ConvergenceScene
 
 st.set_page_config(page_title="Rex-AI • Generador", page_icon="🤖", layout="wide")
@@ -321,8 +321,22 @@ for idx, cand in enumerate(cands, start=1):
 if summary_rows:
     st.subheader("Ranking multiobjetivo")
     st.caption("Ordenado por score total, con sellado y riesgo resumidos.")
-    summary_df = pd.DataFrame(summary_rows)
-    st.dataframe(summary_df, hide_index=True, use_container_width=True)
+    cockpit = RankingCockpit(
+        entries=summary_rows,
+        metric_specs=[
+            MetricSpec("Rigidez", "Rigidez", "{:.2f}"),
+            MetricSpec("Estanqueidad", "Estanqueidad", "{:.2f}"),
+            MetricSpec("Energía (kWh)", "Energía", "{:.2f}", unit="kWh", higher_is_better=False),
+            MetricSpec("Agua (L)", "Agua", "{:.1f}", unit="L", higher_is_better=False),
+            MetricSpec("Crew (min)", "Crew", "{:.1f}", unit="min", higher_is_better=False),
+        ],
+        key="generator_ranking",
+        score_label="Score",
+        selection_label="📌 Candidato destacado",
+    )
+    selected_summary = cockpit.render()
+    if selected_summary is not None:
+        st.session_state["generator_ranking_focus"] = selected_summary
 
 # ----------------------------- Showroom de candidatos -----------------------------
 st.subheader("Resultados del generador")

--- a/docs/ui-components.md
+++ b/docs/ui-components.md
@@ -70,6 +70,58 @@ MetricGalaxy(
 - El `delta` se renderiza en un subtítulo pequeño; usalo para diferencias heurística/ML.
 - `min_width` controla el ancho mínimo de cada tarjeta dentro de la grilla.
 
+### `RankingCockpit`
+Cabina de ranking con tarjetas comparativas, barras neumórficas y filtros interactivos.
+
+```python
+from app.modules.luxe_components import MetricSpec, RankingCockpit
+
+cockpit = RankingCockpit(
+    entries=[
+        {
+            "Rank": 1,
+            "Score": 0.91,
+            "Proceso": "P04 · Sinter EVA",
+            "Rigidez": 12.4,
+            "Estanqueidad": 0.88,
+            "Energía (kWh)": 14.2,
+            "Agua (L)": 8.1,
+            "Crew (min)": 36.0,
+            "Seal": "✅",
+            "Riesgo": "Bajo",
+        },
+        {
+            "Rank": 2,
+            "Score": 0.86,
+            "Proceso": "P02 · Laminado CTB",
+            "Rigidez": 11.9,
+            "Estanqueidad": 0.9,
+            "Energía (kWh)": 18.5,
+            "Agua (L)": 6.4,
+            "Crew (min)": 42.0,
+            "Seal": "⚠️",
+            "Riesgo": "Medio",
+        },
+    ],
+    metric_specs=[
+        MetricSpec("Rigidez", "Rigidez", "{:.2f}"),
+        MetricSpec("Estanqueidad", "Estanqueidad", "{:.2f}"),
+        MetricSpec("Energía (kWh)", "Energía", "{:.1f}", unit="kWh", higher_is_better=False),
+        MetricSpec("Agua (L)", "Agua", "{:.1f}", unit="L", higher_is_better=False),
+        MetricSpec("Crew (min)", "Crew", "{:.0f}", unit="min", higher_is_better=False),
+    ],
+    key="demo_ranking",
+    selection_label="📌 Foco del cockpit",
+)
+
+focused_entry = cockpit.render()
+```
+
+- `entries` es una lista de diccionarios: cada fila debe exponer las claves para score, riesgo/sellado y métricas.
+- Configurá las barras con `MetricSpec`: la propiedad `higher_is_better=False` invierte la escala (útil para agua/energía/crew).
+- El usuario puede ordenar por cualquier métrica, filtrar riesgos/sellos y elegir una tarjeta activa (la clase `selected` aplica un glow azul).
+- El método `render()` devuelve el diccionario del candidato seleccionado para que puedas sincronizarlo con otros módulos (`st.session_state`, tabs, etc.).
+
 ### `GlassStack`
 Stack responsivo de tarjetas glassmórficas.
 

--- a/tests/ui/test_ranking_cockpit.py
+++ b/tests/ui/test_ranking_cockpit.py
@@ -1,0 +1,87 @@
+import re
+import sys
+import types
+from pathlib import Path
+
+stub_joblib = types.ModuleType("joblib")
+stub_joblib.load = lambda *_args, **_kwargs: None  # type: ignore[attr-defined]
+sys.modules.setdefault("joblib", stub_joblib)
+
+modules_pkg = types.ModuleType("app.modules")
+modules_pkg.__path__ = [str(Path(__file__).resolve().parents[2] / "app" / "modules")]
+sys.modules.setdefault("app.modules", modules_pkg)
+
+try:
+    from app.modules.luxe_components import MetricSpec, RankingCockpit
+finally:
+    sys.modules.pop("app.modules", None)
+
+
+def test_ranking_cockpit_markup() -> None:
+    entries = [
+        {
+            "Rank": 1,
+            "Score": 0.91,
+            "Proceso": "P04 · Sinter EVA",
+            "Rigidez": 12.4,
+            "Estanqueidad": 0.88,
+            "Energía (kWh)": 14.2,
+            "Agua (L)": 9.0,
+            "Crew (min)": 36.0,
+            "Seal": "✅",
+            "Riesgo": "Bajo",
+        },
+        {
+            "Rank": 2,
+            "Score": 0.83,
+            "Proceso": "P02 · Laminado CTB",
+            "Rigidez": 11.6,
+            "Estanqueidad": 0.9,
+            "Energía (kWh)": 12.8,
+            "Agua (L)": 6.0,
+            "Crew (min)": 42.0,
+            "Seal": "⚠️",
+            "Riesgo": "Medio",
+        },
+        {
+            "Rank": 3,
+            "Score": 0.78,
+            "Proceso": "P03 · Regolito",
+            "Rigidez": 10.9,
+            "Estanqueidad": 0.84,
+            "Energía (kWh)": 11.3,
+            "Agua (L)": 3.2,
+            "Crew (min)": 50.0,
+            "Seal": "✅",
+            "Riesgo": "Crítico",
+        },
+    ]
+
+    specs = [
+        MetricSpec("Rigidez", "Rigidez", "{:.1f}"),
+        MetricSpec("Estanqueidad", "Estanqueidad", "{:.2f}"),
+        MetricSpec("Energía (kWh)", "Energía", "{:.1f}", unit="kWh"),
+        MetricSpec("Agua (L)", "Agua", "{:.1f}", unit="L", higher_is_better=False),
+    ]
+
+    cockpit = RankingCockpit(entries=entries, metric_specs=specs, key="test_ranking")
+    scales = cockpit._metric_scales(entries)
+    prepared = cockpit._prepare_entries(entries, scales)
+    markup = cockpit._build_cards(prepared, selected_idx=1)
+
+    assert markup.count("ranking-card__rank") == 3
+    assert "selected" in markup
+    assert "seal-warn" in markup
+    assert "tone-high" in markup
+    assert "kWh" in markup
+
+    agua_fills = [
+        float(value)
+        for value in re.findall(
+            r"data-metric='Agua \(L\)'.*?--fill:([0-9.]+)%;",
+            markup,
+            flags=re.S,
+        )
+    ]
+    assert len(agua_fills) == 3
+    assert agua_fills[0] < agua_fills[1] < agua_fills[2]


### PR DESCRIPTION
## Summary
- add a neumorphic ranking cockpit component with MetricSpec helpers in `luxe_components`
- replace the generator dataframe with the cockpit and expose the focused candidate in session state
- document the cockpit API in `docs/ui-components.md` and cover it with a render test

## Testing
- pytest tests/ui/test_ranking_cockpit.py


------
https://chatgpt.com/codex/tasks/task_e_68db035696c08331a28c56cb4f614007