### PR TITLE
Remove direct logging_utils import in generator wrapper

### DIFF
--- a/app/modules/generator.py
+++ b/app/modules/generator.py
@@ -75,7 +75,6 @@ resolve_dataset_path = ds.resolve_dataset_path
 slugify = ds.slugify
 _load_regolith_vector = ds._load_regolith_vector
 from app.modules import logging_utils
-from app.modules.logging_utils import append_inference_log
 from app.modules.data_sources import (
     _CATEGORY_SYNONYMS,
     DATASETS_ROOT,
@@ -196,6 +195,7 @@ def append_inference_log(
 ) -> None:
     """Proxy :func:`logging_utils.append_inference_log` for backward compatibility."""
 
+    # Wrapper retained to preserve legacy imports during the refactor.
     logging_utils.append_inference_log(
         input_features=input_features,
         prediction=prediction,


### PR DESCRIPTION
## Summary
- drop the direct append_inference_log import from generator
- document the compatibility wrapper used to forward to logging_utils

## Testing
- pytest tests/test_generator.py::test_append_inference_log_reuses_daily_writer -q

------
https://chatgpt.com/codex/tasks/task_e_68dd7d7316e08331bb3be0c3f332b3f7