### PR TITLE
Refactor generator hero and controls

### DIFF
--- a/app/static/layout.css
+++ b/app/static/layout.css
@@ -131,30 +131,12 @@
 
 .layout-grid::before,
 .layout-grid::after {
-  content: "";
-  position: absolute;
-  inset: 0;
-  pointer-events: none;
-  opacity: 0;
-  transition: opacity 420ms ease;
+  content: none;
 }
 
-.layout-grid:hover::before {
-  opacity: 0.25;
-  background: radial-gradient(
-    circle at 16% 8%,
-    rgba(96, 165, 250, 0.18),
-    transparent 55%
-  );
-}
-
+.layout-grid:hover::before,
 .layout-grid:hover::after {
-  opacity: 0.18;
-  background: radial-gradient(
-    circle at 84% 92%,
-    rgba(45, 212, 191, 0.22),
-    transparent 58%
-  );
+  opacity: 0;
 }
 
 .layout-grid > .side-panel,
@@ -173,8 +155,8 @@
 }
 
 .depth-stack {
-  background: linear-gradient(160deg, rgba(15, 20, 30, 0.88), rgba(15, 20, 30, 0.65));
-  border: 1px solid rgba(148, 163, 184, 0.26);
+  background: color-mix(in srgb, var(--surface-panel) 94%, transparent);
+  border: 1px solid color-mix(in srgb, var(--border-soft) 80%, transparent);
   padding: 1.6rem;
   box-shadow: var(--panel-shadow-soft);
   backdrop-filter: blur(12px);
@@ -183,33 +165,7 @@
 
 .depth-stack::before,
 .depth-stack::after {
-  content: "";
-  position: absolute;
-  inset: 0;
-  z-index: 0;
-  pointer-events: none;
-  transition: transform 960ms cubic-bezier(0.22, 1, 0.36, 1),
-    opacity 680ms ease;
-}
-
-.depth-stack::before {
-  background: radial-gradient(120% 120% at 12% 12%, rgba(96, 165, 250, 0.18), transparent);
-  transform: translate3d(-16px, -18px, 0) scale(1.08);
-  opacity: 0.65;
-}
-
-.depth-stack::after {
-  background: radial-gradient(110% 110% at 90% 90%, rgba(45, 212, 191, 0.18), transparent);
-  transform: translate3d(12px, 18px, 0) scale(1.04);
-  opacity: 0.45;
-}
-
-.depth-stack:hover::before {
-  transform: translate3d(-6px, -8px, 0) scale(1.02);
-}
-
-.depth-stack:hover::after {
-  transform: translate3d(6px, 12px, 0) scale(1.01);
+  content: none;
 }
 
 .depth-stack > * {
@@ -227,42 +183,7 @@
 .layer-shadow::before,
 .layer-shadow::after,
 .layer-glow::after {
-  content: "";
-  position: absolute;
-  inset: -18%;
-  pointer-events: none;
-  z-index: -1;
-  filter: blur(28px);
-  opacity: 0.55;
-  transform: translate3d(0, 0, 0) scale(1.12);
-  transition: opacity 480ms ease, transform 680ms cubic-bezier(0.22, 1, 0.36, 1);
-}
-
-.layer-glow::before {
-  background: conic-gradient(from var(--shine-rotation), var(--glow-1), var(--glow-2), transparent 70%);
-}
-
-.layer-glow::after {
-  background: conic-gradient(from calc(var(--shine-rotation) + 140deg), var(--glow-3), transparent 60%);
-}
-
-.layer-shadow::before {
-  background: radial-gradient(circle at 30% 30%, rgba(15, 23, 42, 0.5), transparent 65%);
-  filter: blur(38px);
-}
-
-.layer-shadow::after {
-  background: radial-gradient(circle at 70% 70%, rgba(15, 23, 42, 0.48), transparent 70%);
-  filter: blur(44px);
-  opacity: 0.65;
-}
-
-.layer-glow:hover::before,
-.layer-glow:hover::after,
-.layer-shadow:hover::before,
-.layer-shadow:hover::after {
-  opacity: 0.85;
-  transform: translate3d(0, -4px, 0) scale(1.18);
+  content: none;
 }
 
 .fade-in {
@@ -354,27 +275,16 @@
   border-radius: 26px;
   padding: 2.1rem 2.2rem;
   border: 1px solid rgba(59, 130, 246, 0.32);
-  background: linear-gradient(135deg, rgba(59, 130, 246, 0.2), rgba(14, 165, 233, 0.12));
+  background: color-mix(in srgb, var(--surface-panel) 92%, transparent);
   overflow: hidden;
 }
 
 .hero-gen::before,
 .hero-res::before {
-  content: "";
-  position: absolute;
-  inset: -40% 20% 10% -30%;
-  background: radial-gradient(circle at 20% 20%, rgba(14, 165, 233, 0.35), transparent 55%);
-  filter: blur(40px);
-  opacity: 0.55;
-  transform: translate3d(0, 12px, 0);
-  transition: opacity 520ms ease, transform 680ms ease;
+  content: none;
 }
 
-.hero-gen:hover::before,
-.hero-res:hover::before {
-  opacity: 0.82;
-  transform: translate3d(0, 0, 0);
-}
+
 
 .hero-gen p,
 .hero-res p {

--- a/tests/ui/test_generator_layout.py
+++ b/tests/ui/test_generator_layout.py
@@ -1,0 +1,11 @@
+from pathlib import Path
+
+
+def test_generator_layout_copy() -> None:
+    """Smoke test that ensures the generator page uses the simplified layout."""
+    content = Path("app/pages/3_Generator.py").read_text(encoding="utf-8")
+
+    assert "st.header(\"Generador asistido por IA\")" in content
+    assert "Generar lote" in content
+    assert "control.expander(\"Opciones avanzadas\")" in content
+    assert "TeslaHero" not in content


### PR DESCRIPTION
## Summary
- replace the generator hero with a simple header and badge group, and surface the active target inside a dedicated side card
- regroup the main sliders in the control panel, move the seed input into an expander, and update the CTA copy to “Generar lote”
- remove custom gradient effects from `layout.css` and add a smoke test that guards the simplified layout copy

## Testing
- pytest tests/ui/test_generator_layout.py

------
https://chatgpt.com/codex/tasks/task_e_68dc86af7bc08331aba97e442a2b8ceb