### PR TITLE
Use switch_page for playbook generator navigation

### DIFF
--- a/app/pages/3_Generator.py
+++ b/app/pages/3_Generator.py
@@ -40,7 +40,7 @@ load_theme()
 
 render_breadcrumbs("generator")
 
-_playbook_prefill_raw = st.session_state.get("_playbook_generator_filters")
+_playbook_prefill_raw = st.session_state.pop("_playbook_generator_filters", None)
 _playbook_prefilters: dict[str, object] | None = None
 _playbook_prefill_label: str | None = None
 if isinstance(_playbook_prefill_raw, dict):
@@ -531,7 +531,6 @@ target = st.session_state.get("target")
 playbook_filters_applied = False
 if _playbook_prefilters is not None and isinstance(target, dict):
     _apply_generator_prefilters(_playbook_prefilters, target)
-    st.session_state.pop("_playbook_generator_filters", None)
     playbook_filters_applied = True
 
 # ----------------------------- Encabezado -----------------------------

--- a/app/pages/7_Scenario_Playbooks.py
+++ b/app/pages/7_Scenario_Playbooks.py
@@ -198,8 +198,8 @@ with col_sel:
             "scenario": pb.name,
             "filters": filters_payload,
         }
-        st.experimental_set_query_params(page="3_Generator")
-        st.experimental_rerun()
+        st.session_state["mission_active_step"] = "generator"
+        st.switch_page("pages/3_Generator.py")
 
 # ======== Brief del Playbook + Estado de datos ========
 st.markdown("### 🧪 Brief del escenario")


### PR DESCRIPTION
## Summary
- navigate from Scenario Playbooks to the generator with `st.switch_page` and persist the mission step
- consume `_playbook_generator_filters` once in the generator to avoid repeated applications

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68dd7d432798833186735611b9a84e62