### PR TITLE
Add scenario badges and prioritization to inventory carousel

### DIFF
--- a/app/Home.py
+++ b/app/Home.py
@@ -54,6 +54,48 @@ def format_mass(value: float | int | None) -> str:
     return f"{value:.0f} kg"
 
 
+_SCENARIO_CONFIG: dict[str, dict[str, object]] = {
+    "residences": {
+        "label": "Residences",
+        "badge_tone": "residences",
+        "priority": 0,
+    },
+    "daring": {
+        "label": "Daring",
+        "badge_tone": "daring",
+        "priority": 1,
+    },
+}
+
+_CATEGORY_SCENARIO_MAP = {
+    "foam": "residences",
+    "foam packaging": "residences",
+    "packaging": "residences",
+    "food packaging": "residences",
+    "structural elements": "residences",
+    "eva waste": "daring",
+    "fabrics": "daring",
+    "gloves": "daring",
+}
+
+_SCENARIO_KEYWORDS = {
+    "residences": ("foam", "pack", "alumin", "struct"),
+    "daring": ("carbon", "mesh", "eva", "fabric", "glove"),
+}
+
+
+def map_category_to_scenario(category: str) -> str:
+    normalized = (category or "").strip().lower()
+    if not normalized:
+        return "residences"
+    if normalized in _CATEGORY_SCENARIO_MAP:
+        return _CATEGORY_SCENARIO_MAP[normalized]
+    for scenario, keywords in _SCENARIO_KEYWORDS.items():
+        if any(keyword in normalized for keyword in keywords):
+            return scenario
+    return "residences"
+
+
 def _tone_rank(tone: str | None) -> int:
     order = {"positive": 0, "info": 1, "warning": 2, "danger": 3}
     return order.get(tone or "", -1)
@@ -683,22 +725,51 @@ st.markdown(
 
 inventory_df = inventory_reference_df
 
-category_items = []
+category_items: list[CarouselItem] = []
 if inventory_df is not None and not inventory_df.empty:
+    total_mass = float(inventory_df["mass_kg"].sum() or 0)
     category_summary = (
         inventory_df.groupby("category")[["mass_kg", "volume_l"]]
         .sum()
         .sort_values("mass_kg", ascending=False)
         .head(6)
     )
+    category_cards: list[dict[str, object]] = []
     for category, row in category_summary.iterrows():
-        category_items.append(
-            CarouselItem(
-                title=category,
-                value=format_mass(row["mass_kg"]),
-                description=f"Volumen: {row['volume_l']:.0f} L",
-            )
+        scenario_key = map_category_to_scenario(category)
+        scenario_config = _SCENARIO_CONFIG.get(
+            scenario_key, _SCENARIO_CONFIG["residences"]
         )
+        mass_value = float(row["mass_kg"])
+        volume_value = float(row["volume_l"])
+        share = (mass_value / total_mass) if total_mass else 0.0
+        share_pct = share * 100
+        description_parts = [f"Volumen: {volume_value:.0f} L"]
+        if share_pct >= 1:
+            description_parts.append(f"{share_pct:.0f}% de la masa total")
+        elif share_pct > 0:
+            description_parts.append(f"{share_pct:.1f}% de la masa total")
+        category_cards.append(
+            {
+                "priority": int(scenario_config["priority"]),
+                "mass": mass_value,
+                "item": CarouselItem(
+                    title=category,
+                    value=format_mass(mass_value),
+                    description=" • ".join(description_parts),
+                    badge=str(scenario_config["label"]),
+                    badge_tone=str(scenario_config["badge_tone"]),
+                    highlight=share >= 0.2,
+                ),
+            }
+        )
+    category_items = [
+        entry["item"]
+        for entry in sorted(
+            category_cards,
+            key=lambda entry: (entry["priority"], -entry["mass"]),
+        )
+    ]
 
 if category_items:
     CarouselRail(

--- a/app/modules/luxe_components.py
+++ b/app/modules/luxe_components.py
@@ -1473,9 +1473,36 @@ _LUXE_COMPONENT_CSS = """
   gap: 0.4rem;
 }
 
+.luxe-carousel-card--highlight {
+  border-color: color-mix(in srgb, var(--accent) 55%, transparent);
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--accent) 30%, transparent);
+}
+
 .luxe-carousel-card h4 {
   margin: 0;
   font-size: 1.02rem;
+}
+
+.luxe-carousel-card__badge {
+  justify-self: start;
+  padding: 0.12rem 0.55rem;
+  border-radius: 999px;
+  font-size: 0.68rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  background: color-mix(in srgb, var(--border-soft) 70%, transparent);
+  color: color-mix(in srgb, var(--text-muted) 92%, transparent);
+}
+
+.luxe-carousel-card__badge--residences {
+  background: color-mix(in srgb, var(--accent) 38%, transparent);
+  color: color-mix(in srgb, var(--accent) 82%, white 18%);
+}
+
+.luxe-carousel-card__badge--daring {
+  background: color-mix(in srgb, var(--warning) 35%, transparent);
+  color: color-mix(in srgb, var(--warning) 78%, white 22%);
 }
 
 .luxe-carousel-card__value {
@@ -1492,6 +1519,10 @@ _LUXE_COMPONENT_CSS = """
 .luxe-carousel-card__icon {
   font-size: 1.4rem;
   opacity: 0.75;
+}
+
+.luxe-carousel-card--highlight .luxe-carousel-card__value {
+  color: color-mix(in srgb, var(--accent) 75%, var(--text-primary) 25%);
 }
 
 .luxe-action-deck {
@@ -4222,6 +4253,9 @@ class CarouselItem:
     value: str | None = None
     description: str | None = None
     icon: str | None = None
+    badge: str | None = None
+    badge_tone: str | None = None
+    highlight: bool = False
 
     def markup(self) -> str:
         icon_html = (
@@ -4239,8 +4273,22 @@ class CarouselItem:
             if self.description
             else ""
         )
+        badge_class = (
+            f" luxe-carousel-card__badge--{self.badge_tone}"
+            if self.badge and self.badge_tone
+            else ""
+        )
+        badge_html = (
+            f"<span class='luxe-carousel-card__badge{badge_class}'>{self.badge}</span>"
+            if self.badge
+            else ""
+        )
+        classes = ["luxe-carousel-card"]
+        if self.highlight:
+            classes.append("luxe-carousel-card--highlight")
         return (
-            "<div class='luxe-carousel-card'>"
+            f"<div class='{' '.join(classes)}'>"
+            f"{badge_html}"
             f"{icon_html}"
             f"<h4>{self.title}</h4>"
             f"{value_html}"


### PR DESCRIPTION
## Summary
- map inventory categories to mission scenarios and annotate carousel cards with scenario badges
- highlight mass share for critical categories and sort carousel by scenario priority
- style carousel cards with new badge and highlight treatments

## Testing
- pytest tests/ui/test_home_components.py

------
https://chatgpt.com/codex/tasks/task_e_68dd713fe180833192eb8bb8d8d46d96