### PR TITLE
Add mission board panel to home

### DIFF
--- a/app/static/home.css
+++ b/app/static/home.css
@@ -203,6 +203,23 @@ section {
   color: var(--muted);
 }
 
+#sticky-metrics {
+  margin-bottom: 0.5rem;
+}
+
+#sticky-metrics + .mission-board {
+  margin-top: 0.75rem;
+  box-shadow: 0 28px 60px -48px rgba(59, 130, 246, 0.45);
+}
+
+.mission-board__link strong {
+  color: var(--ink);
+}
+
+.mission-board__link:hover strong {
+  color: color-mix(in srgb, var(--accent) 88%, white 12%);
+}
+
 .timeline {
   margin-top: 18px;
   border-left: 2px solid color-mix(in srgb, var(--accent) 25%, transparent);

--- a/tests/ui/test_home_mission_board.py
+++ b/tests/ui/test_home_mission_board.py
@@ -1,0 +1,38 @@
+from app.modules.luxe_components import MissionBoard
+
+
+def test_mission_board_markup_highlights_active_step() -> None:
+    payload = [
+        {
+            "key": "inventory",
+            "title": "Inventario",
+            "description": "Normalizá residuos NASA y marcá flags EVA o multilayer.",
+            "href": "./?page=1_Inventory_Builder",
+            "icon": "🧱",
+        },
+        {
+            "key": "target",
+            "title": "Target",
+            "description": "Define objetivo y límites de agua/energía.",
+            "href": "./?page=2_Target_Designer",
+            "icon": "🎯",
+        },
+        {
+            "key": "generator",
+            "title": "Generador",
+            "description": "Compará recetas IA vs heurística y valida contribuciones.",
+            "href": "./?page=3_Generator",
+            "icon": "🤖",
+        },
+    ]
+
+    board = MissionBoard.from_payload(payload, title="Próxima acción")
+    markup = board.markup(highlight_key="generator")
+
+    assert markup.count("<li") == len(payload)
+    assert "<ol" in markup and "</ol>" in markup
+    assert "data-key='generator'" in markup
+    active_segment = markup.split("data-key='generator'", 1)[0].split("<li")[-1]
+    assert "is-active" in active_segment
+    assert "./?page=3_Generator" in markup
+    assert "class='mission-board__badge'>1<" in markup


### PR DESCRIPTION
## Summary
- replace the Home page toggles and action decks with a streamlined MissionBoard panel of ordered links
- add the reusable MissionBoard component, extend MissionMetrics for board layouts, and update the home stylesheet to fit above-the-fold
- cover the new board with a UI test exercising the highlight state

## Testing
- pytest tests/ui/test_home_mission_board.py

------
https://chatgpt.com/codex/tasks/task_e_68dbfc17f76c83319180d00effb3dcb3