### PR TITLE
Remove redundant pyarrow import guard

### DIFF
--- a/app/modules/generator.py
+++ b/app/modules/generator.py
@@ -137,11 +137,6 @@ except Exception:  # pragma: no cover - pyarrow is expected in production
     pa = None  # type: ignore[assignment]
     pq = None  # type: ignore[assignment]
 
-try:
-    import pyarrow.parquet as pq
-except Exception:  # pragma: no cover - pyarrow is expected in production
-    pq = None  # type: ignore[assignment]
-
 from app.modules.execution import (
     DEFAULT_PARALLEL_THRESHOLD,
     ExecutionBackend,


### PR DESCRIPTION
## Summary
- remove the duplicate pyarrow.parquet try/except guard in the generator module so aliases are defined in one place

## Testing
- python -m compileall app/modules/generator.py

------
https://chatgpt.com/codex/tasks/task_e_68dd7d71bf74833197bfc35650ff997b