### PR TITLE
Refresh mission HUD metadata after model updates

### DIFF
--- a/app/modules/model_training.py
+++ b/app/modules/model_training.py
@@ -1608,6 +1608,16 @@ def train_and_save(
         LEGACY_METADATA_PATH.write_text(payload, encoding="utf-8")
     except Exception:  # pragma: no cover - legacy path optional
         pass
+
+    try:
+        from app.modules.navigation import refresh_model_metadata
+    except Exception:  # pragma: no cover - navigation optional outside Streamlit
+        pass
+    else:
+        try:
+            refresh_model_metadata()
+        except Exception:  # pragma: no cover - cache refresh best-effort
+            LOGGER.debug("No se pudo refrescar metadata del HUD tras entrenamiento", exc_info=True)
     return metadata
 
 
@@ -1622,6 +1632,15 @@ def bootstrap_demo_model(*, seed: int | None = 21, n_samples: int = 64) -> Path:
         LEGACY_METADATA_PATH.write_text(payload, encoding="utf-8")
     except Exception:  # pragma: no cover - legacy path opcional
         pass
+    try:
+        from app.modules.navigation import refresh_model_metadata
+    except Exception:  # pragma: no cover - navigation optional outside Streamlit
+        pass
+    else:
+        try:
+            refresh_model_metadata()
+        except Exception:  # pragma: no cover - cache refresh best-effort
+            LOGGER.debug("No se pudo refrescar metadata del HUD tras bootstrap", exc_info=True)
     return PIPELINE_PATH
 
 


### PR DESCRIPTION
## Summary
- replace the Mission HUD metadata LRU cache with a session-state backed cache and add a refresh helper
- invoke `refresh_model_metadata()` after training/bootstrap flows to keep HUD data current
- add a unit test that exercises metadata refresh so `trained_at`/`uncertainty` updates appear without restarting Streamlit

## Testing
- pytest tests/ui/test_navigation_hud.py

------
https://chatgpt.com/codex/tasks/task_e_68dd7b6445188331bcc8f542305601a0