### PR TITLE
Fix mission HUD target CTA behaviour

### DIFF
--- a/app/modules/navigation.py
+++ b/app/modules/navigation.py
@@ -236,6 +236,7 @@ def render_mission_hud() -> None:
         )
 
     target_state = st.session_state.get("target", {})
+    has_target = bool(target_state)
 
     def _format_limit(value: object) -> str:
         if isinstance(value, (int, float)):
@@ -284,6 +285,13 @@ def render_mission_hud() -> None:
         uncertainty=metadata["uncertainty"],
     )
 
+    settings_cta = ""
+    if has_target:
+        settings_cta = (
+            f"<a class=\"mission-hud__settings\" href=\"{_page_url('2_Target_Designer')}\" "
+            "title=\"Editar target\">🎯 Editar target</a>"
+        )
+
     st.markdown(
         f"""
         <div class="mission-hud mission-hud--compact">
@@ -305,7 +313,7 @@ def render_mission_hud() -> None:
                   {details_rows}
                 </div>
               </details>
-              <a class="mission-hud__settings" href="{_page_url('Design_Lab')}">⚙️ Ajustes</a>
+              {settings_cta}
             </div>
           </div>
         </div>

--- a/tests/ui/test_navigation_hud.py
+++ b/tests/ui/test_navigation_hud.py
@@ -12,13 +12,36 @@ from pytest_streamlit import StreamlitRunner
 def _hud_demo_app() -> None:
     from app.modules import navigation
 
+    navigation.st.session_state["target"] = {
+        "scenario": "Demo",
+        "max_water_l": 120,
+    }
     navigation.set_active_step("generator")
     navigation.render_mission_hud()
 
 
 
-def test_mission_hud_limits_actions() -> None:
+def _fake_registry():  # noqa: D401
+    class _Registry:
+        ready = True
+        metadata = {
+            "model_name": "demo-regressor",
+            "trained_label": "Simulación",
+            "trained_at": "2024-01-01",
+        }
+
+        def uncertainty_label(self) -> str:  # noqa: D401
+            return "reportada"
+
+    return _Registry()
+
+
+def test_mission_hud_limits_actions(monkeypatch) -> None:
     """The compact HUD should never expose more than three actions."""
+
+    from app.modules import navigation
+
+    monkeypatch.setattr(navigation, "get_model_registry", _fake_registry)
 
     runner = StreamlitRunner(_hud_demo_app)
     app = runner.run()
@@ -33,4 +56,32 @@ def test_mission_hud_limits_actions() -> None:
 
     assert hud_markup, "Mission HUD markup was not rendered"
     assert hud_markup[0].count("<a class='mission-hud__action") <= 3
-    assert "Ajustes" in hud_markup[0]
+    assert "Editar target" in hud_markup[0]
+
+
+def test_mission_hud_hides_settings_without_target(monkeypatch) -> None:
+    """The target edit CTA should be hidden when session lacks objectives."""
+
+    from app.modules import navigation
+
+    monkeypatch.setattr(navigation, "get_model_registry", _fake_registry)
+
+    def _app_without_target() -> None:
+        from app.modules import navigation
+
+        navigation.set_active_step("generator")
+        navigation.render_mission_hud()
+
+    runner = StreamlitRunner(_app_without_target)
+    app = runner.run()
+
+    hud_markup = "".join(
+        body
+        for body in (
+            getattr(block, "body", "") for block in getattr(app, "markdown", [])
+        )
+        if isinstance(body, str) and '<div class="mission-hud' in body
+    )
+
+    assert hud_markup, "Mission HUD markup was not rendered"
+    assert "Editar target" not in hud_markup


### PR DESCRIPTION
## Summary
- point the mission HUD "Editar target" call-to-action to the target designer panel and hide it when no target is defined
- adjust the HUD regression tests to cover the new CTA behaviour and stub the model registry during the test run

## Testing
- pytest tests/ui/test_navigation_hud.py

------
https://chatgpt.com/codex/tasks/task_e_68dd7876b75483319428fbe876820794