### PR TITLE
Remove duplicate Streamlit page config calls

### DIFF
--- a/app/pages/8_Feedback_and_Impact.py
+++ b/app/pages/8_Feedback_and_Impact.py
@@ -9,8 +9,6 @@ st.set_page_config(page_title="Feedback & Impact", page_icon="📝", layout="wid
 from app.modules.navigation import render_breadcrumbs, set_active_step
 from app.modules.ui_blocks import load_theme
 
-st.set_page_config(page_title="Feedback & Impact", page_icon="📝", layout="wide")
-
 set_active_step("feedback")
 
 load_theme()

--- a/app/pages/9_Capacity_Simulator.py
+++ b/app/pages/9_Capacity_Simulator.py
@@ -9,8 +9,6 @@ st.set_page_config(page_title="Capacity Simulator", page_icon="🧮", layout="wi
 from app.modules.navigation import render_breadcrumbs, set_active_step
 from app.modules.ui_blocks import load_theme
 
-st.set_page_config(page_title="Capacity Simulator", page_icon="🧮", layout="wide")
-
 set_active_step("capacity")
 
 load_theme()


### PR DESCRIPTION
## Summary
- remove the redundant `st.set_page_config` invocation on the Feedback & Impact page
- drop the extra page configuration call from the Capacity Simulator page to ensure a single bootstrap configuration

## Testing
- pytest *(fails: existing candidate showroom table ordering test due to missing column_weights argument and external Altair deprecation warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68dd7051f66883318bc8db9a73cb988c