### PR TITLE
Resolve Streamlit widget and indentation issues

### DIFF
--- a/app/Home.py
+++ b/app/Home.py
@@ -423,22 +423,11 @@ with cta_col1:
         ],
         columns_min="18rem",
     ).render()
-    if st.button("📤 Exportar", use_container_width=True):
-    st.markdown(
-        """
-        <div class="cta-grid">
-          <div class="cta-card reveal">
-            <span class="icon">📤</span>
-            <strong>Exportar receta y telemetría</strong>
-            <p>Descargá reportes con Sankey, contribuciones y feedback para seguimiento.</p>
-          </div>
-        </div>
-        """,
-        unsafe_allow_html=True,
-    )
+
     export_state_key = "home_cta_export_state"
     if st.session_state.get(export_state_key) == "loading":
         st.session_state[export_state_key] = "success"
+
     export_state = st.session_state.setdefault(export_state_key, "idle")
     if futuristic_button(
         "Exportar\nreceta y telemetría",
@@ -451,6 +440,7 @@ with cta_col1:
     ):
         st.session_state[export_state_key] = "loading"
         st.switch_page("pages/4_Results_and_Tradeoffs.py")
+
 with cta_col2:
     ActionDeck(
         cards=[
@@ -462,22 +452,11 @@ with cta_col2:
         ],
         columns_min="18rem",
     ).render()
-    if st.button("🧮 Simular escenarios", use_container_width=True):
-    st.markdown(
-        """
-        <div class="cta-grid">
-          <div class="cta-card reveal">
-            <span class="icon">🧮</span>
-            <strong>Simular escenarios</strong>
-            <p>Prueba configuraciones de energía, crew y materiales para stress tests.</p>
-          </div>
-        </div>
-        """,
-        unsafe_allow_html=True,
-    )
+
     sim_state_key = "home_cta_simulation_state"
     if st.session_state.get(sim_state_key) == "loading":
         st.session_state[sim_state_key] = "success"
+
     sim_state = st.session_state.setdefault(sim_state_key, "idle")
     if futuristic_button(
         "Simular\nescenarios",

--- a/app/modules/ui_blocks.py
+++ b/app/modules/ui_blocks.py
@@ -225,7 +225,7 @@ def surface(
 ) -> Iterator[DeltaGenerator]:
     """Render content inside a themed surface wrapper."""
 
-    load_theme()
+    load_theme(show_hud=False)
     container = st.container()
     opener = _surface_markup(tone=tone, padding=padding, shadow=shadow, radius=radius)
     container.markdown(opener, unsafe_allow_html=True)
@@ -246,7 +246,7 @@ def glass_card(
 ) -> Iterator[DeltaGenerator]:
     """Render content inside a frosted glass style surface."""
 
-    load_theme()
+    load_theme(show_hud=False)
     container = st.container()
     opener = _surface_markup(
         tone="base", padding=padding, shadow=shadow, radius=radius, extra_class="rex-glass"

--- a/app/pages/4_Results_and_Tradeoffs.py
+++ b/app/pages/4_Results_and_Tradeoffs.py
@@ -8,7 +8,6 @@ import streamlit as st
 
 from app.modules.ui_blocks import load_theme, layout_block
 from app.modules.navigation import render_breadcrumbs, set_active_step
-from app.modules.ui_blocks import load_theme
 from app.modules.luxe_components import (
     GlassCard,
     GlassStack,
@@ -112,6 +111,7 @@ for label, val_ml, val_h, interval in labels:
     ci_html = ""
     if interval:
         ci_html = f"<div class='delta'>CI 95%: [{interval[0]:.3f}, {interval[1]:.3f}]</div>"
+
     cards.append(
         f"<div class='stat-card layer-shadow'>"
         f"<span>{label}</span>"
@@ -120,8 +120,7 @@ for label, val_ml, val_h, interval in labels:
         f"{ci_html}"
         "</div>"
     )
-metrics_html = "<div class='metric-grid fade-in'>" + "".join(cards) + "</div>"
-st.markdown(metrics_html, unsafe_allow_html=True)
+
     delta_value = val_ml - val_h
     caption_bits = [f"Heurística: {val_h:.3f}"]
     if interval:
@@ -129,6 +128,7 @@ st.markdown(metrics_html, unsafe_allow_html=True)
             caption_bits.append(f"CI 95% [{interval[0]:.3f}, {interval[1]:.3f}]")
         except (TypeError, ValueError, IndexError):
             pass
+
     metric_items.append(
         MetricItem(
             label=label,
@@ -138,6 +138,9 @@ st.markdown(metrics_html, unsafe_allow_html=True)
             icon=icon_map.get(label),
         )
     )
+
+metrics_html = "<div class='metric-grid fade-in'>" + "".join(cards) + "</div>"
+st.markdown(metrics_html, unsafe_allow_html=True)
 
 MetricGalaxy(metrics=metric_items, density="compact").render()
 if uncertainty:

--- a/app/pages/7_Scenario_Playbooks.py
+++ b/app/pages/7_Scenario_Playbooks.py
@@ -2,10 +2,10 @@
 import _bootstrap  # noqa: F401
 
 import streamlit as st
-import pandas as pd
 
 from app.modules.navigation import render_breadcrumbs, set_active_step
 from app.modules.scenarios import PLAYBOOKS  # dict: {scenario: Playbook(name, summary, steps=[...])}
+from app.modules.ui_blocks import load_theme
 
 # ⚠️ Debe ser la primera llamada
 st.set_page_config(page_title="Scenario Playbooks", page_icon="📚", layout="wide")


### PR DESCRIPTION
## Summary
- clean up the home page CTA columns to rely on the futuristic button widgets without redundant markdown blocks
- fix the results metrics loop so cards and MetricGalaxy entries render together without indentation errors
- import the shared theme on the playbooks page and prevent duplicated HUD widgets when using surface/glass helpers

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68db088592d08331aba95aec53df463b