### PR TITLE
Add resource limit filters to candidate showroom

### DIFF
--- a/tests/ui/test_candidate_table.py
+++ b/tests/ui/test_candidate_table.py
@@ -60,6 +60,7 @@ def test_candidate_table_filters_and_feedback() -> None:
     filtered_html = "".join(_collect_markup(app))
     assert "Proceso Riesgoso" not in filtered_html
     assert "🛡️ Filtro: seguros" in filtered_html
+    assert "💧 Dentro de límite de agua" in filtered_html
 
     from app.modules import candidate_showroom as showroom
 


### PR DESCRIPTION
## Summary
- add optional energy, water, and crew limit controls to the candidate showroom UI and enforce them in the filtering pipeline
- extend badges and active filter summaries to highlight resource-compliant candidates
- update UI regression tests to cover the new water limit badge

## Testing
- `pytest tests/ui/test_candidate_table.py tests/ui/test_candidate_showroom.py`


------
https://chatgpt.com/codex/tasks/task_e_68dd6af82a008331aee32b9b14172334