### PR TITLE
Add minimal UX copy guidance and align app text

### DIFF
--- a/app/Home.py
+++ b/app/Home.py
@@ -90,63 +90,63 @@ mission_stages = [
         key="inventory",
         order=1,
         name="Inventario",
-        hero_headline="Calibrá el inventario",
-        hero_copy="Normalizá residuos, detectá flags EVA y estructuras multi-layer.",
+        hero_headline="Prepará el inventario",
+        hero_copy="Normalizá residuos y registrá flags EVA o multilayer.",
         card_body=(
-            "Normalizá residuos, marcá flags (multilayer, EVA, nitrilo) y trabajá sobre "
-            "<code>data/waste_inventory_sample.csv</code> o tu CSV limpio."
+            "Normalizá residuos en <code>data/waste_inventory_sample.csv</code> o en tu CSV y "
+            "registrá flags EVA, multilayer o nitrilo."
         ),
         compact_card_body=(
-            "Normalizá residuos y flags EVA/multilayer sobre <code>data/waste_inventory_sample.csv</code>."
+            "Normalizá residuos y flags EVA o multilayer en <code>data/waste_inventory_sample.csv</code>."
         ),
         icon="🧱",
         timeline_label="Inventario en vivo",
-        timeline_description="Ingerí CSV NASA, normalizá unidades y marca riesgos EVA desde la cabina.",
-        footer="Dataset NASA + crew flags",
+        timeline_description="Cargá CSV NASA, normalizá unidades y marcá riesgos EVA.",
+        footer="Dataset NASA y flags de crew",
     ),
     HeroFlowStage(
         key="target",
         order=2,
         name="Target",
-        hero_headline="Seleccioná objetivo",
-        hero_copy="Define límites de agua, energía y logística con presets marcianos.",
+        hero_headline="Definí el objetivo",
+        hero_copy="Configurá límites de agua, energía y crew-time con presets marcianos.",
         card_body=(
-            "Elegí producto final, límites de agua/energía y presets marcianos (container, utensil, tool, interior)."
+            "Elegí producto final, límites de agua y energía y presets marcianos (container, utensil, tool, interior)."
         ),
         compact_card_body="Elegí producto y límites con presets marcianos certificados.",
         icon="🎯",
         timeline_label="Target marciano",
-        timeline_description="Seleccioná producto final, límites de agua y energía, o usa presets homologados.",
-        footer="Presets o límites manuales",
+        timeline_description="Seleccioná producto, límites de agua y energía o usá presets homologados.",
+        footer="Presets y límites manuales",
     ),
     HeroFlowStage(
         key="generator",
         order=3,
         name="Generador",
-        hero_headline="Generá y valida",
-        hero_copy="Rex-AI mezcla, explica contribuciones y exporta procesos listos para la tripulación.",
+        hero_headline="Generá y validá",
+        hero_copy="Combiná residuos, compará IA vs heurística y verificá contribuciones.",
         card_body=(
-            "Rex-AI mezcla ítems, compara heurística vs modelo y explica cada contribución en vivo."
+            "Rex-AI mezcla ítems, contrasta heurística con modelo y detalla cada contribución en vivo."
         ),
-        compact_card_body="Mezclá ítems, compará heurística vs IA y revisá contribuciones al instante.",
+        compact_card_body="Mezclá ítems, compará IA vs heurística y revisá contribuciones al instante.",
         icon="🤖",
         timeline_label="Generador IA",
-        timeline_description="Explorá mezclas óptimas, revisá contribuciones y bandas de confianza en segundos.",
-        footer="ML + heurística cooperativa",
+        timeline_description="Explorá mezclas, revisá contribuciones y bandas de confianza en segundos.",
+        footer="ML y heurística cooperativa",
     ),
     HeroFlowStage(
         key="results",
         order=4,
         name="Resultados",
         hero_headline="Reportá y exportá",
-        hero_copy="Trade-offs, confianza 95% y comparativa heurística listos para ingeniería.",
+        hero_copy="Compartí trade-offs, confianza 95% y comparativas para ingeniería.",
         card_body=(
-            "Trade-offs, bandas 95%, comparación heurística vs IA y export Sankey/feedback listos para ingeniería."
+            "Trade-offs, bandas 95%, comparación heurística vs IA y export de Sankey o feedback listos para ingeniería."
         ),
-        compact_card_body="Revisá trade-offs, bandas 95% y export Sankey/feedback final.",
+        compact_card_body="Revisá trade-offs, bandas 95% y exportá Sankey o feedback final.",
         icon="📊",
         timeline_label="Resultados y export",
-        timeline_description="Compará heurísticas vs IA, exportá recetas y registra feedback para retraining.",
+        timeline_description="Compará heurística e IA, exportá recetas y registrá feedback para retraining.",
         footer="Listo para experimentos",
     ),
 ]
@@ -198,11 +198,11 @@ mission_metrics = [
 hero_col, metrics_col = st.columns([2.8, 1.2], gap="large")
 with hero_col:
     TeslaHero(
-        title="Rex-AI orquesta el reciclaje orbital y marciano",
+        title="Rex-AI coordina el reciclaje orbital y marciano",
         subtitle=(
-            "Un loop autónomo que mezcla regolito MGS-1, polímeros EVA y residuos de carga "
-            "para fabricar piezas listas para misión. El copiloto gestiona riesgos, "
-            "energía y trazabilidad sin perder contexto."
+            "Automatiza mezclas con regolito MGS-1, polímeros EVA y residuos de carga "
+            "para producir piezas listas para misión. Gestiona riesgos, energía y trazabilidad "
+            "en una sola vista."
         ),
         chips=[
             {"label": "RandomForest multisalida", "tone": "accent"},
@@ -243,14 +243,14 @@ mission_board_payload = [
     {
         "key": "target",
         "title": "Target",
-        "description": "Define objetivo, límites de agua/energía y presets marcianos.",
+        "description": "Definí objetivo, límites de agua y energía y presets marcianos.",
         "href": "./?page=2_Target_Designer",
         "icon": "🎯",
     },
     {
         "key": "generator",
         "title": "Generador",
-        "description": "Compara recetas IA vs heurística y valida contribuciones.",
+        "description": "Compará recetas IA y heurística y validá contribuciones.",
         "href": "./?page=3_Generator",
         "icon": "🤖",
     },
@@ -304,7 +304,7 @@ st.markdown(
         <span class="home-section__icon">🧪</span>
         <h2>Laboratorio profundo</h2>
       </div>
-      <p class="home-section__lead">Radiografiamos el inventario NASA, destacamos masas críticas y exponemos hipótesis de proceso en paneles compactos.</p>
+      <p class="home-section__lead">Analizamos el inventario NASA, destacamos masas críticas y mostramos hipótesis de proceso en paneles compactos.</p>
     </section>
     """,
     unsafe_allow_html=True,
@@ -396,7 +396,7 @@ if info_cards:
         unsafe_allow_html=True,
     )
 # ──────────── Ruta guiada ────────────
-st.markdown("### Ruta de misión (guided flow)")
+st.markdown("### Ruta de misión")
 
 demo_steps = timeline_milestones
 active_demo_step = guided_demo(steps=demo_steps, step_duration=6.5)
@@ -426,5 +426,5 @@ MetricGalaxy(
 
 st.info(
     "Usá el **Mission HUD** superior para saltar entre pasos o presioná las teclas `1-9` "
-    "para navegar más rápido por el flujo guiado."
+    "para navegar rápido por el flujo guiado."
 )

--- a/app/pages/3_Generator.py
+++ b/app/pages/3_Generator.py
@@ -72,7 +72,7 @@ def _format_label_summary(summary: dict[str, dict[str, float]] | None) -> str:
     return " · ".join(parts)
 
 # ----------------------------- Encabezado -----------------------------
-st.header("Generador asistido por IA")
+st.header("Generador IA")
 badge_group(
     (
         "RandomForest + XGBoost (alternativo)",
@@ -113,7 +113,7 @@ button_error = st.session_state.get(generator_error_key)
 with layout_block("layout-grid layout-grid--dual layout-grid--flow", parent=None) as grid:
     with layout_stack(parent=grid) as left_column:
         with layout_block("side-panel layer-shadow fade-in", parent=left_column) as control:
-            control.markdown("### 🎛️ Configuración")
+            control.markdown("### 🎛️ Configurar lote")
             stored_mode = st.session_state.get("prediction_mode", "Modo Rex-AI (ML)")
             mode = control.radio(
                 "Motor de predicción",
@@ -124,7 +124,7 @@ with layout_block("layout-grid layout-grid--dual layout-grid--flow", parent=None
             st.session_state["prediction_mode"] = mode
             use_ml = mode == "Modo Rex-AI (ML)"
 
-            control.markdown("#### Parámetros principales")
+            control.markdown("#### Ajustar parámetros")
             col_iters, col_recipes = control.columns(2)
             opt_evals = col_iters.slider(
                 "Iteraciones (Ax/BoTorch)",
@@ -152,7 +152,7 @@ with layout_block("layout-grid layout-grid--dual layout-grid--flow", parent=None
 
             crew_low = target.get("crew_time_low", False)
             control.caption(
-                "Los resultados privilegian %s"
+                "Los resultados priorizan %s"
                 % ("tiempo de tripulación" if crew_low else "un balance general")
             )
 
@@ -184,7 +184,7 @@ with layout_block("layout-grid layout-grid--dual layout-grid--flow", parent=None
             if button_error and button_state_now == "error":
                 control.error(button_error)
             elif button_state_now == "success":
-                control.caption("✅ Última corrida lista abajo. Volvé a ejecutar si cambias parámetros.")
+                control.caption("✅ Última corrida disponible abajo. Volvé a ejecutar si cambiás parámetros.")
             if not use_ml:
                 control.info("Modo heurístico activo: las métricas se basan en reglas físicas y no en ML.")
 
@@ -204,7 +204,7 @@ with layout_block("layout-grid layout-grid--dual layout-grid--flow", parent=None
                     control.dataframe(preview_df, hide_index=True, use_container_width=True)
     with layout_stack(parent=grid) as right_column:
         with layout_block("side-panel layer-shadow fade-in", parent=right_column) as target_card:
-            target_card.markdown("### 🎯 Objetivo activo")
+            target_card.markdown("### 🎯 Objetivo")
             target_card.markdown(f"**{target.get('name', '—')}**")
             scenario_label = target.get("scenario") or "Escenario general"
             target_card.caption(f"Escenario: {scenario_label}")
@@ -230,7 +230,7 @@ with layout_block("layout-grid layout-grid--dual layout-grid--flow", parent=None
                 target_card.dataframe(summary_df, hide_index=True, use_container_width=True)
 
         with layout_block("depth-stack layer-shadow fade-in-delayed", parent=right_column) as ai_panel:
-            ai_panel.markdown("### 🧠 Modelo Rex-AI")
+            ai_panel.markdown("### 🧠 Modelo IA")
             model_registry = get_model_registry()
             trained_at = model_registry.metadata.get("trained_at", "—")
             n_samples = model_registry.metadata.get("n_samples", "—")
@@ -309,16 +309,16 @@ history_df = st.session_state.get("optimizer_history", pd.DataFrame())
 if not cands:
     st.info(
         "Todavía no hay candidatos. Configurá los controles y presioná **Generar lote**. "
-        "Asegurate de que el inventario tenga pouches, espumas, EVA/CTB, textiles o nitrilo; "
-        "y que el catálogo incluya P02/P03/P04."
+        "Verificá que el inventario incluya pouches, espumas, EVA/CTB, textiles o nitrilo y "
+        "que el catálogo contenga P02, P03 o P04."
     )
-    with st.expander("¿Qué hace el generador (en criollo)?", expanded=False):
+    with st.expander("¿Cómo funciona el generador?", expanded=False):
         st.markdown(
-            "- **Mira tus residuos** (enfocado en los problemáticos de NASA).\n"
-            "- **Elige un proceso** coherente (laminar, sinter con regolito, reconfigurar CTB, etc.).\n"
-            "- **Predice** propiedades y recursos de la receta.\n"
+            "- **Revisa residuos** con foco en los problemáticos de NASA.\n"
+            "- **Elige un proceso** consistente (laminar, sinter con regolito, reconfigurar CTB).\n"
+            "- **Predice** propiedades y recursos de cada receta.\n"
             "- **Puntúa** balanceando objetivos y costos.\n"
-            "- **Muestra trazabilidad** para ver qué basura se valorizó."
+            "- **Muestra trazabilidad** para ver qué residuos se valorizaron."
         )
     st.stop()
 
@@ -327,8 +327,8 @@ if isinstance(history_df, pd.DataFrame) and not history_df.empty:
     scene = ConvergenceScene(
         history_df,
         subtitle=(
-            "Pistas visuales sobre cómo evoluciona el frente Pareto tras cada iteración "
-            "(pasá el cursor para leer hipervolumen, dominancia y scores)."
+            "Visualizá cómo evoluciona el frente Pareto tras cada iteración. Pasá el cursor "
+            "para ver hipervolumen, dominancia y scores."
         ),
     )
     scene.render(st)
@@ -356,8 +356,8 @@ for idx, cand in enumerate(cands, start=1):
     )
 
 if summary_rows:
-    st.subheader("Ranking multiobjetivo")
-    st.caption("Ordenado por score total, con sellado y riesgo resumidos.")
+    st.subheader("Ranking de candidatos")
+    st.caption("Ordenado por score total con sellado y riesgo resumidos.")
     cockpit = RankingCockpit(
         entries=summary_rows,
         metric_specs=[
@@ -378,8 +378,8 @@ if summary_rows:
 # ----------------------------- Showroom de candidatos -----------------------------
 st.subheader("Resultados del generador")
 st.caption(
-    "Explorá cada receta como card 3D con tabs de propiedades, recursos y trazabilidad. "
-    "Ajustá el timeline lateral para priorizar rigidez o agua y filtrar rápidamente."
+    "Explorá cada receta con tabs de propiedades, recursos y trazabilidad. "
+    "Ajustá el timeline lateral para priorizar rigidez o agua y filtrar rápido."
 )
 
 filtered_cands = render_candidate_showroom(cands, target)
@@ -575,25 +575,25 @@ for i, c in enumerate(cands):
             st.session_state["selected"] = {"data": c, "safety": badge}
             st.success("Opción seleccionada. Abrí **4) Resultados**, **5) Comparar & Explicar** o **6) Pareto & Export**.")
 
-# ----------------------------- Explicación en criollo (popover global) -----------------------------
+# ----------------------------- Explicación rápida (popover global) -----------------------------
 top = filtered_cands[0] if filtered_cands else (cands[0] if cands else None)
-pop = st.popover("🧠 ¿Por qué estas recetas pintan bien? (explicación en criollo)")
+pop = st.popover("🧠 ¿Por qué destacamos estas recetas?")
 with pop:
     bullets = []
-    bullets.append("• Sumamos puntos si **rigidez/estanqueidad** se acercan a lo que pediste.")
-    bullets.append("• Restamos si se pasa en **agua/energía/tiempo** de la tripulación.")
+    bullets.append("• Sumamos puntos cuando **rigidez** y **estanqueidad** se acercan al objetivo.")
+    bullets.append("• Restamos si supera límites de **agua**, **energía** o **tiempo de crew**.")
     if top:
         cats = " ".join(map(str, top.get("source_categories", []))).lower()
         flg = " ".join(map(str, top.get("source_flags", []))).lower()
         if any(k in cats or k in flg for k in ["pouches", "multilayer", "foam", "eva", "ctb", "nitrile", "wipe"]):
-            bullets.append("• Bonus porque priorizamos **basura problemática** (la que más molesta en la base).")
+            bullets.append("• Priorizamos residuos problemáticos (pouches, EVA, multilayer, nitrilo, wipes).")
         if top.get("regolith_pct", 0) > 0:
-            bullets.append("• Usa **MGS-1** (regolito) como carga mineral → ISRU: menos dependencia de la Tierra.")
+            bullets.append("• Valoramos **MGS-1** como carga mineral para ISRU y menos dependencia de la Tierra.")
     st.markdown("\n".join(bullets))
 
 # ----------------------------- Glosario -----------------------------
 micro_divider()
-with st.expander("📚 Glosario ultra rápido", expanded=False):
+with st.expander("📚 Glosario rápido", expanded=False):
     st.markdown(
         "- **ISRU**: *In-Situ Resource Utilization*. Usar recursos del lugar (en Marte, el **regolito** MGS-1).\n"
         "- **P02 – Press & Heat Lamination**: “plancha” y “fusiona” multicapa para dar forma.\n"
@@ -601,4 +601,4 @@ with st.expander("📚 Glosario ultra rápido", expanded=False):
         "- **P04 – CTB Reconfig**: reusar/transformar bolsas EVA/CTB con herrajes.\n"
         "- **Score**: qué tanto ‘cierra’ la opción según objetivo y límites de recursos/tiempo."
     )
-st.info("Tip: generá varias opciones y pasá a **4) Resultados**, **5) Comparar** y **6) Pareto & Export** para cerrar tu plan.")
+st.info("Generá varias opciones y pasá a **4) Resultados**, **5) Comparar** y **6) Pareto & Export** para cerrar tu plan.")

--- a/docs/ui-components.md
+++ b/docs/ui-components.md
@@ -2,6 +2,8 @@
 
 La librería `app.modules.luxe_components` concentra los bloques visuales premium que usamos en la demo de Rex-AI. Cada componente inyecta automáticamente estilos (parallax, glassmorphism, brillo dinámico) y expone parámetros declarativos para adaptar el branding sin duplicar CSS.
 
+> **Copy minimalista**: cuando documentes o agregues componentes, alineá los textos con la [Guía de copy minimalista](./ux-copy-minimal.md). Usá títulos cortos, verbos de acción y evita metáforas para mantener una narrativa consistente en toda la interfaz.
+
 ## Componentes disponibles
 
 ### `TeslaHero`

--- a/docs/ux-copy-minimal.md
+++ b/docs/ux-copy-minimal.md
@@ -1,0 +1,33 @@
+# Guía de copy minimalista
+
+## Principios de tono
+- Escribí en forma directa y concreta. Cada frase debe indicar la acción o el dato clave sin rodeos.
+- Evitá superlativos y exageraciones. Preferí cifras o hechos verificables.
+- Usá verbos de acción en títulos y botones ("Configurá", "Exportá", "Revisá").
+- Optá por títulos cortos (máx. 4 palabras). Si necesitás contexto adicional, agregalo en un subtítulo o caption.
+- No uses metáforas ni analogías espaciales; describí lo que ocurre en la interfaz.
+- Mantené la voz en segunda persona singular (vos) para ser consistente con el resto del producto.
+
+## Plantillas sugeridas
+- **Título de sección:** `Verbo + objeto directo` (ej.: `Analizá residuos`, `Generá lote`).
+- **Subtítulo o lead:** `Contexto breve + resultado` (ej.: `Analizamos el inventario NASA y señalamos masas críticas`).
+- **Botón principal:** `Verbo de acción en infinitivo o imperativo` (ej.: `Generar lote`, `Exportar reporte`).
+- **Mensajes de estado:** `Verbo + estado actual` (ej.: `Procesando lote`, `Resultados listos`).
+- **Avisos informativos:** `Acción recomendada + condición` (ej.: `Cargá el inventario antes de generar recetas`).
+
+## Ejemplos antes / después
+### Home (`app/Home.py`)
+- **Antes:** "Rex-AI orquesta el reciclaje orbital y marciano".
+- **Después:** "Rex-AI coordina el reciclaje orbital y marciano" (sustituye la metáfora por un verbo directo).
+
+- **Antes:** "Radiografiamos el inventario NASA, destacamos masas críticas...".
+- **Después:** "Analizamos el inventario NASA, destacamos masas críticas..." (elimina la metáfora médica y mantiene la acción).
+
+### Generador (`app/pages/3_Generator.py`)
+- **Antes:** "¿Qué hace el generador (en criollo)?".
+- **Después:** "¿Cómo funciona el generador?" (pregunta directa, sin modismos).
+
+- **Antes:** "Pistas visuales sobre cómo evoluciona el frente Pareto...".
+- **Después:** "Visualizá cómo evoluciona el frente Pareto..." (usa un verbo de acción y elimina lenguaje figurado).
+
+Seguí estas pautas al redactar nuevos componentes o revisar copy existente para conservar una narrativa minimalista y consistente.


### PR DESCRIPTION
## Summary
- add a UX copy minimalism guide with tone principles, templates, and before/after examples based on Home and Generator screens
- rewrite Home and Generator page strings to use direct action verbs, short titles, and literal language
- reference the new guide from the UI components README to enforce the shared narrative style

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc9d0ba3a483319d34dccac9c07a18