### PR TITLE
Create mission flow showcase component

### DIFF
--- a/app/Home.py
+++ b/app/Home.py
@@ -12,15 +12,12 @@ from app.modules.luxe_components import (
     BriefingCard,
     CarouselItem,
     CarouselRail,
-    GlassCard,
-    GlassStack,
     HeroFlowStage,
     MetricGalaxy,
+    MissionFlowShowcase,
     MissionMetrics,
     TeslaHero,
-    TimelineMilestone,
     guided_demo,
-    orbital_timeline,
 )
 from app.modules.ml_models import get_model_registry
 from app.modules.navigation import set_active_step
@@ -121,7 +118,13 @@ mission_stages = [
         name="Inventario",
         hero_headline="Calibrá el inventario",
         hero_copy="Normalizá residuos, detectá flags EVA y estructuras multi-layer.",
-        card_body="Normalizá residuos y marcá flags problemáticos (multilayer, EVA, nitrilo).",
+        card_body=(
+            "Normalizá residuos, marcá flags (multilayer, EVA, nitrilo) y trabajá sobre "
+            "<code>data/waste_inventory_sample.csv</code> o tu CSV limpio."
+        ),
+        compact_card_body=(
+            "Normalizá residuos y flags EVA/multilayer sobre <code>data/waste_inventory_sample.csv</code>."
+        ),
         icon="🧱",
         timeline_label="Inventario en vivo",
         timeline_description="Ingerí CSV NASA, normalizá unidades y marca riesgos EVA desde la cabina.",
@@ -133,7 +136,10 @@ mission_stages = [
         name="Target",
         hero_headline="Seleccioná objetivo",
         hero_copy="Define límites de agua, energía y logística con presets marcianos.",
-        card_body="Elegí producto final y límites de agua, energía y crew para la misión.",
+        card_body=(
+            "Elegí producto final, límites de agua/energía y presets marcianos (container, utensil, tool, interior)."
+        ),
+        compact_card_body="Elegí producto y límites con presets marcianos certificados.",
         icon="🎯",
         timeline_label="Target marciano",
         timeline_description="Seleccioná producto final, límites de agua y energía, o usa presets homologados.",
@@ -145,7 +151,10 @@ mission_stages = [
         name="Generador",
         hero_headline="Generá y valida",
         hero_copy="Rex-AI mezcla, explica contribuciones y exporta procesos listos para la tripulación.",
-        card_body="Rex-AI mezcla ítems, sugiere proceso y explica cada predicción en vivo.",
+        card_body=(
+            "Rex-AI mezcla ítems, compara heurística vs modelo y explica cada contribución en vivo."
+        ),
+        compact_card_body="Mezclá ítems, compará heurística vs IA y revisá contribuciones al instante.",
         icon="🤖",
         timeline_label="Generador IA",
         timeline_description="Explorá mezclas óptimas, revisá contribuciones y bandas de confianza en segundos.",
@@ -157,7 +166,10 @@ mission_stages = [
         name="Resultados",
         hero_headline="Reportá y exportá",
         hero_copy="Trade-offs, confianza 95% y comparativa heurística listos para ingeniería.",
-        card_body="Trade-offs, confianza 95%, comparación heurística vs IA y export final.",
+        card_body=(
+            "Trade-offs, bandas 95%, comparación heurística vs IA y export Sankey/feedback listos para ingeniería."
+        ),
+        compact_card_body="Revisá trade-offs, bandas 95% y export Sankey/feedback final.",
         icon="📊",
         timeline_label="Resultados y export",
         timeline_description="Compará heurísticas vs IA, exportá recetas y registra feedback para retraining.",
@@ -361,11 +373,6 @@ st.markdown("### Ruta de misión (guided flow)")
 
 demo_steps = hero_scene.timeline_milestones()
 active_demo_step = guided_demo(steps=demo_steps, step_duration=6.5)
-GlassStack(
-    cards=hero_scene.glass_cards(),
-    columns_min="15rem",
-    density="compact",
-).render()
 
 active_stage_key = (
     hero_scene.stage_key_for_label(active_demo_step.label)
@@ -377,6 +384,53 @@ metrics_placeholder.markdown(
     unsafe_allow_html=True,
 )
 
+mission_showcase_insights = [
+    "<code>python -m app.modules.model_training</code> genera dataset y RandomForest multisalida listo.",
+    "Cada receta conserva IDs, categorías, flags de riesgo y metadatos de entrenamiento.",
+    "Contribuciones por feature, bandas 95% y comparador heurístico vs IA en UI.",
+    "Export Sankey y feedback listos para continuar el retraining marciano.",
+]
+
+MissionFlowShowcase(
+    stages=mission_stages,
+    title="Acciones siguientes",
+    subtitle="Mantené el contexto del laboratorio mientras ejecutás exports, simulaciones y reportes clave.",
+    timeline_title="¿Qué demuestra esta demo hoy?",
+    insights=mission_showcase_insights,
+    primary_actions=[
+        ActionCard(
+            title="Construir inventario",
+            body="Normalizá residuos NASA y etiquetá flags EVA, multilayer y nitrilo.",
+            icon="🧱",
+        ),
+        ActionCard(
+            title="Generador IA vs heurística",
+            body="Compara recetas propuestas, trade-offs y bandas de confianza.",
+            icon="🤖",
+        ),
+    ],
+    secondary_actions=[
+        ActionCard(
+            title="1. Inventario NASA",
+            body="Trabajá sobre <code>data/waste_inventory_sample.csv</code> o subí tu CSV normalizado.",
+        ),
+        ActionCard(
+            title="2. Objetivo",
+            body="Usá presets (container, utensil, tool, interior) o definí límites manuales.",
+        ),
+        ActionCard(
+            title="3. Generador con IA",
+            body="Revisá contribuciones de features y compará heurística vs modelo.",
+        ),
+        ActionCard(
+            title="4. Reportar",
+            body="Exportá recetas, Sankey y feedback/impact para seguir entrenando Rex-AI.",
+        ),
+    ],
+    action_density="cozy",
+    secondary_action_columns_min="14rem",
+).render()
+
 if scenario_toggle and inventory_df is not None:
     flagged = inventory_df["flags"].dropna().head(6).tolist()
     bullet_items = "".join(
@@ -387,29 +441,10 @@ if scenario_toggle and inventory_df is not None:
         <div class="drawer reveal">
           <h4>Flags operativos activos</h4>
           <ul>{bullet_items}</ul>
-          <div class="timeline">
-            <ul>
-              <li>Pipeline reproducible: <code>python -m app.modules.model_training</code> genera dataset + RandomForest.</li>
-              <li>Trazabilidad completa: cada receta incorpora IDs, categorías y metadatos.</li>
-              <li>Explicabilidad integrada: contribuciones por feature y bandas de confianza 95%.</li>
-              <li>Comparativa heurística vs IA lista para export.</li>
-            </ul>
-          </div>
         </div>
         """,
         unsafe_allow_html=True,
     )
-
-# ──────────── Acciones siguientes ────────────
-st.markdown(
-    """
-    <section class="next-block reveal" id="acciones-siguientes">
-      <div class="section-title"><span class="icon">🚀</span><h2>Acciones siguientes</h2></div>
-      <p>Mantené el contexto del laboratorio mientras ejecutás exports, simulaciones y reportes clave.</p>
-    </section>
-    """,
-    unsafe_allow_html=True,
-)
 
 cta_col1, cta_col2 = st.columns(2, gap="large")
 with cta_col1:
@@ -479,46 +514,6 @@ st.markdown(
     ),
     unsafe_allow_html=True,
 )
-
-ActionDeck(
-    cards=[
-        ActionCard(
-            title="1. Inventario NASA",
-            body="Trabajá sobre <code>data/waste_inventory_sample.csv</code> o subí tu CSV normalizado.",
-        ),
-        ActionCard(
-            title="2. Objetivo",
-            body="Usá presets (container, utensil, tool, interior) o definí límites manuales.",
-        ),
-        ActionCard(
-            title="3. Generador con IA",
-            body="Revisá contribuciones de features y compará heurística vs modelo.",
-        ),
-        ActionCard(
-            title="4. Reportar",
-            body="Exportá recetas, Sankey y feedback/impact para seguir entrenando Rex-AI.",
-        ),
-    ],
-    columns_min="15rem",
-    density="cozy",
-).render()
-
-ActionDeck(
-    cards=[
-        ActionCard(
-            title="Construir inventario",
-            body="Normalizá residuos NASA y etiquetá flags EVA, multilayer y nitrilo.",
-            icon="🧱",
-        ),
-        ActionCard(
-            title="Generador IA vs heurística",
-            body="Compara recetas propuestas, trade-offs y bandas de confianza.",
-            icon="🤖",
-        ),
-    ],
-    columns_min="14rem",
-    density="cozy",
-).render()
 
 # ──────────── CTA navegación ────────────
 st.markdown("### Siguiente acción")
@@ -617,34 +612,6 @@ with cta_buttons[1]:
         st.session_state[generator_state_key] = "loading"
         st.switch_page("pages/3_Generator.py")
 
-# ──────────── Qué demuestra hoy ────────────
-st.markdown("---")
-st.markdown("### ¿Qué demuestra esta demo hoy?")
-
-orbital_timeline(
-    [
-        TimelineMilestone(
-            label="Pipeline reproducible",
-            description="<code>python -m app.modules.model_training</code> genera dataset y RandomForest multisalida listo.",
-            icon="🛠️",
-        ),
-        TimelineMilestone(
-            label="Trazabilidad de recetas",
-            description="Cada receta conserva IDs, categorías, flags de riesgo y metadatos de entrenamiento.",
-            icon="🛰️",
-        ),
-        TimelineMilestone(
-            label="Explicabilidad integrada",
-            description="Contribuciones por feature, bandas 95% y comparador heurístico vs IA en UI.",
-            icon="🧠",
-        ),
-        TimelineMilestone(
-            label="Export y feedback",
-            description="Entrega recetas, Sankey y feedback listos para continuar el retraining marciano.",
-            icon="📦",
-        ),
-    ]
-)
 # ──────────── Animación de aparición por scroll ────────────
 enable_reveal_animation()
 MetricGalaxy(
@@ -652,58 +619,7 @@ MetricGalaxy(
     density="cozy",
 ).render()
 
-# ──────────── Cómo navegar ────────────
-st.markdown("### Cómo navegar ahora")
-GlassStack(
-    cards=[
-        GlassCard(
-            title="1. Inventario NASA",
-            body="Trabajá sobre <code>data/waste_inventory_sample.csv</code> o subí tu CSV normalizado.",
-            icon="📦",
-        ),
-        GlassCard(
-            title="2. Objetivo",
-            body="Usá presets (container, utensil, tool, interior) o definí límites manuales.",
-            icon="🎛️",
-        ),
-        GlassCard(
-            title="3. Generador con IA",
-            body="Revisá contribuciones de features y compará heurística vs modelo.",
-            icon="🤝",
-        ),
-        GlassCard(
-            title="4. Reportar",
-            body="Exportá recetas, Sankey y feedback/impact para seguir entrenando Rex-AI.",
-            icon="📤",
-        ),
-    ],
-    columns_min="15rem",
-    density="cozy",
-).render()
-
-# ──────────── CTA navegación ────────────
 st.info(
     "Usá el **Mission HUD** superior para saltar entre pasos o presioná las teclas `1-9` "
     "para navegar más rápido por el flujo guiado."
 )
-
-# ──────────── Qué demuestra hoy ────────────
-st.markdown("---")
-GlassStack(
-    cards=[
-        GlassCard(
-            title="¿Qué demuestra esta demo hoy?",
-            body=(
-                "<ul>"
-                "<li>Pipeline reproducible: <code>python -m app.modules.model_training</code> genera dataset y el RandomForest multisalida.</li>"
-                "<li>Predicciones con trazabilidad: cada receta incluye IDs, categorías, flags y metadatos de entrenamiento.</li>"
-                "<li>Explicabilidad integrada: contribuciones por feature y bandas de confianza 95%.</li>"
-                "<li>Comparación heurística vs IA y export listo para experimentación.</li>"
-                "</ul>"
-            ),
-            icon="🛰️",
-        ),
-    ],
-    columns_min="26rem",
-    density="roomy",
-).render()

--- a/app/modules/luxe_components.py
+++ b/app/modules/luxe_components.py
@@ -949,6 +949,176 @@ _LUXE_COMPONENT_CSS = """
   margin: var(--stack-margin, 1.6rem 0 0);
 }
 
+.mission-flow-showcase {
+  position: relative;
+  display: grid;
+  gap: clamp(1.4rem, 2.8vw, 1.8rem);
+  padding: clamp(1.4rem, 2.6vw, 1.9rem);
+  border-radius: 26px;
+  border: 1px solid color-mix(in srgb, var(--luxe-border) 75%, transparent);
+  background: linear-gradient(150deg, rgba(15, 23, 42, 0.78), rgba(30, 41, 59, 0.82));
+  box-shadow: 0 26px 60px rgba(8, 15, 35, 0.42);
+  color: var(--luxe-ink);
+}
+
+.mission-flow-showcase::after {
+  content: "";
+  position: absolute;
+  inset: -40% -30% 40% 10%;
+  background: radial-gradient(circle at top right, rgba(96, 165, 250, 0.32), transparent 70%);
+  opacity: 0.55;
+  filter: blur(60px);
+  pointer-events: none;
+}
+
+.mission-flow-showcase__header {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  gap: 0.45rem;
+}
+
+.mission-flow-showcase__header h3 {
+  margin: 0;
+  font-size: clamp(1.35rem, 2.4vw, 1.6rem);
+}
+
+.mission-flow-showcase__header p {
+  margin: 0;
+  color: rgba(226, 232, 240, 0.78);
+  font-size: 0.95rem;
+}
+
+.mission-flow-showcase__content {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  gap: clamp(1.2rem, 2vw, 1.6rem);
+}
+
+@media (min-width: 1100px) {
+  .mission-flow-showcase__content {
+    grid-template-columns: 1.6fr 1fr;
+    align-items: start;
+  }
+}
+
+.mission-flow-showcase__steps {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(var(--mission-step-min, 15rem), 1fr));
+  gap: var(--mission-step-gap, 1.1rem);
+}
+
+.mission-flow-showcase__step {
+  position: relative;
+  display: grid;
+  gap: 0.6rem;
+  padding: var(--mission-step-padding, 1.25rem 1.35rem);
+  border-radius: 22px;
+  border: 1px solid color-mix(in srgb, var(--luxe-border) 75%, transparent);
+  background: linear-gradient(165deg, rgba(15, 23, 42, 0.85), rgba(30, 41, 59, 0.78));
+  box-shadow: inset 0 0 0 1px rgba(59, 130, 246, 0.08), 0 20px 40px rgba(8, 15, 35, 0.38);
+}
+
+.mission-flow-showcase__step-head {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.9rem;
+  align-items: start;
+}
+
+.mission-flow-showcase__step-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.6rem;
+  height: 2.6rem;
+  border-radius: 999px;
+  background: rgba(96, 165, 250, 0.16);
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  font-size: 1.3rem;
+}
+
+.mission-flow-showcase__step h4 {
+  margin: 0;
+  font-size: 1.08rem;
+}
+
+.mission-flow-showcase__copy {
+  margin: 0.35rem 0 0;
+  font-size: 0.96rem;
+  color: rgba(226, 232, 240, 0.78);
+}
+
+.mission-flow-showcase__copy [data-viewport="mobile"] {
+  display: none;
+}
+
+.mission-flow-showcase__step-footer {
+  margin: 0;
+  font-size: 0.82rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(148, 163, 184, 0.78);
+}
+
+@media (max-width: 900px) {
+  .mission-flow-showcase {
+    padding: clamp(1.2rem, 3vw, 1.5rem);
+  }
+
+  .mission-flow-showcase__steps {
+    gap: var(--mission-step-gap-mobile, 0.95rem);
+  }
+
+  .mission-flow-showcase__step {
+    padding: var(--mission-step-padding-mobile, 1.05rem 1.1rem);
+  }
+
+  .mission-flow-showcase__copy [data-viewport="desktop"] {
+    display: none;
+  }
+
+  .mission-flow-showcase__copy [data-viewport="mobile"] {
+    display: inline;
+  }
+}
+
+.mission-flow-showcase__timeline {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.mission-flow-showcase__timeline h4 {
+  margin: 0;
+  font-size: 1.05rem;
+}
+
+.mission-flow-showcase__timeline .orbital-timeline {
+  margin: 0;
+}
+
+.mission-flow-showcase__insights {
+  margin: 0;
+  padding-left: 1.1rem;
+  display: grid;
+  gap: 0.35rem;
+  color: rgba(226, 232, 240, 0.76);
+  font-size: 0.9rem;
+}
+
+.mission-flow-showcase__insights li {
+  margin: 0;
+}
+
+.mission-flow-showcase__actions {
+  margin-top: 1rem;
+}
+
+.mission-flow-showcase__actions + .mission-flow-showcase__actions {
+  margin-top: 1.2rem;
+}
+
 .luxe-card {
   position: relative;
   border-radius: 22px;
@@ -1528,6 +1698,7 @@ class HeroFlowStage:
     hero_headline: str
     hero_copy: str
     card_body: str
+    compact_card_body: str | None = None
     icon: str
     timeline_label: str
     timeline_description: str
@@ -1539,6 +1710,11 @@ class HeroFlowStage:
     @property
     def card_title(self) -> str:
         return f"{self.order} · {self.name}"
+
+    def copy_for_viewport(self, viewport: Literal["desktop", "mobile"] = "desktop") -> str:
+        if viewport == "mobile" and self.compact_card_body:
+            return self.compact_card_body
+        return self.card_body
 
 @dataclass
 class TargetPresetMeta:
@@ -2168,6 +2344,14 @@ def _merge_styles(base: Mapping[str, str], extra: Mapping[str, str] | None = Non
     if extra:
         merged.update({k: v for k, v in extra.items() if v is not None})
     return "; ".join(f"{k}: {v}" for k, v in merged.items())
+
+
+def _density_value(density: str, mapping: Mapping[str, str]) -> str:
+    if density in mapping:
+        return mapping[density]
+    if "cozy" in mapping:
+        return mapping["cozy"]
+    return next(iter(mapping.values()))
 
 
 def ChipRow(
@@ -3250,8 +3434,7 @@ class GlassStack:
     columns_min: str = "16rem"
     density: str = "cozy"
 
-    def render(self) -> None:
-        _load_css()
+    def markup(self) -> str:
         padding_map = {
             "compact": "1.05rem 1.15rem",
             "cozy": "1.3rem 1.4rem",
@@ -3280,8 +3463,213 @@ class GlassStack:
                 "</div>"
             )
         html.append("</div>")
-        st.markdown("".join(html), unsafe_allow_html=True)
+        return "".join(html)
 
+    def render(self) -> None:
+        _load_css()
+        st.markdown(self.markup(), unsafe_allow_html=True)
+
+
+@dataclass
+class MissionFlowShowcase:
+    stages: Sequence[HeroFlowStage]
+    primary_actions: Sequence[ActionCard] = field(default_factory=list)
+    secondary_actions: Sequence[ActionCard] = field(default_factory=list)
+    title: str | None = None
+    subtitle: str | None = None
+    stage_density: str = "cozy"
+    mobile_stage_density: str = "compact"
+    action_density: str = "cozy"
+    action_columns_min: str = "15rem"
+    secondary_action_columns_min: str | None = None
+    timeline_title: str | None = None
+    insights: Sequence[str] = field(default_factory=list)
+    stage_min_width: str = "15rem"
+
+    _ordered_stages: tuple[HeroFlowStage, ...] = field(init=False)
+
+    def __post_init__(self) -> None:
+        self._ordered_stages = tuple(sorted(self.stages, key=lambda stage: stage.order))
+
+    def copy_sequence(self, viewport: Literal["desktop", "mobile"] = "desktop") -> list[str]:
+        return [stage.copy_for_viewport(viewport) for stage in self._ordered_stages]
+
+    def stage_titles(self) -> list[str]:
+        return [stage.card_title for stage in self._ordered_stages]
+
+    def markup(self) -> str:
+        style = {
+            "--mission-step-gap": _density_value(
+                self.stage_density,
+                {"compact": "0.85rem", "cozy": "1.1rem", "roomy": "1.35rem"},
+            ),
+            "--mission-step-padding": _density_value(
+                self.stage_density,
+                {
+                    "compact": "1rem 1.05rem",
+                    "cozy": "1.25rem 1.35rem",
+                    "roomy": "1.5rem 1.65rem",
+                },
+            ),
+            "--mission-step-gap-mobile": _density_value(
+                self.mobile_stage_density,
+                {"compact": "0.8rem", "cozy": "0.95rem", "roomy": "1.15rem"},
+            ),
+            "--mission-step-padding-mobile": _density_value(
+                self.mobile_stage_density,
+                {
+                    "compact": "0.9rem 0.95rem",
+                    "cozy": "1.05rem 1.1rem",
+                    "roomy": "1.25rem 1.35rem",
+                },
+            ),
+            "--mission-step-min": self.stage_min_width,
+        }
+        header_html = self._render_header()
+        content_html = self._render_content()
+        actions_html = self._render_secondary_actions()
+        return (
+            f"<section class='mission-flow-showcase reveal' style='{_merge_styles(style, {})}'>"
+            f"{header_html}{content_html}{actions_html}"
+            "</section>"
+        )
+
+    def render(self) -> None:
+        _load_css()
+        st.markdown(self.markup(), unsafe_allow_html=True)
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+    def _render_header(self) -> str:
+        if not self.title and not self.subtitle:
+            return ""
+        title_html = f"<h3>{self.title}</h3>" if self.title else ""
+        subtitle_html = f"<p>{self.subtitle}</p>" if self.subtitle else ""
+        return f"<header class='mission-flow-showcase__header'>{title_html}{subtitle_html}</header>"
+
+    def _render_content(self) -> str:
+        left_column = self._render_stage_column()
+        right_column = self._render_right_column()
+        return (
+            "<div class='mission-flow-showcase__content'>"
+            f"{left_column}{right_column}"
+            "</div>"
+        )
+
+    def _render_stage_column(self) -> str:
+        steps = []
+        for stage in self._ordered_stages:
+            desktop_copy = stage.copy_for_viewport("desktop")
+            mobile_copy = stage.copy_for_viewport("mobile")
+            footer_html = (
+                f"<p class='mission-flow-showcase__step-footer'>{stage.footer}</p>"
+                if stage.footer
+                else ""
+            )
+            steps.append(
+                "<article class='mission-flow-showcase__step' "
+                f"data-stage='{escape(stage.key)}'>"
+                "<div class='mission-flow-showcase__step-head'>"
+                f"<span class='mission-flow-showcase__step-icon'>{escape(stage.icon)}</span>"
+                "<div>"
+                f"<h4>{escape(stage.card_title)}</h4>"
+                "<p class='mission-flow-showcase__copy'>"
+                f"<span data-viewport='desktop'>{desktop_copy}</span>"
+                f"<span data-viewport='mobile'>{mobile_copy}</span>"
+                "</p>"
+                "</div>"
+                "</div>"
+                f"{footer_html}"
+                "</article>"
+            )
+        steps_html = "".join(steps)
+        return (
+            "<div class='mission-flow-showcase__column mission-flow-showcase__column--left'>"
+            "<div class='mission-flow-showcase__steps'>"
+            f"{steps_html}"
+            "</div>"
+            "</div>"
+        )
+
+    def _render_right_column(self) -> str:
+        blocks: list[str] = []
+        timeline = self._render_timeline()
+        if timeline:
+            blocks.append(timeline)
+        if self.primary_actions:
+            blocks.append(
+                self._render_action_deck(
+                    self.primary_actions,
+                    columns_min=self.action_columns_min,
+                )
+            )
+        if not blocks:
+            return ""
+        return (
+            "<div class='mission-flow-showcase__column mission-flow-showcase__column--right'>"
+            f"{''.join(blocks)}"
+            "</div>"
+        )
+
+    def _render_timeline(self) -> str:
+        if not self._ordered_stages:
+            return ""
+        nodes = []
+        for depth, stage in enumerate(self._ordered_stages):
+            nodes.append(
+                "<div class='orbital-node' "
+                f"style='--depth: {depth * 18}px;'>"
+                f"<span>{escape(stage.icon)}</span>"
+                f"<h4>{stage.timeline_label}</h4>"
+                f"<p>{stage.timeline_description}</p>"
+                "</div>"
+            )
+        timeline_header = (
+            f"<h4>{self.timeline_title}</h4>" if self.timeline_title else ""
+        )
+        insights_html = ""
+        if self.insights:
+            bullet_items = "".join(f"<li>{item}</li>" for item in self.insights)
+            insights_html = (
+                f"<ul class='mission-flow-showcase__insights'>{bullet_items}</ul>"
+            )
+        return (
+            "<aside class='mission-flow-showcase__timeline'>"
+            f"{timeline_header}"
+            "<div class='orbital-timeline'>"
+            f"<div class='orbital-track'>{''.join(nodes)}</div>"
+            "</div>"
+            f"{insights_html}"
+            "</aside>"
+        )
+
+    def _render_action_deck(
+        self,
+        cards: Sequence[ActionCard],
+        *,
+        columns_min: str | None = None,
+    ) -> str:
+        deck = ActionDeck(
+            cards=cards,
+            columns_min=columns_min or self.action_columns_min,
+            density=self.action_density,
+            reveal=False,
+        )
+        return f"<div class='mission-flow-showcase__actions'>{deck.markup()}</div>"
+
+    def _render_secondary_actions(self) -> str:
+        if not self.secondary_actions:
+            return ""
+        columns_min = (
+            self.secondary_action_columns_min
+            if self.secondary_action_columns_min is not None
+            else self.action_columns_min
+        )
+        return self._render_action_deck(
+            self.secondary_actions,
+            columns_min=columns_min,
+        )
 
 __all__ = [
     "BriefingCard",
@@ -3306,6 +3694,7 @@ __all__ = [
     "RankingCockpit",
     "MissionMetric",
     "MissionMetrics",
+    "MissionFlowShowcase",
     "CarouselItem",
     "CarouselRail",
     "ActionCard",

--- a/tests/ui/test_mission_flow.py
+++ b/tests/ui/test_mission_flow.py
@@ -1,0 +1,95 @@
+import sys
+import types
+
+import pytest
+
+if "joblib" not in sys.modules:
+    sys.modules["joblib"] = types.ModuleType("joblib")
+
+pytest.importorskip("numpy")
+pytest.importorskip("plotly")
+
+from app.modules.luxe_components import ActionCard, HeroFlowStage, MissionFlowShowcase
+
+
+@pytest.fixture
+def sample_stages() -> list[HeroFlowStage]:
+    return [
+        HeroFlowStage(
+            key="inventory",
+            order=2,
+            name="Inventario",
+            hero_headline="Inventario",
+            hero_copy="Normalizá residuos en minutos.",
+            card_body="Normalizá residuos y marcá flags EVA.",
+            compact_card_body="Normalizá residuos EVA.",
+            icon="🧱",
+            timeline_label="Inventario",
+            timeline_description="Carga CSV y marca flags críticos.",
+            footer="Dataset NASA",
+        ),
+        HeroFlowStage(
+            key="generator",
+            order=1,
+            name="Generador",
+            hero_headline="Generá y valida",
+            hero_copy="Rex-AI mezcla ítems.",
+            card_body="Rex-AI compara heurística vs IA en vivo.",
+            compact_card_body="Compará heurística vs IA.",
+            icon="🤖",
+            timeline_label="Generador IA",
+            timeline_description="Explorá mezclas óptimas.",
+            footer="Cooperativo",
+        ),
+        HeroFlowStage(
+            key="report",
+            order=3,
+            name="Resultados",
+            hero_headline="Reportar",
+            hero_copy="Exportá todo",
+            card_body="Exportá Sankey y feedback listos para ingeniería.",
+            compact_card_body=None,
+            icon="📦",
+            timeline_label="Export",
+            timeline_description="Entregá reportes completos.",
+            footer=None,
+        ),
+    ]
+
+
+def test_mission_flow_stage_titles_are_unique_and_sorted(sample_stages: list[HeroFlowStage]) -> None:
+    showcase = MissionFlowShowcase(
+        stages=sample_stages,
+        primary_actions=[
+            ActionCard(title="Acción", body="CTA principal", icon="🚀"),
+        ],
+        insights=["Insight"],
+    )
+
+    html = showcase.markup()
+    titles = showcase.stage_titles()
+    last_index = -1
+    for title in titles:
+        occurrences = html.count(title)
+        assert occurrences == 1, f"{title} should appear once, found {occurrences}"
+        current_index = html.index(title)
+        assert current_index > last_index
+        last_index = current_index
+
+
+def test_mission_flow_copy_sequences(sample_stages: list[HeroFlowStage]) -> None:
+    showcase = MissionFlowShowcase(stages=sample_stages)
+
+    desktop_copy = showcase.copy_sequence("desktop")
+    mobile_copy = showcase.copy_sequence("mobile")
+
+    assert desktop_copy == [
+        "Rex-AI compara heurística vs IA en vivo.",
+        "Normalizá residuos y marcá flags EVA.",
+        "Exportá Sankey y feedback listos para ingeniería.",
+    ]
+    assert mobile_copy == [
+        "Compará heurística vs IA.",
+        "Normalizá residuos EVA.",
+        "Exportá Sankey y feedback listos para ingeniería.",
+    ]


### PR DESCRIPTION
## Summary
- add the MissionFlowShowcase component to luxe_components, including responsive styling and helpers
- refactor the home page mission narrative to use the showcase with refreshed stage copy and CTA decks
- add mission flow UI tests that validate stage copy ordering for desktop and mobile variants

## Testing
- pytest tests/ui/test_mission_flow.py

------
https://chatgpt.com/codex/tasks/task_e_68db0c0d4adc833183878e60a0e3899f