### PR TITLE
Add minimal CTA button and gate cinematic effects

### DIFF
--- a/app/modules/candidate_showroom.py
+++ b/app/modules/candidate_showroom.py
@@ -228,6 +228,7 @@ def _render_candidate_card(
         loading_label="Abriendo holograma…",
         success_label="Receta seleccionada",
         help_text="Previsualizá la receta y confirmá desde la ventana holográfica.",
+        mode="cinematic",
     ):
         st.session_state["showroom_modal"] = idx
         current = _normalize_success(st.session_state.get(_SUCCESS_KEY))
@@ -246,6 +247,7 @@ def _render_candidate_card(
                     width="full",
                     loading_label="Sincronizando…",
                     success_label="Receta confirmada",
+                    mode="cinematic",
                 ):
                     st.session_state["selected"] = {"data": cand, "safety": badge}
                     st.session_state[_SUCCESS_KEY] = {
@@ -263,6 +265,7 @@ def _render_candidate_card(
                     state="idle",
                     width="full",
                     sound=False,
+                    mode="cinematic",
                 ):
                     st.session_state.pop("showroom_modal", None)
 

--- a/app/modules/ui_blocks.py
+++ b/app/modules/ui_blocks.py
@@ -136,6 +136,33 @@ _BUTTON_STYLES = """
 @keyframes rexai-spin{from{transform:rotate(0deg);}to{transform:rotate(360deg);}}
 """
 
+_MINIMAL_BUTTON_STYLES = """
+.rexai-minimal-wrapper{display:flex;flex-direction:column;gap:6px;}
+.rexai-minimal-wrapper[data-width="full"]{width:100%;}
+.rexai-minimal-wrapper[data-width="auto"]{display:inline-flex;}
+.rexai-minimal-button{border:1px solid rgba(148,163,184,0.32);border-radius:14px;padding:14px 18px;font-weight:600;font-size:1rem;color:var(--rexai-button-fg,rgba(15,23,42,0.94));background:var(--rexai-button-bg,rgba(148,163,184,0.08));box-shadow:0 4px 12px rgba(15,23,42,0.04);transition:transform 0.16s ease,box-shadow 0.18s ease,background 0.2s ease,color 0.2s ease;cursor:pointer;min-height:52px;text-align:center;display:flex;justify-content:center;align-items:center;gap:10px;}
+.rexai-minimal-button:disabled{cursor:not-allowed;opacity:0.6;}
+.rexai-minimal-wrapper[data-width="full"] .rexai-minimal-button{width:100%;}
+.rexai-minimal-wrapper[data-state="loading"] .rexai-minimal-button{background:rgba(148,163,184,0.14);box-shadow:0 4px 14px rgba(59,130,246,0.18);cursor:progress;}
+.rexai-minimal-wrapper[data-state="success"] .rexai-minimal-button{border-color:rgba(16,185,129,0.42);background:rgba(16,185,129,0.12);color:rgba(15,118,110,0.92);}
+.rexai-minimal-wrapper[data-state="error"] .rexai-minimal-button{border-color:rgba(248,113,113,0.48);background:rgba(248,113,113,0.1);color:rgba(153,27,27,0.92);}
+.rexai-minimal-icon{font-size:1.2rem;line-height:1;}
+.rexai-minimal-text{display:flex;flex-direction:column;gap:4px;line-height:1.2;align-items:center;justify-content:center;}
+.rexai-minimal-text[data-layout="inline"]{flex-direction:row;gap:10px;}
+.rexai-minimal-line{display:block;}
+.rexai-minimal-status{font-size:0.78rem;color:rgba(71,85,105,0.82);text-transform:uppercase;letter-spacing:0.04em;transition:opacity 0.18s ease;height:0;opacity:0;}
+.rexai-minimal-status[data-active="true"]{height:auto;opacity:1;}
+.rexai-minimal-help{font-size:0.82rem;color:rgba(100,116,139,0.9);margin:0 4px;}
+@media (prefers-color-scheme:dark){
+  .rexai-minimal-button{border-color:rgba(148,163,184,0.24);background:rgba(100,116,139,0.12);color:rgba(226,232,240,0.94);box-shadow:0 6px 16px rgba(15,23,42,0.3);}
+  .rexai-minimal-wrapper[data-state="loading"] .rexai-minimal-button{background:rgba(148,163,184,0.18);}
+  .rexai-minimal-wrapper[data-state="success"] .rexai-minimal-button{background:rgba(34,197,94,0.14);color:rgba(190,242,100,0.95);}
+  .rexai-minimal-wrapper[data-state="error"] .rexai-minimal-button{background:rgba(248,113,113,0.18);color:rgba(254,226,226,0.92);}
+  .rexai-minimal-status{color:rgba(148,163,184,0.86);}
+  .rexai-minimal-help{color:rgba(148,163,184,0.88);}
+}
+"""
+
 
 def load_theme(*, show_hud: bool = True) -> None:
     """Inject shared CSS and expose HUD toggles for the Rex-AI theme."""
@@ -333,6 +360,183 @@ def section(title: str, subtitle: str = "") -> None:
         st.caption(subtitle)
 
 
+_BUTTON_STATES: set[str] = {"idle", "loading", "success", "error"}
+
+
+def _split_lines(text: str) -> list[str]:
+    lines = [ln.strip() for ln in text.splitlines() if ln.strip()]
+    if not lines:
+        stripped = text.strip()
+        return [stripped or text]
+    return lines
+
+
+def _normalize_button_options(
+    label: str,
+    *,
+    state: Literal["idle", "loading", "success", "error"],
+    loading_label: str | None,
+    success_label: str | None,
+    error_label: str | None,
+    status_hints: dict[str, str] | None,
+    help_text: str | None,
+    icon: str | None,
+) -> dict[str, Any]:
+    if state not in _BUTTON_STATES:
+        raise ValueError(f"Estado no soportado: {state}")
+
+    state_messages = {
+        "idle": label,
+        "loading": loading_label or "Procesando…",
+        "success": success_label or "Listo",
+        "error": error_label or "Reintentar",
+    }
+    hints = status_hints or {
+        "idle": "",
+        "loading": "Optimizando parámetros",
+        "success": "Listo para revisar",
+        "error": "Revisá parámetros o intenta de nuevo",
+    }
+
+    current_label = state_messages.get(state, label)
+    label_lines = _split_lines(current_label)
+    line_count = max(1, len(label_lines))
+    layout_mode = "stack" if (len(label_lines) > 1 and not icon) else "inline"
+    status_text = hints.get(state, "")
+    return {
+        "state": state,
+        "state_messages": state_messages,
+        "status_hints": hints,
+        "label_lines": label_lines,
+        "line_count": line_count,
+        "layout_mode": layout_mode,
+        "status_text": status_text,
+        "help_text": help_text,
+    }
+
+
+def _render_button_component(
+    markup: str,
+    *,
+    key: str,
+    line_count: int,
+    has_help: bool,
+) -> bool:
+    base_height = 100 + max(0, line_count - 1) * 8
+    component_kwargs = {"height": base_height + (20 if has_help else 0), "key": key}
+    try:
+        result = components_html(markup, **component_kwargs)
+    except TypeError:
+        component_kwargs.pop("key", None)
+        result = components_html(markup, **component_kwargs)
+
+    session_key = f"__rexai_fx_ts::{key}"
+    if isinstance(result, dict) and result.get("event") == "click":
+        ts = result.get("ts")
+        if ts and st.session_state.get(session_key) != ts:
+            st.session_state[session_key] = ts
+            return True
+    return False
+
+
+def minimal_button(
+    label: str,
+    key: str,
+    *,
+    state: Literal["idle", "loading", "success", "error"] = "idle",
+    width: Literal["full", "auto"] = "full",
+    help_text: str | None = None,
+    loading_label: str | None = None,
+    success_label: str | None = None,
+    error_label: str | None = None,
+    disabled: bool = False,
+    status_hints: dict[str, str] | None = None,
+    icon: str | None = None,
+) -> bool:
+    """Render a minimal CTA button with the shared Rex-AI API."""
+
+    options = _normalize_button_options(
+        label,
+        state=state,
+        loading_label=loading_label,
+        success_label=success_label,
+        error_label=error_label,
+        status_hints=status_hints,
+        help_text=help_text,
+        icon=icon,
+    )
+
+    container_width = "full" if width not in {"full", "auto"} else width
+    button_id = f"rexai-minimal-{uuid4().hex}"
+    label_lines = options["label_lines"]
+    layout_mode = options["layout_mode"]
+    line_count = options["line_count"]
+    status_text = options["status_text"]
+    icon_html = (
+        f'<span class="rexai-minimal-icon" aria-hidden="true">{escape(icon)}</span>'
+        if icon
+        else ""
+    )
+    text_block = "".join(
+        f'<span class="rexai-minimal-line">{escape(line)}</span>' for line in label_lines
+    )
+    text_wrapper = (
+        f'<span class="rexai-minimal-text" data-layout="{layout_mode}" '
+        f'data-lines="{line_count}">{text_block}</span>'
+    )
+
+    help_html = (
+        f'<div class="rexai-minimal-help">{escape(help_text)}</div>' if help_text else ""
+    )
+
+    script = "".join(
+        [
+            "(function(){",
+            "const styleId='rexai-minimal-style';",
+            f"const styleCSS={json.dumps(_MINIMAL_BUTTON_STYLES)};",
+            "if(!document.getElementById(styleId)){const style=document.createElement('style');style.id=styleId;style.textContent=styleCSS;document.head.appendChild(style);}",
+            f"const cfg={{state:{json.dumps(state)},statusText:{json.dumps(status_text)},disabled:{json.dumps(bool(disabled))},width:{json.dumps(container_width)}}};",
+            "const wrapperId='" + button_id + "';",
+            "const Streamlit=window.parent && window.parent.Streamlit;",
+            "if(!Streamlit){return;}",
+            "const wrapper=document.getElementById(wrapperId);",
+            "if(!wrapper){return;}",
+            "Streamlit.setComponentReady();",
+            "wrapper.setAttribute('data-fx','minimal');",
+            "wrapper.setAttribute('data-state',cfg.state);",
+            "wrapper.setAttribute('data-width',cfg.width);",
+            "const statusEl=wrapper.querySelector('.rexai-minimal-status');",
+            "if(statusEl){statusEl.textContent=cfg.statusText||'';statusEl.setAttribute('data-active',cfg.statusText?'true':'false');}",
+            "const buttonEl=wrapper.querySelector('button');",
+            "if(buttonEl){buttonEl.disabled=cfg.disabled || cfg.state==='loading';",
+            "if(cfg.state==='loading'){buttonEl.setAttribute('aria-busy','true');}else{buttonEl.removeAttribute('aria-busy');}",
+            "if(!cfg.disabled){buttonEl.addEventListener('click',()=>Streamlit.setComponentValue({event:'click',ts:Date.now()}));}}",
+            "const sync=()=>Streamlit.setFrameHeight(document.body.scrollHeight);",
+            "sync();",
+            "window.addEventListener('resize',sync);",
+            "})();",
+        ]
+    )
+
+    html_markup = f"""
+    <div id="{button_id}" class="rexai-minimal-wrapper" data-state="{state}" data-width="{container_width}" data-fx="minimal">
+      <button type="button" class="rexai-minimal-button" {'disabled="disabled"' if disabled else ''}>
+        {icon_html}{text_wrapper}
+      </button>
+      <span class="rexai-minimal-status" data-active="{'true' if status_text else 'false'}">{escape(status_text)}</span>
+      {help_html}
+    </div>
+    <script>{script}</script>
+    """
+
+    return _render_button_component(
+        html_markup,
+        key=key,
+        line_count=line_count,
+        has_help=bool(help_text),
+    )
+
+
 def futuristic_button(
     label: str,
     key: str,
@@ -348,44 +552,48 @@ def futuristic_button(
     disabled: bool = False,
     status_hints: dict[str, str] | None = None,
     icon: str | None = None,
+    mode: Literal["minimal", "cinematic"] = "minimal",
 ) -> bool:
-    """Render the futuristic CTA microinteraction button and return ``True`` on click."""
+    """Render the CTA button with optional cinematic microinteractions."""
 
-    if state not in {"idle", "loading", "success", "error"}:
-        raise ValueError(f"Estado no soportado: {state}")
+    if mode == "minimal":
+        return minimal_button(
+            label,
+            key,
+            state=state,
+            width=width,
+            help_text=help_text,
+            loading_label=loading_label,
+            success_label=success_label,
+            error_label=error_label,
+            disabled=disabled,
+            status_hints=status_hints,
+            icon=icon,
+        )
 
-    state_messages = {
-        "idle": label,
-        "loading": loading_label or "Procesando…",
-        "success": success_label or "Listo",
-        "error": error_label or "Reintentar",
-    }
-    status_hints = status_hints or {
-        "idle": "",
-        "loading": "Optimizando parámetros",
-        "success": "Listo para revisar",
-        "error": "Revisá parámetros o intenta de nuevo",
-    }
+    if mode != "cinematic":
+        raise ValueError(f"Modo no soportado para futuristic_button: {mode}")
+
+    options = _normalize_button_options(
+        label,
+        state=state,
+        loading_label=loading_label,
+        success_label=success_label,
+        error_label=error_label,
+        status_hints=status_hints,
+        help_text=help_text,
+        icon=icon,
+    )
 
     container_width = "full" if width not in {"full", "auto"} else width
-    status_text = status_hints.get(state, "")
+    status_text = options["status_text"]
     help_html = (
         f'<div class="rexai-fx-help">{escape(help_text)}</div>' if help_text else ""
     )
-
-    label_current = state_messages.get(state, label)
+    label_lines = options["label_lines"]
+    line_count = options["line_count"]
+    layout_mode = options["layout_mode"]
     button_id = f"rexai-fx-{uuid4().hex}"
-
-    def _label_lines(text: str) -> list[str]:
-        lines = [ln.strip() for ln in text.splitlines() if ln.strip()]
-        if not lines:
-            stripped = text.strip()
-            return [stripped or text]
-        return lines
-
-    label_lines = _label_lines(label_current)
-    line_count = max(1, len(label_lines))
-    layout_mode = "stack" if (len(label_lines) > 1 and not icon) else "inline"
     icon_html = (
         f'<span class="rexai-fx-icon" aria-hidden="true">{escape(icon)}</span>'
         if icon
@@ -402,8 +610,8 @@ def futuristic_button(
 
     config: dict[str, Any] = {
         "state": state,
-        "stateMessages": state_messages,
-        "statusHints": status_hints,
+        "stateMessages": options["state_messages"],
+        "statusHints": options["status_hints"],
         "sound": sound,
         "vibration": bool(enable_vibration),
         "vibrationPattern": [8, 14, 4, 18] if enable_vibration else [],
@@ -432,11 +640,14 @@ def futuristic_button(
             "const wrapper=document.getElementById(wrapperId);",
             "if(!wrapper){return;}",
             "Streamlit.setComponentReady();",
+            "wrapper.setAttribute('data-fx','cinematic');",
+            "wrapper.setAttribute('data-state',cfg.state);",
+            "wrapper.setAttribute('data-width'," + json.dumps(container_width) + ");",
             "const buttonEl=wrapper.querySelector('button');",
             "if(buttonEl){buttonEl.disabled=cfg.disabled;}",
             "const statusEl=wrapper.querySelector('.rexai-fx-status');",
             "if(statusEl){const hint=(cfg.statusHints && cfg.statusHints[cfg.state])||'';statusEl.textContent=hint;statusEl.setAttribute('data-active',hint?'true':'false');}",
-            "if(window.RexAIMicro){const controller=window.RexAIMicro.mount(wrapper,cfg);if(controller){controller.applyState(cfg.state);}}else{wrapper.setAttribute('data-state',cfg.state);}",
+            "if(window.RexAIMicro){const controller=window.RexAIMicro.mount(wrapper,cfg);if(controller){controller.applyState(cfg.state);}}",
             "const send=(payload)=>Streamlit.setComponentValue(payload);",
             "if(buttonEl && !cfg.disabled){buttonEl.addEventListener('click',()=>send({event:'click',ts:Date.now()}));}",
             "const sync=()=>Streamlit.setFrameHeight(document.body.scrollHeight);",
@@ -447,7 +658,7 @@ def futuristic_button(
     script = "".join(script_parts)
 
     html_markup = f"""
-    <div id="{button_id}" class="rexai-fx-wrapper" data-state="{state}" data-width="{container_width}">
+    <div id="{button_id}" class="rexai-fx-wrapper" data-state="{state}" data-width="{container_width}" data-fx="cinematic">
       <button type="button" class="rexai-fx-button" {'disabled="disabled"' if disabled else ''}>
         <span class="rexai-fx-particles"></span>
         {label_html}
@@ -458,20 +669,12 @@ def futuristic_button(
     <script>{script}</script>
     """
 
-    base_height = 100 + max(0, line_count - 1) * 8
-    component_kwargs = {"height": base_height + (20 if help_text else 0), "key": key}
-    try:
-        result = components_html(html_markup, **component_kwargs)
-    except TypeError:
-        component_kwargs.pop("key", None)
-        result = components_html(html_markup, **component_kwargs)
-    session_key = f"__rexai_fx_ts::{key}"
-    if isinstance(result, dict) and result.get("event") == "click":
-        ts = result.get("ts")
-        if ts and st.session_state.get(session_key) != ts:
-            st.session_state[session_key] = ts
-            return True
-    return False
+    return _render_button_component(
+        html_markup,
+        key=key,
+        line_count=line_count,
+        has_help=bool(help_text),
+    )
 
 
 @contextmanager

--- a/app/pages/1_Inventory_Builder.py
+++ b/app/pages/1_Inventory_Builder.py
@@ -5,7 +5,7 @@ import pandas as pd
 from st_aggrid import AgGrid, GridOptionsBuilder, GridUpdateMode, JsCode
 from app.modules.io import load_waste_df, save_waste_df
 from app.modules.navigation import set_active_step
-from app.modules.ui_blocks import load_theme
+from app.modules.ui_blocks import load_theme, minimal_button
 
 _SAVE_SUCCESS_FLAG = "_inventory_save_success"
 
@@ -24,7 +24,8 @@ set_active_step("inventory")
 
 load_theme()
 
-if st.session_state.pop(_SAVE_SUCCESS_FLAG, False):
+save_success = st.session_state.pop(_SAVE_SUCCESS_FLAG, False)
+if save_success:
     st.success("Inventario guardado.")
 
 st.title("1) Inventario de residuos")
@@ -366,7 +367,21 @@ with preview_col:
 
 colA, colB = st.columns(2)
 with colA:
-    if st.button("💾 Guardar inventario", type="primary"):
+    button_state = "success" if save_success else "idle"
+    if minimal_button(
+        "💾 Guardar inventario",
+        key="inventory_save",
+        state=button_state,
+        width="full",
+        help_text="Se exporta a data/waste_inventory_sample.csv",
+        success_label="Inventario guardado",
+        status_hints={
+            "idle": "",
+            "loading": "Guardando dataset",
+            "success": "Inventario actualizado",
+            "error": "",
+        },
+    ):
         out = st.session_state["inventory_data"][["id", "category", "material_family", "mass_kg", "volume_l", "flags"]].copy()
         save_waste_df(out)
         st.session_state[_SAVE_SUCCESS_FLAG] = True

--- a/app/pages/3_Generator.py
+++ b/app/pages/3_Generator.py
@@ -15,10 +15,10 @@ from app.modules.process_planner import choose_process
 from app.modules.safety import check_safety, safety_badge
 from app.modules.ui_blocks import (
     badge_group,
-    futuristic_button,
     layout_block,
     load_theme,
     micro_divider,
+    minimal_button,
 )
 from app.modules.luxe_components import ChipRow, MetricSpec, RankingCockpit, TeslaHero
 from app.modules.visualizations import ConvergenceScene
@@ -148,7 +148,7 @@ with layout_block("layout-grid layout-grid--dual layout-grid--flow", parent=None
         crew_low = target.get("crew_time_low", False)
         control.caption("Los resultados privilegian %s" % ("tiempo de tripulación" if crew_low else "un balance general"))
         with control:
-            run = futuristic_button(
+            run = minimal_button(
                 "Generar recomendaciones",
                 key="generator_run_button",
                 state=button_state,
@@ -157,7 +157,6 @@ with layout_block("layout-grid layout-grid--dual layout-grid--flow", parent=None
                 loading_label="Generando…",
                 success_label="Candidatos listos",
                 error_label="Reintentar",
-                enable_vibration=True,
                 status_hints={
                     "idle": "",
                     "loading": "Corriendo optimizador",

--- a/app/pages/6_Pareto_and_Export.py
+++ b/app/pages/6_Pareto_and_Export.py
@@ -577,6 +577,7 @@ La capa “Pareto” marca los que no pueden mejorarse en un eje sin empeorar ot
                 "success": "Disponible en Export Center",
                 "error": "Revisá la opción seleccionada",
             },
+            mode="cinematic",
         ):
             st.session_state[select_state_key] = "loading"
             st.session_state[select_trigger_key] = True

--- a/app/static/microinteractions.js
+++ b/app/static/microinteractions.js
@@ -96,7 +96,8 @@
       "rgba(129,140,248,0.8)",
     ];
 
-    if (!button) {
+    const fxMode = root.dataset ? root.dataset.fx : undefined;
+    if (!button || fxMode !== "cinematic") {
       return null;
     }
 

--- a/tests/ui/test_futuristic_button_usage.py
+++ b/tests/ui/test_futuristic_button_usage.py
@@ -65,7 +65,8 @@ def test_futuristic_button_transitions(monkeypatch) -> None:
     app = runner.run()
 
     html_block = app.session_state["__fx_markup__"]
-    assert "rexai-fx-line" in html_block
+    assert "rexai-minimal-line" in html_block
+    assert 'data-fx="minimal"' in html_block
     assert _extract_state_markup(html_block) == "idle"
 
     app = app.button(key="demo_fx_loading").click().run()
@@ -75,3 +76,30 @@ def test_futuristic_button_transitions(monkeypatch) -> None:
     app = app.button(key="demo_fx_success").click().run()
     html_block = app.session_state["__fx_markup__"]
     assert _extract_state_markup(html_block) == "success"
+
+
+def test_futuristic_button_cinematic_mode(monkeypatch) -> None:
+    ui_blocks = import_module("app.modules.ui_blocks")
+
+    def _capture_html(markup: str, **kwargs: object) -> dict[str, object]:
+        import streamlit as st
+
+        st.session_state["__fx_markup__"] = markup
+        return {}
+
+    monkeypatch.setattr(ui_blocks, "components_html", _capture_html)
+
+    def _cinematic_app() -> None:
+        import streamlit as st
+
+        from app.modules.ui_blocks import futuristic_button
+
+        futuristic_button("Demo", key="cinematic_demo", mode="cinematic")
+
+    runner = StreamlitRunner(_cinematic_app)
+    app = runner.run()
+
+    html_block = app.session_state["__fx_markup__"]
+    assert "rexai-fx-wrapper" in html_block
+    assert 'data-fx="cinematic"' in html_block
+    assert "rexai-fx-particles" in html_block


### PR DESCRIPTION
## Summary
- add a reusable `minimal_button` helper with light-touch styles and shared CTA API
- default `futuristic_button` to the minimal experience, gating cinematic effects behind `mode="cinematic"`
- update inventory, generator, and critical flows to use the minimal button while keeping cinematic demos opt-in
- ensure micro-interactions only mount for `data-fx="cinematic"` wrappers and expand UI tests to cover both modes

## Testing
- pytest tests/ui/test_futuristic_button_usage.py -q
- pytest tests/ui/test_candidate_showroom.py -q

------
https://chatgpt.com/codex/tasks/task_e_68dc069126e08331b539db43059781f7