### PR TITLE
Fix advanced generator expander scoping

### DIFF
--- a/app/pages/3_Generator.py
+++ b/app/pages/3_Generator.py
@@ -616,9 +616,9 @@ with layout_block("layout-grid layout-grid--dual layout-grid--flow", parent=None
                 help="Cantidad de combinaciones candidatas por lote.",
             )
 
-            with control.expander("Opciones avanzadas"):
+            with control.expander("Opciones avanzadas") as advanced:
                 seed_default = st.session_state.get("generator_seed_input", "")
-                seed_input = control.text_input(
+                seed_input = advanced.text_input(
                     "Semilla (opcional)",
                     value=seed_default,
                     help="Ingresá un entero para repetir exactamente el mismo lote.",


### PR DESCRIPTION
## Summary
- capture the advanced options expander container to avoid leaking widgets outside
- render the generator seed input via the expander container while preserving session state

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd7b6797308331b3be8b6c6267b7bf