### PR TITLE
Fix generator expander seed input handling

### DIFF
--- a/app/pages/3_Generator.py
+++ b/app/pages/3_Generator.py
@@ -616,9 +616,9 @@ with layout_block("layout-grid layout-grid--dual layout-grid--flow", parent=None
                 help="Cantidad de combinaciones candidatas por lote.",
             )
 
-            with control.expander("Opciones avanzadas") as advanced:
+            with control.expander("Opciones avanzadas"):
                 seed_default = st.session_state.get("generator_seed_input", "")
-                seed_input = advanced.text_input(
+                seed_input = control.text_input(
                     "Semilla (opcional)",
                     value=seed_default,
                     help="Ingresá un entero para repetir exactamente el mismo lote.",


### PR DESCRIPTION
## Summary
- update the generator advanced options expander to call the text input within the context manager
- continue persisting the seed value in `st.session_state["generator_seed_input"]`

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd75ee89648331b71c2f0e3ac24812