### PR TITLE
Add scenario-specific presets and regolith guidance to feedback page

### DIFF
--- a/app/modules/impact.py
+++ b/app/modules/impact.py
@@ -16,7 +16,9 @@ except Exception:  # pragma: no cover - pyarrow is optional at runtime
     pa = None  # type: ignore[assignment]
     pq = None  # type: ignore[assignment]
 
-from .paths import LOGS_DIR
+from .paths import DATA_ROOT, LOGS_DIR
+
+DATA_DIR = DATA_ROOT
 
 
 @dataclass
@@ -173,7 +175,10 @@ def append_impact(entry: ImpactEntry) -> str:
 
 
 def append_feedback(entry: FeedbackEntry) -> str:
-    payload = _prepare_payload(asdict(entry))
+    entry_dict = asdict(entry)
+    if not entry_dict.get("scenario"):
+        entry_dict["scenario"] = "-"
+    payload = _prepare_payload(entry_dict)
     date_str = _entry_date(entry.ts_iso)
     _append_record(f"feedback_{date_str}.parquet", payload)
     return payload["run_id"]

--- a/tests/test_impact_logging.py
+++ b/tests/test_impact_logging.py
@@ -88,6 +88,8 @@ def test_feedback_logging_concatenates_daily(tmp_path, monkeypatch):
     assert len(files) == 2
     df0 = pd.read_parquet(files[0])
     assert "run_id" in df0.columns
+    assert "scenario" in df0.columns
+    assert df0.loc[0, "scenario"] == "moon"
     assert "extra_overall" in df0.columns
 
     loaded = impact.load_feedback_df()


### PR DESCRIPTION
## Summary
- add scenario-aware defaults and regolith-derived hints to the feedback capture interface
- surface MGS-1 TG/EGA observations and recommended checklists via the feedback sidebar
- ensure feedback logs always persist the scenario field and cover it with a regression test

## Testing
- pytest tests/test_impact_logging.py

------
https://chatgpt.com/codex/tasks/task_e_68dd713a70248331a238bce59616a352