### PR TITLE
Refactor mission HUD layout

### DIFF
--- a/app/modules/navigation.py
+++ b/app/modules/navigation.py
@@ -2,14 +2,11 @@
 
 from __future__ import annotations
 
-import json
 from dataclasses import dataclass
 from functools import lru_cache
 from typing import Sequence
 
 import streamlit as st
-from streamlit.components.v1 import html
-
 from app.modules.ml_models import get_model_registry
 
 
@@ -79,92 +76,43 @@ def _page_url(page: str) -> str:
 def _hud_css() -> str:
     return """
     <style>
-      .mission-hud {position: sticky; top: 0; z-index: 999; margin-bottom: 1.4rem;}
-      .mission-hud__wrap {backdrop-filter: blur(12px); background: rgba(13,17,23,0.82); border: 1px solid rgba(96,165,250,0.18);
-        border-radius: 20px; padding: 14px 20px; display: grid; grid-template-columns: auto 1fr auto; gap: 18px; align-items: center;}
+      .mission-hud {position: sticky; top: 0; z-index: 999; margin-bottom: var(--mission-hud-stack, 1.1rem);}
+      .mission-hud__wrap {backdrop-filter: blur(14px); background: var(--mission-hud-bg, rgba(13,17,23,0.85)); border: 1px solid var(--mission-hud-border, rgba(96,165,250,0.28));
+        border-radius: var(--mission-hud-radius, 18px); padding: 12px 18px; display: grid; grid-template-columns: auto 1fr auto; gap: var(--mission-hud-gap, 16px); align-items: center;
+        box-shadow: var(--mission-hud-shadow, 0 18px 38px rgba(8,18,36,0.32));}
       .mission-hud__logo {display: flex; align-items: center; gap: 10px; font-weight: 700; letter-spacing: .02em; color: var(--ink, #e2e8f0); font-size: 1.05rem;}
-      .mission-hud__steps {display: flex; gap: 10px; overflow-x: auto; padding-bottom: 6px;}
-      .mission-hud__step {display: inline-flex; align-items: center; gap: 8px; padding: 6px 12px; border-radius: 999px; border: 1px solid rgba(148,163,184,0.22); color: rgba(226,232,240,0.78); font-size: 0.82rem; transition: all .3s ease; text-decoration: none; white-space: nowrap;}
-      .mission-hud__step:hover {border-color: rgba(96,165,250,0.45); color: #f8fafc; box-shadow: 0 6px 18px rgba(15,118,110,0.18);}
-      .mission-hud__step.is-active {background: linear-gradient(135deg, rgba(59,130,246,0.35), rgba(14,165,233,0.18)); border-color: rgba(96,165,250,0.75); color: #f8fafc;}
-      .mission-hud__status {display: grid; gap: 4px; text-align: right;}
-      .mission-hud__status small {opacity: 0.68; font-size: 0.7rem;}
-      .mission-hud__progress {height: 4px; margin-top: 8px; background: rgba(96,165,250,0.18); border-radius: 99px; overflow: hidden;}
-      .mission-hud__progress-bar {height: 100%; background: linear-gradient(90deg, rgba(59,130,246,1), rgba(14,165,233,1)); transition: width .4s ease;}
-      .mission-hud__ctas {display: flex; gap: 8px; margin-top: 6px; justify-content: flex-end;}
-      .mission-hud__cta {padding: 6px 12px; border-radius: 10px; border: 1px solid rgba(96,165,250,0.4); background: rgba(15,23,42,0.75); color: #e2e8f0; font-size: 0.78rem; text-decoration: none; transition: all .3s ease;}
-      .mission-hud__cta:hover {background: rgba(59,130,246,0.18);}
+      .mission-hud__actions {display: flex; gap: 10px; align-items: center;}
+      .mission-hud__action {display: inline-flex; align-items: center; gap: 8px; padding: 8px 14px; border-radius: 14px; border: 1px solid rgba(148,163,184,0.22);
+        background: rgba(15,23,42,0.35); color: rgba(226,232,240,0.78); font-size: 0.82rem; text-decoration: none; transition: all .3s ease; white-space: nowrap;}
+      .mission-hud__action:hover {border-color: rgba(96,165,250,0.45); color: #f8fafc;}
+      .mission-hud__action.is-current {border-color: rgba(96,165,250,0.78); background: linear-gradient(135deg, rgba(59,130,246,0.38), rgba(14,165,233,0.22)); color: #f8fafc;}
+      .mission-hud__meta {display: flex; align-items: center; gap: 12px;}
+      .mission-hud__settings {padding: 7px 12px; border-radius: 12px; border: 1px solid rgba(96,165,250,0.32); background: rgba(15,23,42,0.55);
+        color: #e2e8f0; font-size: 0.78rem; text-decoration: none; transition: all .3s ease; display: inline-flex; align-items: center; gap: 6px;}
+      .mission-hud__settings:hover {background: rgba(59,130,246,0.18);}
+      .mission-hud__details {margin: 0; position: relative;}
+      .mission-hud__details summary {list-style: none; cursor: pointer; display: inline-flex; align-items: center; gap: 6px; padding: 6px 10px; border-radius: 12px;
+        border: 1px solid rgba(96,165,250,0.22); background: rgba(15,23,42,0.42); color: rgba(226,232,240,0.82); font-size: 0.78rem; transition: all .3s ease;}
+      .mission-hud__details[open] summary {background: rgba(59,130,246,0.18); color: #f8fafc;}
+      .mission-hud__details summary::-webkit-details-marker {display: none;}
+      .mission-hud__details-content {position: absolute; right: 0; top: calc(100% + 10px); width: 260px; padding: 14px; border-radius: 14px; background: rgba(11,17,27,0.96);
+        border: 1px solid rgba(59,130,246,0.32); box-shadow: 0 18px 48px rgba(8,18,36,0.35); display: grid; gap: 8px;}
+      .mission-hud__details dl {margin: 0; display: grid; gap: 6px;}
+      .mission-hud__details dt {font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.04em; color: rgba(148,163,184,0.78);}
+      .mission-hud__details dd {margin: 0; font-size: 0.82rem; color: rgba(226,232,240,0.9);}
+      @media (max-width: 900px) {
+        .mission-hud__wrap {grid-template-columns: 1fr; gap: 14px;}
+        .mission-hud__logo {justify-content: space-between;}
+        .mission-hud__actions {flex-wrap: wrap;}
+        .mission-hud__meta {justify-content: space-between;}
+        .mission-hud__details-content {position: static; width: 100%;}
+      }
       .mission-breadcrumbs {margin-bottom: 1rem; font-size: 0.78rem; display: flex; gap: 6px; align-items: center; color: rgba(226,232,240,0.76);}
       .mission-breadcrumbs a {color: rgba(148,197,255,0.85); text-decoration: none; font-weight: 600;}
       .mission-breadcrumbs span {opacity: 0.65;}
     </style>
     """
 
-
-def _render_shortcuts_script(step_urls: dict[str, str]) -> None:
-    payload = json.dumps(step_urls)
-    escaped = payload.replace("\\", "\\\\").replace("'", "\\'")
-    html(
-        """
-        <div id="mission-hud-portal"></div>
-        <script>
-        (function() {
-          const initKey = '__missionHudHotkeys';
-          if (window[initKey]) return;
-          const urls = JSON.parse('%s');
-          function goTo(url) {
-            if (!url) return;
-            const base = window.parent?.location ?? window.location;
-            base.href = url;
-          }
-          function onKey(event) {
-            if (event.altKey || event.metaKey || event.ctrlKey) return;
-            const tag = (event.target?.tagName || '').toLowerCase();
-            if (['input','textarea','select'].includes(tag) || event.target?.isContentEditable) return;
-            const url = urls[event.code];
-            if (url) {
-              event.preventDefault();
-              goTo(url);
-            }
-          }
-          function animateSteps() {
-            const attempt = () => {
-              const host = window.parent?.document ?? document;
-              const chips = host.querySelectorAll('.mission-hud__step');
-              if (!chips.length) return;
-              if (!window.framerMotion || !window.framerMotion.animate) return;
-              chips.forEach((chip, idx) => {
-                window.framerMotion.animate(
-                  chip,
-                  { opacity: [0, 1], transform: ['translateY(-6px)', 'translateY(0px)'] },
-                  { duration: 0.6, delay: idx * 0.05, easing: 'easeOut' }
-                );
-              });
-            };
-            if (window.framerMotion) {
-              attempt();
-            } else {
-              const scriptId = 'framer-motion-umd';
-              if (!document.getElementById(scriptId)) {
-                const script = document.createElement('script');
-                script.id = scriptId;
-                script.src = 'https://unpkg.com/framer-motion@10.16.5/dist/framer-motion.umd.js';
-                script.onload = attempt;
-                document.head.appendChild(script);
-              }
-            }
-          }
-          window.addEventListener('keydown', onKey, true);
-          const observer = new MutationObserver(animateSteps);
-          observer.observe(document.body, { childList: true, subtree: true });
-          animateSteps();
-          window[initKey] = true;
-        })();
-        </script>
-        """
-        % escaped,
-        height=0,
-    )
 
 
 def render_mission_hud() -> None:
@@ -177,73 +125,73 @@ def render_mission_hud() -> None:
     else:
         st.session_state[_HUD_STATE_KEY] = 1
 
+    if not MISSION_STEPS:
+        return
+
     metadata = _model_metadata()
     active_step = _step_from_key(st.session_state.get("mission_active_step"))
 
-    progress_index = 0
-    steps_markup = []
-    for idx, step in enumerate(MISSION_STEPS, start=1):
-        url = _page_url(step.page)
-        is_active = active_step.key == step.key if active_step else False
-        if is_active:
-            progress_index = idx
-        class_attr = "is-active" if is_active else ""
-        steps_markup.append(
-            (
-                f"<a class='mission-hud__step {class_attr}' href='{url}' title='{step.description}'>"
-                f"<span>{step.icon}</span><strong>{idx} · {step.label}</strong>"
-                "</a>"
-            )
-        )
-
-    progress = (progress_index / len(MISSION_STEPS)) if progress_index else 0.0
-
-    next_step = None
-    prev_step = None
     if active_step:
-        current_idx = MISSION_STEPS.index(active_step)
-        if current_idx + 1 < len(MISSION_STEPS):
-            next_step = MISSION_STEPS[current_idx + 1]
-        if current_idx - 1 >= 0:
-            prev_step = MISSION_STEPS[current_idx - 1]
+        current_index = MISSION_STEPS.index(active_step)
+    else:
+        current_index = 0
+        active_step = MISSION_STEPS[0]
 
-    ctas: list[str] = []
-    if prev_step:
-        ctas.append(
-            f'<a class="mission-hud__cta" href="{_page_url(prev_step.page)}">⬅️ {prev_step.label}</a>'
+    visible_steps: list[tuple[MissionStep, bool]] = []
+    for offset in range(3):
+        idx = current_index + offset
+        if idx >= len(MISSION_STEPS):
+            break
+        step = MISSION_STEPS[idx]
+        visible_steps.append((step, offset == 0))
+
+    actions_markup = []
+    for step, is_current in visible_steps:
+        step_idx = MISSION_STEPS.index(step) + 1
+        label = f"<span>{step.icon}</span><strong>{step_idx} · {step.label}</strong>"
+        class_attr = "is-current" if is_current else ""
+        actions_markup.append(
+            f"<a class='mission-hud__action {class_attr}' href='{_page_url(step.page)}' title='{step.description}'>"
+            f"{label}"
+            "</a>"
         )
-    if next_step:
-        ctas.append(
-            f'<a class="mission-hud__cta" href="{_page_url(next_step.page)}">{next_step.label} ➡️</a>'
-        )
+
+    details_rows = """
+        <dl>
+          <div><dt>Estado</dt><dd>{status}</dd></div>
+          <div><dt>Modelo</dt><dd>{model}</dd></div>
+          <div><dt>Entrenado en</dt><dd>{trained_label}</dd></div>
+          <div><dt>Actualizado</dt><dd>{trained_at}</dd></div>
+          <div><dt>Incertidumbre</dt><dd>{uncertainty}</dd></div>
+        </dl>
+    """.format(
+        status=metadata["status"],
+        model=metadata["model_name"],
+        trained_label=metadata["trained_label"],
+        trained_at=metadata["trained_at"],
+        uncertainty=metadata["uncertainty"],
+    )
 
     st.markdown(
         f"""
-        <div class="mission-hud">
+        <div class="mission-hud mission-hud--compact">
           <div class="mission-hud__wrap">
             <div class="mission-hud__logo">🛰️ Mission HUD <span style="opacity:0.6;font-weight:500;">Rex-AI</span></div>
-            <div>
-              <div class="mission-hud__steps">{''.join(steps_markup)}</div>
-              <div class="mission-hud__progress"><div class="mission-hud__progress-bar" style="width:{progress*100:.1f}%;"></div></div>
-            </div>
-            <div class="mission-hud__status">
-              <div><strong>{metadata['status']}</strong> · {metadata['model_name']}</div>
-              <small>Entrenado: {metadata['trained_label']} · {metadata['trained_at']} · {metadata['uncertainty']}</small>
-              <div class="mission-hud__ctas">{''.join(ctas)}</div>
+            <div class="mission-hud__actions">{''.join(actions_markup)}</div>
+            <div class="mission-hud__meta">
+              <details class="mission-hud__details">
+                <summary>Detalles del modelo</summary>
+                <div class="mission-hud__details-content">
+                  {details_rows}
+                </div>
+              </details>
+              <a class="mission-hud__settings" href="{_page_url('Design_Lab')}">⚙️ Ajustes</a>
             </div>
           </div>
         </div>
         """,
         unsafe_allow_html=True,
     )
-
-    ordered_urls = {
-        ("Digit0" if idx == 10 else f"Digit{idx}"): _page_url(step.page)
-        for idx, step in enumerate(MISSION_STEPS, start=1)
-        if idx <= 10
-    }
-    _render_shortcuts_script(ordered_urls)
-
 
 def render_breadcrumbs(current_step_key: str, extra: Sequence[tuple[str, str]] | None = None) -> None:
     """Render breadcrumbs using mission steps and optional extra nodes."""

--- a/app/static/home.css
+++ b/app/static/home.css
@@ -1,6 +1,32 @@
 /* Home page minimal layout styles */
 
 @layer pages {
+  :root {
+    --mission-hud-stack: clamp(0.75rem, 0.55rem + 1vw, 1.35rem);
+  }
+
+  .mission-hud--compact {
+    margin-bottom: var(--mission-hud-stack);
+  }
+
+  .mission-hud--compact .mission-hud__actions {
+    gap: 0.75rem;
+  }
+
+  .mission-hud--compact .mission-hud__action strong {
+    font-weight: 600;
+  }
+
+  .mission-hud--compact .mission-hud__meta {
+    gap: 0.85rem;
+  }
+
+  @media (max-width: 60rem) {
+    .mission-hud--compact .mission-hud__meta {
+      flex-wrap: wrap;
+    }
+  }
+
   .main > div {
     padding-top: var(--home-stack-gap);
   }

--- a/app/static/layout.css
+++ b/app/static/layout.css
@@ -10,6 +10,12 @@
   --glow-3: rgba(45, 212, 191, 0.3);
   --shine-rotation: 18deg;
   --animation-duration: 680ms;
+  --mission-hud-radius: 18px;
+  --mission-hud-gap: 16px;
+  --mission-hud-stack: clamp(0.8rem, 1vw + 0.4rem, 1.35rem);
+  --mission-hud-bg: color-mix(in srgb, var(--surface-panel) 95%, transparent);
+  --mission-hud-border: color-mix(in srgb, var(--border-soft) 78%, transparent);
+  --mission-hud-shadow: 0 18px 38px rgba(8, 18, 36, 0.28);
 }
 
 .layout-stack {
@@ -465,4 +471,13 @@
   .depth-stack {
     padding: 1.25rem 1.35rem;
   }
+}
+
+.mission-hud--compact {
+  isolation: isolate;
+}
+
+.mission-hud--compact .mission-hud__details-content {
+  background: color-mix(in srgb, var(--surface-panel) 98%, transparent);
+  border: 1px solid color-mix(in srgb, var(--border-soft) 78%, transparent);
 }

--- a/tests/ui/test_navigation_hud.py
+++ b/tests/ui/test_navigation_hud.py
@@ -1,0 +1,36 @@
+"""Regression tests for the mission HUD navigation bar."""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("streamlit")
+
+from pytest_streamlit import StreamlitRunner
+
+
+def _hud_demo_app() -> None:
+    from app.modules import navigation
+
+    navigation.set_active_step("generator")
+    navigation.render_mission_hud()
+
+
+
+def test_mission_hud_limits_actions() -> None:
+    """The compact HUD should never expose more than three actions."""
+
+    runner = StreamlitRunner(_hud_demo_app)
+    app = runner.run()
+
+    hud_markup = [
+        body
+        for body in (
+            getattr(block, "body", "") for block in getattr(app, "markdown", [])
+        )
+        if isinstance(body, str) and '<div class="mission-hud' in body
+    ]
+
+    assert hud_markup, "Mission HUD markup was not rendered"
+    assert hud_markup[0].count("<a class='mission-hud__action") <= 3
+    assert "Ajustes" in hud_markup[0]


### PR DESCRIPTION
## Summary
- redesign the mission HUD to focus on the active step, show two upcoming steps, and surface model metadata inside a collapsible card with a settings link
- tune shared home and layout styles to support the compact HUD spacing and overlays
- add a UI regression test to ensure the navigation HUD never exposes more than three actionable links

## Testing
- pytest tests/ui/test_navigation_hud.py

------
https://chatgpt.com/codex/tasks/task_e_68dc86a43bf08331ac28f291faa56c2b