### PR TITLE
Refactor home layout tokens and remove legacy styles

### DIFF
--- a/app/static/design_tokens.scss
+++ b/app/static/design_tokens.scss
@@ -234,6 +234,27 @@ $colorblind-modes: (
   safe: $colorblind-safe
 );
 
+$home-minimal: (
+  content-max: 58rem,
+  stack-gap: clamp(2.5rem, 4vw, 3.5rem),
+  section-gap: clamp(1.1rem, calc(1.2rem + 0.5vw), 1.8rem),
+  header-gap: var(--space-sm),
+  icon-size: 2.5rem,
+  icon-radius: 0.9rem,
+  icon-font-size: 1.35rem,
+  text-max: 62ch,
+  lead-size: clamp(1rem, calc(0.98rem + 0.28vw), 1.2rem),
+  card-gap: var(--space-lg),
+  card-padding: clamp(1.1rem, calc(0.9rem + 1vw), 1.9rem),
+  card-radius: 1.25rem,
+  card-shadow: var(--shadow-soft),
+  heading-spacing: var(--space-sm),
+  list-gap: var(--space-xs),
+  list-indent: 1.25rem,
+  board-gap: var(--space-md),
+  muted: var(--muted)
+);
+
 @mixin emit-token-map($map) {
   @each $key, $value in $map {
     @if $key == color-scheme {
@@ -244,8 +265,15 @@ $colorblind-modes: (
   }
 }
 
+@mixin emit-home-map($map) {
+  @each $key, $value in $map {
+    --home-#{$key}: #{$value};
+  }
+}
+
 :root {
   @include emit-token-map(map-get($themes, dark));
+  @include emit-home-map($home-minimal);
 }
 
 body {
@@ -256,6 +284,7 @@ body {
   body[data-rexai-theme="#{$theme-name}"],
   .stApp[data-rexai-theme="#{$theme-name}"] {
     @include emit-token-map($tokens);
+    @include emit-home-map($home-minimal);
   }
 }
 
@@ -272,6 +301,9 @@ body {
     .stApp[data-rexai-colorblind="#{$mode}"] {
       @include emit-token-map($tokens);
     }
+  }
+}
+
 $primary-scale: (
   50: #f2f6ff,
   100: #dbe6ff,

--- a/app/static/home.css
+++ b/app/static/home.css
@@ -1,238 +1,108 @@
-/* Home page specific layout and component styling */
+/* Home page minimal layout styles */
 
-.main > div {
-  padding-top: 1.5rem;
-}
+@layer pages {
+  .main > div {
+    padding-top: var(--home-stack-gap);
+  }
 
-section {
-  width: 100%;
-}
+  .home-section,
+  .home-card-stack,
+  #sticky-metrics,
+  .mission-board,
+  .luxe-carousel {
+    max-width: var(--home-content-max);
+    margin-left: auto;
+    margin-right: auto;
+  }
 
-.overview-block,
-.lab-block,
-.next-block {
-  margin-bottom: 4rem;
-}
+  .home-section {
+    margin-bottom: var(--home-stack-gap);
+    display: flex;
+    flex-direction: column;
+    gap: var(--home-section-gap);
+  }
 
-.reveal {
-  opacity: 0;
-  transform: translateY(42px);
-  transition: opacity 0.8s ease, transform 0.8s ease;
-}
+  .home-section__header {
+    display: flex;
+    align-items: center;
+    gap: var(--home-header-gap);
+  }
 
-.reveal.is-visible {
-  opacity: 1;
-  transform: translateY(0);
-}
+  .home-section__icon {
+    width: var(--home-icon-size);
+    height: var(--home-icon-size);
+    border-radius: var(--home-icon-radius);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    background: color-mix(in srgb, var(--accent) 18%, transparent);
+    color: var(--accent);
+    font-size: var(--home-icon-font-size);
+    box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--accent) 24%, transparent);
+  }
 
-.hero {
-  position: relative;
-  border-radius: 28px;
-  padding: 36px 42px;
-  background: var(--hero-background);
-  border: 1px solid color-mix(in srgb, var(--hero-border) 32%, transparent);
-  color: var(--ink);
-  overflow: hidden;
-}
+  .home-section__lead {
+    margin: 0;
+    max-width: var(--home-text-max);
+    color: var(--home-muted);
+    font-size: var(--home-lead-size);
+  }
 
-.hero::after {
-  content: "";
-  position: absolute;
-  inset: -120px;
-  background: radial-gradient(circle at top right, color-mix(in srgb, var(--accent) 45%, transparent) 0%, transparent 55%);
-  pointer-events: none;
-}
+  .home-card-stack {
+    display: flex;
+    flex-direction: column;
+    gap: var(--home-card-gap);
+    margin-bottom: var(--home-stack-gap);
+  }
 
-.hero h1 {
-  font-size: 2.25rem;
-  margin-bottom: 12px;
-  letter-spacing: 0.02em;
-}
+  .home-card {
+    padding: var(--home-card-padding);
+    border-radius: var(--home-card-radius);
+    border: 1px solid color-mix(in srgb, var(--border-soft) 82%, transparent);
+    background: color-mix(in srgb, var(--surface-panel) 92%, transparent);
+    box-shadow: var(--home-card-shadow);
+  }
 
-.hero p {
-  font-size: 1.04rem;
-  max-width: 720px;
-  color: var(--muted);
-}
+  .home-card h4 {
+    margin: 0 0 var(--home-heading-spacing);
+  }
 
-.tesla-hero {
-  position: relative;
-  border-radius: 28px;
-  overflow: hidden;
-  min-height: 360px;
-  display: flex;
-  align-items: flex-end;
-}
+  .home-card p {
+    margin: 0;
+    color: var(--home-muted);
+    font-size: var(--home-lead-size);
+  }
 
-.tesla-hero__bg {
-  position: absolute;
-  inset: 0;
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-  filter: saturate(1.3) brightness(0.7);
-}
+  .home-card__list {
+    margin: 0;
+    padding-left: var(--home-list-indent);
+    color: var(--home-muted);
+    font-size: var(--home-lead-size);
+  }
 
-.tesla-hero__veil {
-  position: absolute;
-  inset: 0;
-  background: linear-gradient(180deg, rgba(15, 23, 42, 0.05) 10%, rgba(2, 6, 23, 0.85) 100%);
-}
+  .home-card__list li + li {
+    margin-top: var(--home-list-gap);
+  }
 
-.tesla-hero__content {
-  position: relative;
-  padding: 48px;
-  max-width: 760px;
-}
+  #sticky-metrics {
+    margin: 0 auto var(--home-board-gap);
+  }
 
-.tesla-hero__content h1 {
-  font-size: 2.6rem;
-  margin-bottom: 16px;
-  letter-spacing: 0.01em;
-}
+  #sticky-metrics + .mission-board {
+    margin-top: var(--home-board-gap);
+    margin-bottom: var(--home-stack-gap);
+    box-shadow: var(--home-card-shadow);
+  }
 
-.tesla-hero__content p {
-  font-size: 1.05rem;
-  color: var(--muted);
-  margin-bottom: 18px;
-}
+  .mission-board__link strong {
+    color: var(--ink);
+  }
 
-.ghost-card {
-  margin-top: 38px;
-  display: grid;
-  gap: 18px;
-  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-}
+  .mission-board__link:hover strong {
+    color: color-mix(in srgb, var(--accent) 85%, var(--ink) 15%);
+  }
 
-.ghost-card > div {
-  padding: 20px 22px;
-  border-radius: 20px;
-  border: 1px solid var(--border-soft);
-  background: var(--surface-card);
-  color: var(--ink);
-}
-
-.ghost-card h3 {
-  margin-bottom: 6px;
-  font-size: 1.05rem;
-}
-
-.ghost-card p {
-  color: var(--muted);
-  font-size: 0.94rem;
-  margin: 0;
-}
-
-.stepper {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-  gap: 14px;
-  margin: 32px 0 18px;
-}
-
-.step {
-  border-radius: 18px;
-  border: 1px solid var(--step-border);
-  padding: 16px 18px;
-  background: var(--step-bg);
-}
-
-.step span {
-  display: inline-flex;
-  width: 32px;
-  height: 32px;
-  border-radius: 999px;
-  align-items: center;
-  justify-content: center;
-  background: var(--step-icon-bg);
-  color: var(--ink);
-  font-weight: 700;
-  margin-bottom: 10px;
-}
-
-.step h4 {
-  margin: 0 0 6px;
-}
-
-.step p {
-  color: var(--muted);
-  font-size: 0.9rem;
-  margin: 0;
-}
-
-.section-title {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  margin-bottom: 14px;
-}
-
-.section-title span.icon {
-  width: 34px;
-  height: 34px;
-  border-radius: 12px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background: color-mix(in srgb, var(--accent) 18%, transparent);
-  color: var(--accent);
-  font-size: 1.1rem;
-}
-
-.lab-grid {
-  display: grid;
-  gap: 24px;
-  grid-template-columns: minmax(0, 1fr);
-}
-
-.drawer {
-  border-radius: 18px;
-  border: 1px solid color-mix(in srgb, var(--border-soft) 70%, transparent);
-  padding: 18px 20px;
-  background: color-mix(in srgb, var(--surface-panel) 88%, transparent);
-  margin-top: 16px;
-}
-
-.drawer h4 {
-  margin-top: 0;
-}
-
-.drawer ul {
-  margin: 0;
-  padding-left: 20px;
-  color: var(--muted);
-}
-
-#sticky-metrics {
-  margin-bottom: 0.5rem;
-}
-
-#sticky-metrics + .mission-board {
-  margin-top: 0.75rem;
-  box-shadow: 0 28px 60px -48px rgba(59, 130, 246, 0.45);
-}
-
-.mission-board__link strong {
-  color: var(--ink);
-}
-
-.mission-board__link:hover strong {
-  color: color-mix(in srgb, var(--accent) 88%, white 12%);
-}
-
-.timeline {
-  margin-top: 18px;
-  border-left: 2px solid color-mix(in srgb, var(--accent) 25%, transparent);
-  padding-left: 18px;
-}
-
-.timeline li {
-  margin-bottom: 14px;
-  color: var(--muted);
-}
-
-@media (max-width: 992px) {
-  .tesla-hero__content {
-    padding: 32px 24px;
+  .luxe-carousel {
+    margin-bottom: var(--home-stack-gap);
   }
 }

--- a/app/static/theme.css
+++ b/app/static/theme.css
@@ -1,22 +1,31 @@
 :root {
+  color-scheme: dark;
   --bg: #0b0d12;
-  --ink: #f8fafc;
-  --muted: #b8c3d5;
+  --surface-panel: #101724;
+  --surface-card: #141c2a;
+  --card: #141c2a;
+  --surface-ghost: #1c2636;
+  --stroke: #1f2a3c;
+  --bd: #243042;
   --border-soft: #243042;
   --border-strong: #31405a;
-  --card: #141c2a;
-  --shadow-card: 0 24px 48px rgba(4, 8, 20, 0.45);
-  --shadow-flat: none;
-  --hero-background: radial-gradient(900px 260px at 25% -10%, rgba(80, 120, 255, 0.1), transparent);
+  --accent: #5aa9ff;
+  --accent-soft: #93c5fd;
+  --ink: #f8fafc;
+  --muted: #b8c3d5;
+  --hero-background: linear-gradient(135deg, rgba(59,130,246,0.22), rgba(59,130,246,0.05)), linear-gradient(180deg, rgba(15,23,42,0.9), rgba(15,23,42,0.72));
   --hero-border: #3b82f6;
   --chip-bg: #16243a;
   --chip-border: #243a5f;
   --chip-ink: #f1f5ff;
   --step-bg: #101a2a;
   --step-border: #223551;
+  --step-icon-bg: rgba(90, 169, 255, 0.24);
   --metric-bg: #101a2a;
   --metric-border: #223551;
   --metric-shadow: 0 18px 32px rgba(4, 8, 20, 0.45);
+  --shadow-card: 0 24px 48px rgba(4, 8, 20, 0.45);
+  --shadow-flat: none;
   --tone-ok-bg: #123829;
   --tone-ok-fg: #63f0a5;
   --tone-ok-border: #1f6141;
@@ -30,231 +39,373 @@
   --badge-warn: #f59e0b;
   --badge-risk: #fb7185;
   --pill-bg: transparent;
-  --font-scale: 1;
-  --transition-quick: 140ms;
+  --home-content-max: 58rem;
+  --home-stack-gap: clamp(2.5rem, 4vw, 3.5rem);
+  --home-section-gap: clamp(1.1rem, calc(1.2rem + 0.5vw), 1.8rem);
+  --home-header-gap: var(--space-sm);
+  --home-icon-size: 2.5rem;
+  --home-icon-radius: 0.9rem;
+  --home-icon-font-size: 1.35rem;
+  --home-text-max: 62ch;
+  --home-lead-size: clamp(1rem, calc(0.98rem + 0.28vw), 1.2rem);
+  --home-card-gap: var(--space-lg);
+  --home-card-padding: clamp(1.1rem, calc(0.9rem + 1vw), 1.9rem);
+  --home-card-radius: 1.25rem;
+  --home-card-shadow: var(--shadow-soft);
+  --home-heading-spacing: var(--space-sm);
+  --home-list-gap: var(--space-xs);
+  --home-list-indent: 1.25rem;
+  --home-board-gap: var(--space-md);
+  --home-muted: var(--muted);
 }
 
 body {
-  background: var(--bg);
-  color: var(--ink);
-  font-size: calc(1rem * var(--font-scale, 1));
-  transition: background-color var(--transition-quick, 140ms) ease, color var(--transition-quick, 140ms) ease;
+  --font-scale: 1;
 }
 
-body, .stApp {
-  font-feature-settings: "liga" on;
+body[data-rexai-theme="dark"],
+.stApp[data-rexai-theme="dark"] {
+  color-scheme: dark;
+  --bg: #0b0d12;
+  --surface-panel: #101724;
+  --surface-card: #141c2a;
+  --card: #141c2a;
+  --surface-ghost: #1c2636;
+  --stroke: #1f2a3c;
+  --bd: #243042;
+  --border-soft: #243042;
+  --border-strong: #31405a;
+  --accent: #5aa9ff;
+  --accent-soft: #93c5fd;
+  --ink: #f8fafc;
+  --muted: #b8c3d5;
+  --hero-background: linear-gradient(135deg, rgba(59,130,246,0.22), rgba(59,130,246,0.05)), linear-gradient(180deg, rgba(15,23,42,0.9), rgba(15,23,42,0.72));
+  --hero-border: #3b82f6;
+  --chip-bg: #16243a;
+  --chip-border: #243a5f;
+  --chip-ink: #f1f5ff;
+  --step-bg: #101a2a;
+  --step-border: #223551;
+  --step-icon-bg: rgba(90, 169, 255, 0.24);
+  --metric-bg: #101a2a;
+  --metric-border: #223551;
+  --metric-shadow: 0 18px 32px rgba(4, 8, 20, 0.45);
+  --shadow-card: 0 24px 48px rgba(4, 8, 20, 0.45);
+  --shadow-flat: none;
+  --tone-ok-bg: #123829;
+  --tone-ok-fg: #63f0a5;
+  --tone-ok-border: #1f6141;
+  --tone-warn-bg: #3f2a0f;
+  --tone-warn-fg: #f2c057;
+  --tone-warn-border: #7a5b1f;
+  --tone-risk-bg: #3d1518;
+  --tone-risk-fg: #f18882;
+  --tone-risk-border: #7a2b36;
+  --badge-ok: #2dd4bf;
+  --badge-warn: #f59e0b;
+  --badge-risk: #fb7185;
+  --pill-bg: transparent;
+  --home-content-max: 58rem;
+  --home-stack-gap: clamp(2.5rem, 4vw, 3.5rem);
+  --home-section-gap: clamp(1.1rem, calc(1.2rem + 0.5vw), 1.8rem);
+  --home-header-gap: var(--space-sm);
+  --home-icon-size: 2.5rem;
+  --home-icon-radius: 0.9rem;
+  --home-icon-font-size: 1.35rem;
+  --home-text-max: 62ch;
+  --home-lead-size: clamp(1rem, calc(0.98rem + 0.28vw), 1.2rem);
+  --home-card-gap: var(--space-lg);
+  --home-card-padding: clamp(1.1rem, calc(0.9rem + 1vw), 1.9rem);
+  --home-card-radius: 1.25rem;
+  --home-card-shadow: var(--shadow-soft);
+  --home-heading-spacing: var(--space-sm);
+  --home-list-gap: var(--space-xs);
+  --home-list-indent: 1.25rem;
+  --home-board-gap: var(--space-md);
+  --home-muted: var(--muted);
 }
 
-.stApp {
-  background: transparent;
+body[data-rexai-theme="dark-high-contrast"],
+.stApp[data-rexai-theme="dark-high-contrast"] {
+  color-scheme: dark;
+  --bg: #010409;
+  --surface-panel: #060b14;
+  --surface-card: #0a1220;
+  --card: #0a1220;
+  --surface-ghost: #0f1b2c;
+  --stroke: #3b82f6;
+  --bd: #3b82f6;
+  --border-soft: #3b82f6;
+  --border-strong: #60a5fa;
+  --accent: #1ea7ff;
+  --accent-soft: #82d3ff;
+  --ink: #ffffff;
+  --muted: #dbe6ff;
+  --hero-background: linear-gradient(135deg, rgba(59,130,246,0.22), rgba(59,130,246,0.05)), linear-gradient(180deg, rgba(15,23,42,0.9), rgba(15,23,42,0.72));
+  --hero-border: #3b82f6;
+  --chip-bg: #16243a;
+  --chip-border: #243a5f;
+  --chip-ink: #f1f5ff;
+  --step-bg: #101a2a;
+  --step-border: #223551;
+  --step-icon-bg: rgba(90, 169, 255, 0.24);
+  --metric-bg: #101a2a;
+  --metric-border: #223551;
+  --metric-shadow: none;
+  --shadow-card: none;
+  --shadow-flat: none;
+  --tone-ok-bg: #083d2b;
+  --tone-ok-fg: #7fffd4;
+  --tone-ok-border: #34d399;
+  --tone-warn-bg: #4a2a00;
+  --tone-warn-fg: #fbbf24;
+  --tone-warn-border: #f59e0b;
+  --tone-risk-bg: #470011;
+  --tone-risk-fg: #ff7b89;
+  --tone-risk-border: #fb7185;
+  --badge-ok: #34d399;
+  --badge-warn: #f59e0b;
+  --badge-risk: #fb7185;
+  --pill-bg: transparent;
+  --home-content-max: 58rem;
+  --home-stack-gap: clamp(2.5rem, 4vw, 3.5rem);
+  --home-section-gap: clamp(1.1rem, calc(1.2rem + 0.5vw), 1.8rem);
+  --home-header-gap: var(--space-sm);
+  --home-icon-size: 2.5rem;
+  --home-icon-radius: 0.9rem;
+  --home-icon-font-size: 1.35rem;
+  --home-text-max: 62ch;
+  --home-lead-size: clamp(1rem, calc(0.98rem + 0.28vw), 1.2rem);
+  --home-card-gap: var(--space-lg);
+  --home-card-padding: clamp(1.1rem, calc(0.9rem + 1vw), 1.9rem);
+  --home-card-radius: 1.25rem;
+  --home-card-shadow: var(--shadow-soft);
+  --home-heading-spacing: var(--space-sm);
+  --home-list-gap: var(--space-xs);
+  --home-list-indent: 1.25rem;
+  --home-board-gap: var(--space-md);
+  --home-muted: var(--muted);
 }
 
-.block-container {
-  padding: 2.6rem 3rem 3rem 3rem;
+body[data-rexai-theme="light"],
+.stApp[data-rexai-theme="light"] {
+  color-scheme: light;
+  --bg: #f4f7fb;
+  --surface-panel: #ffffff;
+  --surface-card: #ffffff;
+  --card: #ffffff;
+  --surface-ghost: #eef2ff;
+  --stroke: #d7def1;
+  --bd: #cfd7ef;
+  --border-soft: #cfd7ef;
+  --border-strong: #94a3b8;
+  --accent: #2563eb;
+  --accent-soft: #93c5fd;
+  --ink: #0f172a;
+  --muted: #4a5a7d;
+  --hero-background: linear-gradient(135deg, rgba(96,165,250,0.25), rgba(96,165,250,0.05)), linear-gradient(180deg, rgba(255,255,255,0.9), rgba(236,244,255,0.78));
+  --hero-border: #60a5fa;
+  --chip-bg: #e2e8f9;
+  --chip-border: #c3d4fb;
+  --chip-ink: #1e293b;
+  --step-bg: #e9effd;
+  --step-border: #c3d4fb;
+  --step-icon-bg: rgba(37, 99, 235, 0.18);
+  --metric-bg: #f1f4fc;
+  --metric-border: #cbd5f5;
+  --metric-shadow: 0 16px 32px rgba(15, 23, 42, 0.1);
+  --shadow-card: 0 24px 48px rgba(15, 23, 42, 0.12);
+  --shadow-flat: none;
+  --tone-ok-bg: #c6f6d5;
+  --tone-ok-fg: #1f5136;
+  --tone-ok-border: #38a169;
+  --tone-warn-bg: #fef3c7;
+  --tone-warn-fg: #854d0e;
+  --tone-warn-border: #f59e0b;
+  --tone-risk-bg: #fee2e2;
+  --tone-risk-fg: #991b1b;
+  --tone-risk-border: #f87171;
+  --badge-ok: #047857;
+  --badge-warn: #c2410c;
+  --badge-risk: #dc2626;
+  --pill-bg: transparent;
+  --home-content-max: 58rem;
+  --home-stack-gap: clamp(2.5rem, 4vw, 3.5rem);
+  --home-section-gap: clamp(1.1rem, calc(1.2rem + 0.5vw), 1.8rem);
+  --home-header-gap: var(--space-sm);
+  --home-icon-size: 2.5rem;
+  --home-icon-radius: 0.9rem;
+  --home-icon-font-size: 1.35rem;
+  --home-text-max: 62ch;
+  --home-lead-size: clamp(1rem, calc(0.98rem + 0.28vw), 1.2rem);
+  --home-card-gap: var(--space-lg);
+  --home-card-padding: clamp(1.1rem, calc(0.9rem + 1vw), 1.9rem);
+  --home-card-radius: 1.25rem;
+  --home-card-shadow: var(--shadow-soft);
+  --home-heading-spacing: var(--space-sm);
+  --home-list-gap: var(--space-xs);
+  --home-list-indent: 1.25rem;
+  --home-board-gap: var(--space-md);
+  --home-muted: var(--muted);
 }
 
-.rexai-hud {
-  border-radius: 18px;
-  border: 1px solid var(--border-soft);
-  background: var(--surface-card, var(--card));
-  box-shadow: var(--shadow-card);
-  padding: 0.75rem 1.3rem 0.6rem;
-  margin-bottom: 1.2rem;
-  display: flex;
-  flex-direction: column;
-  gap: 0.65rem;
+body[data-rexai-theme="light-high-contrast"],
+.stApp[data-rexai-theme="light-high-contrast"] {
+  color-scheme: light;
+  --bg: #ffffff;
+  --surface-panel: #f5faff;
+  --surface-card: #f5faff;
+  --card: #f5faff;
+  --surface-ghost: #e2ecff;
+  --stroke: #1e40af;
+  --bd: #1d4ed8;
+  --border-soft: #1d4ed8;
+  --border-strong: #1d4ed8;
+  --accent: #0f4cd6;
+  --accent-soft: #5f8dff;
+  --ink: #0b1526;
+  --muted: #1f2937;
+  --hero-background: linear-gradient(135deg, rgba(96,165,250,0.25), rgba(96,165,250,0.05)), linear-gradient(180deg, rgba(255,255,255,0.9), rgba(236,244,255,0.78));
+  --hero-border: #60a5fa;
+  --chip-bg: #e0ecff;
+  --chip-border: #1d4ed8;
+  --chip-ink: #0f172a;
+  --step-bg: #e9effd;
+  --step-border: #c3d4fb;
+  --step-icon-bg: rgba(15, 76, 214, 0.16);
+  --metric-bg: #f1f4fc;
+  --metric-border: #cbd5f5;
+  --metric-shadow: none;
+  --shadow-card: none;
+  --shadow-flat: none;
+  --tone-ok-bg: #bbf7d0;
+  --tone-ok-fg: #166534;
+  --tone-ok-border: #15803d;
+  --tone-warn-bg: #fde68a;
+  --tone-warn-fg: #92400e;
+  --tone-warn-border: #b45309;
+  --tone-risk-bg: #fecaca;
+  --tone-risk-fg: #7f1d1d;
+  --tone-risk-border: #b91c1c;
+  --badge-ok: #15803d;
+  --badge-warn: #b45309;
+  --badge-risk: #b91c1c;
+  --pill-bg: transparent;
+  --home-content-max: 58rem;
+  --home-stack-gap: clamp(2.5rem, 4vw, 3.5rem);
+  --home-section-gap: clamp(1.1rem, calc(1.2rem + 0.5vw), 1.8rem);
+  --home-header-gap: var(--space-sm);
+  --home-icon-size: 2.5rem;
+  --home-icon-radius: 0.9rem;
+  --home-icon-font-size: 1.35rem;
+  --home-text-max: 62ch;
+  --home-lead-size: clamp(1rem, calc(0.98rem + 0.28vw), 1.2rem);
+  --home-card-gap: var(--space-lg);
+  --home-card-padding: clamp(1.1rem, calc(0.9rem + 1vw), 1.9rem);
+  --home-card-radius: 1.25rem;
+  --home-card-shadow: var(--shadow-soft);
+  --home-heading-spacing: var(--space-sm);
+  --home-list-gap: var(--space-xs);
+  --home-list-indent: 1.25rem;
+  --home-board-gap: var(--space-md);
+  --home-muted: var(--muted);
 }
 
-body[data-rexai-theme*="high-contrast"] .rexai-hud,
-.stApp[data-rexai-theme*="high-contrast"] .rexai-hud {
-  box-shadow: none;
-  border-color: var(--border-strong);
+body[data-rexai-theme="solarized"],
+.stApp[data-rexai-theme="solarized"] {
+  color-scheme: light;
+  --bg: #fdf6e3;
+  --surface-panel: #fefbf3;
+  --surface-card: #fefcf6;
+  --card: #fefcf6;
+  --surface-ghost: #f2e5c7;
+  --stroke: #e7dcbf;
+  --bd: #d9caa6;
+  --border-soft: #d9caa6;
+  --border-strong: #b5a273;
+  --accent: #268bd2;
+  --accent-soft: #2aa198;
+  --ink: #073642;
+  --muted: #596a72;
+  --hero-background: linear-gradient(135deg, rgba(38,139,210,0.2), rgba(38,139,210,0.05)), linear-gradient(180deg, rgba(253,246,227,0.92), rgba(249,240,213,0.78));
+  --hero-border: #268bd2;
+  --chip-bg: #ece3c5;
+  --chip-border: #d7c69a;
+  --chip-ink: #073642;
+  --step-bg: #f2e7c9;
+  --step-border: #d7c69a;
+  --step-icon-bg: rgba(38, 139, 210, 0.18);
+  --metric-bg: #f5ebd3;
+  --metric-border: #d7c69a;
+  --metric-shadow: 0 12px 24px rgba(7, 54, 66, 0.12);
+  --shadow-card: 0 20px 36px rgba(7, 54, 66, 0.18);
+  --shadow-flat: none;
+  --tone-ok-bg: #c8f1dc;
+  --tone-ok-fg: #1d5c3a;
+  --tone-ok-border: #3a9d6a;
+  --tone-warn-bg: #fee6b4;
+  --tone-warn-fg: #7c5416;
+  --tone-warn-border: #d48b1f;
+  --tone-risk-bg: #f9c0c0;
+  --tone-risk-fg: #8f1d2d;
+  --tone-risk-border: #d2565d;
+  --badge-ok: #2aa198;
+  --badge-warn: #cb4b16;
+  --badge-risk: #dc322f;
+  --pill-bg: transparent;
+  --home-content-max: 58rem;
+  --home-stack-gap: clamp(2.5rem, 4vw, 3.5rem);
+  --home-section-gap: clamp(1.1rem, calc(1.2rem + 0.5vw), 1.8rem);
+  --home-header-gap: var(--space-sm);
+  --home-icon-size: 2.5rem;
+  --home-icon-radius: 0.9rem;
+  --home-icon-font-size: 1.35rem;
+  --home-text-max: 62ch;
+  --home-lead-size: clamp(1rem, calc(0.98rem + 0.28vw), 1.2rem);
+  --home-card-gap: var(--space-lg);
+  --home-card-padding: clamp(1.1rem, calc(0.9rem + 1vw), 1.9rem);
+  --home-card-radius: 1.25rem;
+  --home-card-shadow: var(--shadow-soft);
+  --home-heading-spacing: var(--space-sm);
+  --home-list-gap: var(--space-xs);
+  --home-list-indent: 1.25rem;
+  --home-board-gap: var(--space-md);
+  --home-muted: var(--muted);
 }
 
-.rexai-hud__title {
-  font-size: 0.82rem;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-  font-weight: 700;
-  color: var(--muted);
-}
-
-.rexai-hud__columns {
-  display: flex;
-  gap: 1.2rem;
-  flex-wrap: wrap;
-}
-
-.rexai-hud__column {
-  flex: 1 1 220px;
-}
-
-.rexai-hud__column label {
-  font-size: 0.78rem;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: var(--muted);
-  font-weight: 600;
-}
-
-.rexai-hud__column .stRadio > label {
-  width: 100%;
-}
-
-.rexai-hud__column .stRadio [data-baseweb="radio"] label {
-  color: var(--ink);
-}
-
-.hero {
-  border: 1px solid var(--hero-border, var(--border-soft));
-  border-radius: 22px;
-  padding: 20px 22px;
-  background: var(--hero-background);
-  box-shadow: var(--shadow-card);
-  transition: background var(--transition-quick) ease, border-color var(--transition-quick) ease;
-}
-
-.block {
-  border: 1px solid var(--border-soft);
-  border-radius: 16px;
-  padding: 16px;
-  background: var(--surface-panel, transparent);
-}
-
-.card {
-  background: var(--card, var(--surface-card));
-  border: 1px solid var(--border-soft);
-  border-radius: 16px;
-  padding: 18px;
-  margin-bottom: 12px;
-  box-shadow: var(--shadow-card);
-  transition: background var(--transition-quick) ease, border-color var(--transition-quick) ease, box-shadow var(--transition-quick) ease;
-}
-
-.card.card-flat {
-  box-shadow: var(--shadow-flat, none);
-  border-color: var(--border-strong);
-}
-
-.kpi,
-.metric {
-  border: 1px solid var(--metric-border, var(--border-soft));
-  border-radius: 18px;
-  padding: 18px;
-  background: var(--metric-bg, var(--surface-card));
-  box-shadow: var(--metric-shadow, var(--shadow-card));
-  transition: background var(--transition-quick) ease, border-color var(--transition-quick) ease, box-shadow var(--transition-quick) ease;
-}
-
-.kpi {
-  margin-bottom: 10px;
-}
-
-.kpi h3,
-.metric h5 {
-  margin: 0 0 6px 0;
-  font-size: calc(0.92rem * var(--font-scale, 1));
-  color: var(--muted);
-}
-
-.kpi .v {
-  font-size: calc(1.6rem * var(--font-scale, 1));
-  font-weight: 800;
-  letter-spacing: 0.2px;
-}
-
-.kpi .hint {
-  font-size: calc(0.85rem * var(--font-scale, 1));
-  color: var(--muted);
-}
-
-.pill {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.35rem;
-  padding: 4px 10px;
-  border-radius: 999px;
-  font-weight: 700;
-  font-size: calc(0.78rem * var(--font-scale, 1));
-  border: 1px solid var(--border-soft);
-  margin-right: 6px;
-  background: var(--pill-bg, transparent);
-  color: var(--ink);
-  transition: background var(--transition-quick) ease, border-color var(--transition-quick) ease, color var(--transition-quick) ease;
-}
-
-.pill.ok {
-  background: var(--tone-ok-bg);
-  color: var(--tone-ok-fg);
-  border-color: var(--tone-ok-border);
-}
-
-.pill.warn,
-.pill.med {
-  background: var(--tone-warn-bg);
-  color: var(--tone-warn-fg);
-  border-color: var(--tone-warn-border);
-}
-
-.pill.bad,
-.pill.risk {
-  background: var(--tone-risk-bg);
-  color: var(--tone-risk-fg);
-  border-color: var(--tone-risk-border);
-}
-
-.pill.pill-solid {
-  border-width: 2px;
-}
-
-.small,
-.legend {
-  font-size: calc(0.9rem * var(--font-scale, 1));
-  color: var(--muted);
-}
-
-hr {
-  border: none;
-  height: 1px;
-  background: var(--border-soft);
-  margin: 8px 0 16px 0;
-}
-
-table {
-  font-size: calc(0.95rem * var(--font-scale, 1));
-}
-
-.badge-ok {
-  color: var(--badge-ok);
-}
-
-.badge-warn {
-  color: var(--badge-warn);
-}
-
-.badge-risk {
-  color: var(--badge-risk);
+body[data-rexai-font="base"],
+.stApp[data-rexai-font="base"] {
+  --font-scale: 1;
 }
 
 body[data-rexai-font="large"],
+.stApp[data-rexai-font="large"] {
+  --font-scale: 1.12;
+}
+
 body[data-rexai-font="xlarge"],
-.stApp[data-rexai-font="large"],
 .stApp[data-rexai-font="xlarge"] {
-  line-height: 1.55;
+  --font-scale: 1.24;
 }
 
-body[data-rexai-theme*="high-contrast"] .card,
-body[data-rexai-theme*="high-contrast"] .kpi,
-body[data-rexai-theme*="high-contrast"] .metric,
-.stApp[data-rexai-theme*="high-contrast"] .card,
-.stApp[data-rexai-theme*="high-contrast"] .kpi,
-.stApp[data-rexai-theme*="high-contrast"] .metric {
-  box-shadow: none;
+body[data-rexai-colorblind="safe"],
+.stApp[data-rexai-colorblind="safe"] {
+  --accent: #0f7fb0;
+  --accent-soft: #5cb6d8;
+  --badge-ok: #20897a;
+  --badge-warn: #d9822b;
+  --badge-risk: #c4476d;
+  --tone-ok-bg: #1b4d3a;
+  --tone-ok-fg: #a4e9c0;
+  --tone-ok-border: #2c7a58;
+  --tone-warn-bg: #4a3b16;
+  --tone-warn-fg: #f2c14e;
+  --tone-warn-border: #b98020;
+  --tone-risk-bg: #4a2633;
+  --tone-risk-fg: #f29cb5;
+  --tone-risk-border: #a8516e;
 }
 
-body[data-rexai-colorblind="safe"] .pill,
-.stApp[data-rexai-colorblind="safe"] .pill {
-  filter: saturate(0.92);
 @layer tokens {
   :root {
     color-scheme: dark;

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -5,12 +5,130 @@ tras compilar `app/static/design_tokens.scss`. Actualiza el SCSS y vuelve a ejec
 script para refrescar las tablas.
 
 ## Tokens
+### Accent
+
+| Token | Valor |
+| --- | --- |
+| `--accent` | `#5aa9ff` |
+| `--accent-soft` | `#93c5fd` |
+| `--accent` | `#5aa9ff` |
+| `--accent-soft` | `#93c5fd` |
+| `--accent` | `#1ea7ff` |
+| `--accent-soft` | `#82d3ff` |
+| `--accent` | `#2563eb` |
+| `--accent-soft` | `#93c5fd` |
+| `--accent` | `#0f4cd6` |
+| `--accent-soft` | `#5f8dff` |
+| `--accent` | `#268bd2` |
+| `--accent-soft` | `#2aa198` |
+| `--accent` | `#0f7fb0` |
+| `--accent-soft` | `#5cb6d8` |
+
 ### Lienzo
 Fondo base de la aplicación.
 
 | Token | Valor |
 | --- | --- |
 | `--app-bg` | `radial-gradient(1200px 460px at 20% -20%, rgba(77, 108, 255, 0.18), transparent) #05070f` |
+
+### Badge
+
+| Token | Valor |
+| --- | --- |
+| `--badge-ok` | `#2dd4bf` |
+| `--badge-warn` | `#f59e0b` |
+| `--badge-risk` | `#fb7185` |
+| `--badge-ok` | `#2dd4bf` |
+| `--badge-warn` | `#f59e0b` |
+| `--badge-risk` | `#fb7185` |
+| `--badge-ok` | `#34d399` |
+| `--badge-warn` | `#f59e0b` |
+| `--badge-risk` | `#fb7185` |
+| `--badge-ok` | `#047857` |
+| `--badge-warn` | `#c2410c` |
+| `--badge-risk` | `#dc2626` |
+| `--badge-ok` | `#15803d` |
+| `--badge-warn` | `#b45309` |
+| `--badge-risk` | `#b91c1c` |
+| `--badge-ok` | `#2aa198` |
+| `--badge-warn` | `#cb4b16` |
+| `--badge-risk` | `#dc322f` |
+| `--badge-ok` | `#20897a` |
+| `--badge-warn` | `#d9822b` |
+| `--badge-risk` | `#c4476d` |
+
+### Bd
+
+| Token | Valor |
+| --- | --- |
+| `--bd` | `#243042` |
+| `--bd` | `#243042` |
+| `--bd` | `#3b82f6` |
+| `--bd` | `#cfd7ef` |
+| `--bd` | `#1d4ed8` |
+| `--bd` | `#d9caa6` |
+
+### Bg
+
+| Token | Valor |
+| --- | --- |
+| `--bg` | `#0b0d12` |
+| `--bg` | `#0b0d12` |
+| `--bg` | `#010409` |
+| `--bg` | `#f4f7fb` |
+| `--bg` | `#ffffff` |
+| `--bg` | `#fdf6e3` |
+
+### Border
+
+| Token | Valor |
+| --- | --- |
+| `--border-soft` | `#243042` |
+| `--border-strong` | `#31405a` |
+| `--border-soft` | `#243042` |
+| `--border-strong` | `#31405a` |
+| `--border-soft` | `#3b82f6` |
+| `--border-strong` | `#60a5fa` |
+| `--border-soft` | `#cfd7ef` |
+| `--border-strong` | `#94a3b8` |
+| `--border-soft` | `#1d4ed8` |
+| `--border-strong` | `#1d4ed8` |
+| `--border-soft` | `#d9caa6` |
+| `--border-strong` | `#b5a273` |
+
+### Card
+
+| Token | Valor |
+| --- | --- |
+| `--card` | `#141c2a` |
+| `--card` | `#141c2a` |
+| `--card` | `#0a1220` |
+| `--card` | `#ffffff` |
+| `--card` | `#f5faff` |
+| `--card` | `#fefcf6` |
+
+### Chip
+
+| Token | Valor |
+| --- | --- |
+| `--chip-bg` | `#16243a` |
+| `--chip-border` | `#243a5f` |
+| `--chip-ink` | `#f1f5ff` |
+| `--chip-bg` | `#16243a` |
+| `--chip-border` | `#243a5f` |
+| `--chip-ink` | `#f1f5ff` |
+| `--chip-bg` | `#16243a` |
+| `--chip-border` | `#243a5f` |
+| `--chip-ink` | `#f1f5ff` |
+| `--chip-bg` | `#e2e8f9` |
+| `--chip-border` | `#c3d4fb` |
+| `--chip-ink` | `#1e293b` |
+| `--chip-bg` | `#e0ecff` |
+| `--chip-border` | `#1d4ed8` |
+| `--chip-ink` | `#0f172a` |
+| `--chip-bg` | `#ece3c5` |
+| `--chip-border` | `#d7c69a` |
+| `--chip-ink` | `#073642` |
 
 ### Escala neblina
 Neutros fríos para fondos y bordes.
@@ -60,6 +178,15 @@ Azules base usados para capas principales.
 | `--color-primary-800` | `#233280` |
 | `--color-primary-900` | `#1c2864` |
 
+### Font
+
+| Token | Valor |
+| --- | --- |
+| `--font-scale` | `1` |
+| `--font-scale` | `1` |
+| `--font-scale` | `1.12` |
+| `--font-scale` | `1.24` |
+
 ### Tipografía fluida
 Clamps responsivos por jerarquía.
 
@@ -80,11 +207,209 @@ Tokens para tarjetas translúcidas.
 | `--glass-bg` | `rgba(26, 42, 88, 0.35)` |
 | `--glass-border` | `rgba(132, 156, 214, 0.28)` |
 
+### Hero
+
+| Token | Valor |
+| --- | --- |
+| `--hero-background` | `linear-gradient(135deg, rgba(59,130,246,0.22), rgba(59,130,246,0.05)), linear-gradient(180deg, rgba(15,23,42,0.9), rgba(15,23,42,0.72))` |
+| `--hero-border` | `#3b82f6` |
+| `--hero-background` | `linear-gradient(135deg, rgba(59,130,246,0.22), rgba(59,130,246,0.05)), linear-gradient(180deg, rgba(15,23,42,0.9), rgba(15,23,42,0.72))` |
+| `--hero-border` | `#3b82f6` |
+| `--hero-background` | `linear-gradient(135deg, rgba(59,130,246,0.22), rgba(59,130,246,0.05)), linear-gradient(180deg, rgba(15,23,42,0.9), rgba(15,23,42,0.72))` |
+| `--hero-border` | `#3b82f6` |
+| `--hero-background` | `linear-gradient(135deg, rgba(96,165,250,0.25), rgba(96,165,250,0.05)), linear-gradient(180deg, rgba(255,255,255,0.9), rgba(236,244,255,0.78))` |
+| `--hero-border` | `#60a5fa` |
+| `--hero-background` | `linear-gradient(135deg, rgba(96,165,250,0.25), rgba(96,165,250,0.05)), linear-gradient(180deg, rgba(255,255,255,0.9), rgba(236,244,255,0.78))` |
+| `--hero-border` | `#60a5fa` |
+| `--hero-background` | `linear-gradient(135deg, rgba(38,139,210,0.2), rgba(38,139,210,0.05)), linear-gradient(180deg, rgba(253,246,227,0.92), rgba(249,240,213,0.78))` |
+| `--hero-border` | `#268bd2` |
+
+### Home
+
+| Token | Valor |
+| --- | --- |
+| `--home-content-max` | `58rem` |
+| `--home-stack-gap` | `clamp(2.5rem, 4vw, 3.5rem)` |
+| `--home-section-gap` | `clamp(1.1rem, calc(1.2rem + 0.5vw), 1.8rem)` |
+| `--home-header-gap` | `var(--space-sm)` |
+| `--home-icon-size` | `2.5rem` |
+| `--home-icon-radius` | `0.9rem` |
+| `--home-icon-font-size` | `1.35rem` |
+| `--home-text-max` | `62ch` |
+| `--home-lead-size` | `clamp(1rem, calc(0.98rem + 0.28vw), 1.2rem)` |
+| `--home-card-gap` | `var(--space-lg)` |
+| `--home-card-padding` | `clamp(1.1rem, calc(0.9rem + 1vw), 1.9rem)` |
+| `--home-card-radius` | `1.25rem` |
+| `--home-card-shadow` | `var(--shadow-soft)` |
+| `--home-heading-spacing` | `var(--space-sm)` |
+| `--home-list-gap` | `var(--space-xs)` |
+| `--home-list-indent` | `1.25rem` |
+| `--home-board-gap` | `var(--space-md)` |
+| `--home-muted` | `var(--muted)` |
+| `--home-content-max` | `58rem` |
+| `--home-stack-gap` | `clamp(2.5rem, 4vw, 3.5rem)` |
+| `--home-section-gap` | `clamp(1.1rem, calc(1.2rem + 0.5vw), 1.8rem)` |
+| `--home-header-gap` | `var(--space-sm)` |
+| `--home-icon-size` | `2.5rem` |
+| `--home-icon-radius` | `0.9rem` |
+| `--home-icon-font-size` | `1.35rem` |
+| `--home-text-max` | `62ch` |
+| `--home-lead-size` | `clamp(1rem, calc(0.98rem + 0.28vw), 1.2rem)` |
+| `--home-card-gap` | `var(--space-lg)` |
+| `--home-card-padding` | `clamp(1.1rem, calc(0.9rem + 1vw), 1.9rem)` |
+| `--home-card-radius` | `1.25rem` |
+| `--home-card-shadow` | `var(--shadow-soft)` |
+| `--home-heading-spacing` | `var(--space-sm)` |
+| `--home-list-gap` | `var(--space-xs)` |
+| `--home-list-indent` | `1.25rem` |
+| `--home-board-gap` | `var(--space-md)` |
+| `--home-muted` | `var(--muted)` |
+| `--home-content-max` | `58rem` |
+| `--home-stack-gap` | `clamp(2.5rem, 4vw, 3.5rem)` |
+| `--home-section-gap` | `clamp(1.1rem, calc(1.2rem + 0.5vw), 1.8rem)` |
+| `--home-header-gap` | `var(--space-sm)` |
+| `--home-icon-size` | `2.5rem` |
+| `--home-icon-radius` | `0.9rem` |
+| `--home-icon-font-size` | `1.35rem` |
+| `--home-text-max` | `62ch` |
+| `--home-lead-size` | `clamp(1rem, calc(0.98rem + 0.28vw), 1.2rem)` |
+| `--home-card-gap` | `var(--space-lg)` |
+| `--home-card-padding` | `clamp(1.1rem, calc(0.9rem + 1vw), 1.9rem)` |
+| `--home-card-radius` | `1.25rem` |
+| `--home-card-shadow` | `var(--shadow-soft)` |
+| `--home-heading-spacing` | `var(--space-sm)` |
+| `--home-list-gap` | `var(--space-xs)` |
+| `--home-list-indent` | `1.25rem` |
+| `--home-board-gap` | `var(--space-md)` |
+| `--home-muted` | `var(--muted)` |
+| `--home-content-max` | `58rem` |
+| `--home-stack-gap` | `clamp(2.5rem, 4vw, 3.5rem)` |
+| `--home-section-gap` | `clamp(1.1rem, calc(1.2rem + 0.5vw), 1.8rem)` |
+| `--home-header-gap` | `var(--space-sm)` |
+| `--home-icon-size` | `2.5rem` |
+| `--home-icon-radius` | `0.9rem` |
+| `--home-icon-font-size` | `1.35rem` |
+| `--home-text-max` | `62ch` |
+| `--home-lead-size` | `clamp(1rem, calc(0.98rem + 0.28vw), 1.2rem)` |
+| `--home-card-gap` | `var(--space-lg)` |
+| `--home-card-padding` | `clamp(1.1rem, calc(0.9rem + 1vw), 1.9rem)` |
+| `--home-card-radius` | `1.25rem` |
+| `--home-card-shadow` | `var(--shadow-soft)` |
+| `--home-heading-spacing` | `var(--space-sm)` |
+| `--home-list-gap` | `var(--space-xs)` |
+| `--home-list-indent` | `1.25rem` |
+| `--home-board-gap` | `var(--space-md)` |
+| `--home-muted` | `var(--muted)` |
+| `--home-content-max` | `58rem` |
+| `--home-stack-gap` | `clamp(2.5rem, 4vw, 3.5rem)` |
+| `--home-section-gap` | `clamp(1.1rem, calc(1.2rem + 0.5vw), 1.8rem)` |
+| `--home-header-gap` | `var(--space-sm)` |
+| `--home-icon-size` | `2.5rem` |
+| `--home-icon-radius` | `0.9rem` |
+| `--home-icon-font-size` | `1.35rem` |
+| `--home-text-max` | `62ch` |
+| `--home-lead-size` | `clamp(1rem, calc(0.98rem + 0.28vw), 1.2rem)` |
+| `--home-card-gap` | `var(--space-lg)` |
+| `--home-card-padding` | `clamp(1.1rem, calc(0.9rem + 1vw), 1.9rem)` |
+| `--home-card-radius` | `1.25rem` |
+| `--home-card-shadow` | `var(--shadow-soft)` |
+| `--home-heading-spacing` | `var(--space-sm)` |
+| `--home-list-gap` | `var(--space-xs)` |
+| `--home-list-indent` | `1.25rem` |
+| `--home-board-gap` | `var(--space-md)` |
+| `--home-muted` | `var(--muted)` |
+| `--home-content-max` | `58rem` |
+| `--home-stack-gap` | `clamp(2.5rem, 4vw, 3.5rem)` |
+| `--home-section-gap` | `clamp(1.1rem, calc(1.2rem + 0.5vw), 1.8rem)` |
+| `--home-header-gap` | `var(--space-sm)` |
+| `--home-icon-size` | `2.5rem` |
+| `--home-icon-radius` | `0.9rem` |
+| `--home-icon-font-size` | `1.35rem` |
+| `--home-text-max` | `62ch` |
+| `--home-lead-size` | `clamp(1rem, calc(0.98rem + 0.28vw), 1.2rem)` |
+| `--home-card-gap` | `var(--space-lg)` |
+| `--home-card-padding` | `clamp(1.1rem, calc(0.9rem + 1vw), 1.9rem)` |
+| `--home-card-radius` | `1.25rem` |
+| `--home-card-shadow` | `var(--shadow-soft)` |
+| `--home-heading-spacing` | `var(--space-sm)` |
+| `--home-list-gap` | `var(--space-xs)` |
+| `--home-list-indent` | `1.25rem` |
+| `--home-board-gap` | `var(--space-md)` |
+| `--home-muted` | `var(--muted)` |
+
+### Ink
+
+| Token | Valor |
+| --- | --- |
+| `--ink` | `#f8fafc` |
+| `--ink` | `#f8fafc` |
+| `--ink` | `#ffffff` |
+| `--ink` | `#0f172a` |
+| `--ink` | `#0b1526` |
+| `--ink` | `#073642` |
+
+### Metric
+
+| Token | Valor |
+| --- | --- |
+| `--metric-bg` | `#101a2a` |
+| `--metric-border` | `#223551` |
+| `--metric-shadow` | `0 18px 32px rgba(4, 8, 20, 0.45)` |
+| `--metric-bg` | `#101a2a` |
+| `--metric-border` | `#223551` |
+| `--metric-shadow` | `0 18px 32px rgba(4, 8, 20, 0.45)` |
+| `--metric-bg` | `#101a2a` |
+| `--metric-border` | `#223551` |
+| `--metric-shadow` | `none` |
+| `--metric-bg` | `#f1f4fc` |
+| `--metric-border` | `#cbd5f5` |
+| `--metric-shadow` | `0 16px 32px rgba(15, 23, 42, 0.1)` |
+| `--metric-bg` | `#f1f4fc` |
+| `--metric-border` | `#cbd5f5` |
+| `--metric-shadow` | `none` |
+| `--metric-bg` | `#f5ebd3` |
+| `--metric-border` | `#d7c69a` |
+| `--metric-shadow` | `0 12px 24px rgba(7, 54, 66, 0.12)` |
+
+### Muted
+
+| Token | Valor |
+| --- | --- |
+| `--muted` | `#b8c3d5` |
+| `--muted` | `#b8c3d5` |
+| `--muted` | `#dbe6ff` |
+| `--muted` | `#4a5a7d` |
+| `--muted` | `#1f2937` |
+| `--muted` | `#596a72` |
+
+### Pill
+
+| Token | Valor |
+| --- | --- |
+| `--pill-bg` | `transparent` |
+| `--pill-bg` | `transparent` |
+| `--pill-bg` | `transparent` |
+| `--pill-bg` | `transparent` |
+| `--pill-bg` | `transparent` |
+| `--pill-bg` | `transparent` |
+
 ### Sombras multicapa
 Capas apiladas para profundidad.
 
 | Token | Valor |
 | --- | --- |
+| `--shadow-card` | `0 24px 48px rgba(4, 8, 20, 0.45)` |
+| `--shadow-flat` | `none` |
+| `--shadow-card` | `0 24px 48px rgba(4, 8, 20, 0.45)` |
+| `--shadow-flat` | `none` |
+| `--shadow-card` | `none` |
+| `--shadow-flat` | `none` |
+| `--shadow-card` | `0 24px 48px rgba(15, 23, 42, 0.12)` |
+| `--shadow-flat` | `none` |
+| `--shadow-card` | `none` |
+| `--shadow-flat` | `none` |
+| `--shadow-card` | `0 20px 36px rgba(7, 54, 66, 0.18)` |
+| `--shadow-flat` | `none` |
 | `--shadow-soft` | `0 2px 6px -2px rgba(12, 18, 37, 0.4), 0 1px 0 rgba(255, 255, 255, 0.04)` |
 | `--shadow-lift` | `0 8px 24px -6px rgba(24, 44, 88, 0.42), 0 1px 0 rgba(255, 255, 255, 0.06)` |
 | `--shadow-float` | `0 18px 45px -10px rgba(10, 18, 40, 0.48), 0 4px 18px -6px rgba(46, 115, 255, 0.3)` |
@@ -114,15 +439,135 @@ Transformaciones para hover/press/focus.
 | `--state-press-filter` | `brightness(0.95) saturate(0.95)` |
 | `--state-focus-ring` | `0 0 0 3px rgba(111, 141, 255, 0.4)` |
 
+### Step
+
+| Token | Valor |
+| --- | --- |
+| `--step-bg` | `#101a2a` |
+| `--step-border` | `#223551` |
+| `--step-icon-bg` | `rgba(90, 169, 255, 0.24)` |
+| `--step-bg` | `#101a2a` |
+| `--step-border` | `#223551` |
+| `--step-icon-bg` | `rgba(90, 169, 255, 0.24)` |
+| `--step-bg` | `#101a2a` |
+| `--step-border` | `#223551` |
+| `--step-icon-bg` | `rgba(90, 169, 255, 0.24)` |
+| `--step-bg` | `#e9effd` |
+| `--step-border` | `#c3d4fb` |
+| `--step-icon-bg` | `rgba(37, 99, 235, 0.18)` |
+| `--step-bg` | `#e9effd` |
+| `--step-border` | `#c3d4fb` |
+| `--step-icon-bg` | `rgba(15, 76, 214, 0.16)` |
+| `--step-bg` | `#f2e7c9` |
+| `--step-border` | `#d7c69a` |
+| `--step-icon-bg` | `rgba(38, 139, 210, 0.18)` |
+
+### Stroke
+
+| Token | Valor |
+| --- | --- |
+| `--stroke` | `#1f2a3c` |
+| `--stroke` | `#1f2a3c` |
+| `--stroke` | `#3b82f6` |
+| `--stroke` | `#d7def1` |
+| `--stroke` | `#1e40af` |
+| `--stroke` | `#e7dcbf` |
+
 ### Superficies
 Valores base para superficies oscuras.
 
 | Token | Valor |
 | --- | --- |
+| `--surface-panel` | `#101724` |
+| `--surface-card` | `#141c2a` |
+| `--surface-ghost` | `#1c2636` |
+| `--surface-panel` | `#101724` |
+| `--surface-card` | `#141c2a` |
+| `--surface-ghost` | `#1c2636` |
+| `--surface-panel` | `#060b14` |
+| `--surface-card` | `#0a1220` |
+| `--surface-ghost` | `#0f1b2c` |
+| `--surface-panel` | `#ffffff` |
+| `--surface-card` | `#ffffff` |
+| `--surface-ghost` | `#eef2ff` |
+| `--surface-panel` | `#f5faff` |
+| `--surface-card` | `#f5faff` |
+| `--surface-ghost` | `#e2ecff` |
+| `--surface-panel` | `#fefbf3` |
+| `--surface-card` | `#fefcf6` |
+| `--surface-ghost` | `#f2e5c7` |
 | `--surface-bg` | `rgba(12, 16, 28, 0.9)` |
 | `--surface-border` | `rgba(126, 144, 184, 0.18)` |
 | `--surface-ink` | `#f8fbff` |
 | `--surface-muted` | `rgba(205, 215, 235, 0.75)` |
+
+### Tone
+
+| Token | Valor |
+| --- | --- |
+| `--tone-ok-bg` | `#123829` |
+| `--tone-ok-fg` | `#63f0a5` |
+| `--tone-ok-border` | `#1f6141` |
+| `--tone-warn-bg` | `#3f2a0f` |
+| `--tone-warn-fg` | `#f2c057` |
+| `--tone-warn-border` | `#7a5b1f` |
+| `--tone-risk-bg` | `#3d1518` |
+| `--tone-risk-fg` | `#f18882` |
+| `--tone-risk-border` | `#7a2b36` |
+| `--tone-ok-bg` | `#123829` |
+| `--tone-ok-fg` | `#63f0a5` |
+| `--tone-ok-border` | `#1f6141` |
+| `--tone-warn-bg` | `#3f2a0f` |
+| `--tone-warn-fg` | `#f2c057` |
+| `--tone-warn-border` | `#7a5b1f` |
+| `--tone-risk-bg` | `#3d1518` |
+| `--tone-risk-fg` | `#f18882` |
+| `--tone-risk-border` | `#7a2b36` |
+| `--tone-ok-bg` | `#083d2b` |
+| `--tone-ok-fg` | `#7fffd4` |
+| `--tone-ok-border` | `#34d399` |
+| `--tone-warn-bg` | `#4a2a00` |
+| `--tone-warn-fg` | `#fbbf24` |
+| `--tone-warn-border` | `#f59e0b` |
+| `--tone-risk-bg` | `#470011` |
+| `--tone-risk-fg` | `#ff7b89` |
+| `--tone-risk-border` | `#fb7185` |
+| `--tone-ok-bg` | `#c6f6d5` |
+| `--tone-ok-fg` | `#1f5136` |
+| `--tone-ok-border` | `#38a169` |
+| `--tone-warn-bg` | `#fef3c7` |
+| `--tone-warn-fg` | `#854d0e` |
+| `--tone-warn-border` | `#f59e0b` |
+| `--tone-risk-bg` | `#fee2e2` |
+| `--tone-risk-fg` | `#991b1b` |
+| `--tone-risk-border` | `#f87171` |
+| `--tone-ok-bg` | `#bbf7d0` |
+| `--tone-ok-fg` | `#166534` |
+| `--tone-ok-border` | `#15803d` |
+| `--tone-warn-bg` | `#fde68a` |
+| `--tone-warn-fg` | `#92400e` |
+| `--tone-warn-border` | `#b45309` |
+| `--tone-risk-bg` | `#fecaca` |
+| `--tone-risk-fg` | `#7f1d1d` |
+| `--tone-risk-border` | `#b91c1c` |
+| `--tone-ok-bg` | `#c8f1dc` |
+| `--tone-ok-fg` | `#1d5c3a` |
+| `--tone-ok-border` | `#3a9d6a` |
+| `--tone-warn-bg` | `#fee6b4` |
+| `--tone-warn-fg` | `#7c5416` |
+| `--tone-warn-border` | `#d48b1f` |
+| `--tone-risk-bg` | `#f9c0c0` |
+| `--tone-risk-fg` | `#8f1d2d` |
+| `--tone-risk-border` | `#d2565d` |
+| `--tone-ok-bg` | `#1b4d3a` |
+| `--tone-ok-fg` | `#a4e9c0` |
+| `--tone-ok-border` | `#2c7a58` |
+| `--tone-warn-bg` | `#4a3b16` |
+| `--tone-warn-fg` | `#f2c14e` |
+| `--tone-warn-border` | `#b98020` |
+| `--tone-risk-bg` | `#4a2633` |
+| `--tone-risk-fg` | `#f29cb5` |
+| `--tone-risk-border` | `#a8516e` |
 
 ## Uso
 

--- a/tests/ui/test_home_css.py
+++ b/tests/ui/test_home_css.py
@@ -1,0 +1,68 @@
+from pathlib import Path
+import sys
+import types
+
+import pytest
+
+pytest.importorskip("numpy")
+pytest.importorskip("plotly")
+
+if "joblib" not in sys.modules:
+    sys.modules["joblib"] = types.ModuleType("joblib")
+
+from app.modules.luxe_components import (  # noqa: E402
+    CarouselItem,
+    CarouselRail,
+    MissionBoard,
+    MissionMetrics,
+)
+
+
+def test_home_markup_prunes_legacy_classes() -> None:
+    metrics = MissionMetrics.from_payload(
+        [
+            {
+                "key": "status",
+                "label": "Estado",
+                "value": "✅ Modelo listo",
+                "details": ["Nombre: rexai-rf-ensemble"],
+                "stage_key": "inventory",
+            }
+        ],
+        animate=False,
+    )
+    board = MissionBoard.from_payload(
+        [
+            {
+                "key": "inventory",
+                "title": "Inventario",
+                "description": "Normalizá residuos y marcá flags EVA o multilayer.",
+                "href": "./?page=1_Inventory_Builder",
+                "icon": "🧱",
+            }
+        ],
+        reveal=False,
+    )
+    carousel = CarouselRail(
+        items=[CarouselItem(title="EVA scraps", value="320 kg")],
+        reveal=False,
+    )
+
+    markup = "\n".join(
+        [
+            metrics.markup(with_board=True),
+            board.markup(highlight_key="inventory"),
+            carousel.markup(),
+        ]
+    )
+
+    for legacy in ("reveal", "ghost-card", "tesla-hero", "parallax"):
+        assert legacy not in markup
+
+
+def test_home_css_prunes_obsolete_rules() -> None:
+    css = Path("app/static/home.css").read_text(encoding="utf-8")
+
+    assert ".home-section" in css
+    for legacy in (".reveal", ".ghost-card", ".tesla-hero", "parallax"):
+        assert legacy not in css


### PR DESCRIPTION
## Summary
- update the home page markup to use the new single-column cards and disable the legacy reveal animation hooks
- extract the reduced home layout variables into the token source, rebuild the compiled theme/css bundle, and refresh the design-system docs
- prune obsolete selectors from `home.css` and add a regression test that checks the markup and stylesheet for legacy classes

## Testing
- `python scripts/build_theme.py`
- `pytest tests/ui/test_home_css.py`


------
https://chatgpt.com/codex/tasks/task_e_68dbffbabc3483318f06f9c95e117080