### PR TITLE
Documentar propuesta externa para flujo de experimentos

### DIFF
--- a/docs/experiments_logbook.md
+++ b/docs/experiments_logbook.md
@@ -1,26 +1,10 @@
 # Registro de experimentos físicos / simulador
 
-Para acompañar el esquema de feedback se define la convención de archivos
-`datasets/raw/experiments_YYYYMMDD.parquet`. Cada lote documenta:
+El flujo operativo para experimentos permanece en pausa hasta que el equipo de
+operaciones confirme su implementación. Toda la propuesta detallada se movió a
+[`docs/proposals/experiments_feedback_flow.md`](proposals/experiments_feedback_flow.md)
+para evaluar y ajustar fuera del plan activo.
 
-| Campo | Descripción |
-| --- | --- |
-| `experiment_id` | UUID o hash del ensayo (concordante con cuaderno físico). |
-| `recipe_id`, `process_id` | Claves que vinculan el ensayo con la receta generada. |
-| `environment` | `lab`, `iss_sim`, `analog_field`, etc. |
-| `operator_id` | Astronauta/técnico responsable del ensayo. |
-| `started_at`, `finished_at` | Timestamps ISO8601 para trazabilidad. |
-| `raw_measurements` | JSON con lecturas crudas (temperatura, presión, torque…). |
-| `verdict` | `pass`, `fail`, `inconclusive`. |
-| `next_actions` | Texto breve con follow-up (p.ej. repetir con ajuste). |
-
-## Flujo operativo
-
-1. Registrar cada corrida en el Parquet del día usando la tabla anterior.
-2. Al finalizar el turno, ejecutar `scripts/ingest_feedback.py` para promover las
-   corridas con mediciones consolidadas al dataset gold.
-3. Guardar los Parquet diarios en `data/logs/experiments/` para respaldos y
-   auditorías.
-
-Este registro asegura trazabilidad completa desde la planificación de la receta
-hasta las mediciones que alimentan el modelo.
+Mientras tanto, enfocarse en los procesos documentados en `feedback/README.md`
+y en el pipeline descrito en `docs/feedback_loop.md`, que continúan vigentes
+para incorporar mediciones validadas en la app.

--- a/docs/feedback_loop.md
+++ b/docs/feedback_loop.md
@@ -3,6 +3,12 @@
 Este documento describe el flujo operativo para cerrar el lazo entre la app,
 los ensayos físicos/simulador y el reentrenamiento incremental del modelo.
 
+> **Nota**: el flujo detallado para registrar experimentos permanece como
+> propuesta externa mientras el equipo confirma su implementación. Consultar
+> [`docs/proposals/experiments_feedback_flow.md`](proposals/experiments_feedback_flow.md)
+> para la versión pendiente y mantener este documento como referencia activa
+> para el feedback disponible.
+
 ## 1. Registro de feedback
 
 1. Los operadores exportan resultados de cada receta validada al archivo
@@ -27,6 +33,8 @@ El comando:
   `datasets/gold/labels.parquet`, preservando la última medición por
   `(recipe_id, process_id)`.
 * Añade una marca `ingested_at` para auditar cuándo se incorporó cada fila.
+* Crea el directorio de destino (`datasets/gold/` por defecto) si todavía no
+  existe.
 
 Para verificar el impacto sin escribir resultados usar `--dry-run`.
 
@@ -60,3 +68,5 @@ estrategias:
 
 Integrar las sugerencias en la UI o en un cuaderno de planificación permite
 concentrar ensayos en recetas que maximizan aprendizaje por etiqueta añadida.
+Cuando el flujo de experimentos se active, las corridas documentadas en la
+propuesta externa podrán alimentar este mismo circuito de realimentación.

--- a/docs/proposals/experiments_feedback_flow.md
+++ b/docs/proposals/experiments_feedback_flow.md
@@ -1,0 +1,55 @@
+# Propuesta externa — Flujo de experimentos y registro
+
+**Estado**: pendiente de confirmación del equipo de operaciones.
+
+Este documento consolida el flujo sugerido para capturar resultados de ensayos
+físicos o de simulador y preparar los datos para reentrenamientos del modelo.
+Permanece fuera del plan activo hasta que el equipo confirme que contará con los
+recursos para sostenerlo.
+
+## Objetivo
+
+Establecer una convención única para documentar experimentos y facilitar su
+ingesta en el dataset "gold". El diseño prioriza:
+
+* **Trazabilidad** entre receta, proceso y corrida ejecutada.
+* **Compatibilidad** con los esquemas existentes en `datasets/feedback_schema.yaml`.
+* **Reproducibilidad** de métricas y pesos aplicados durante el reentrenamiento.
+
+## Registro propuesto
+
+Mientras no exista un almacenamiento definitivo, se sugiere crear un directorio
+ad hoc en el entorno de trabajo (por ejemplo
+`datasets/raw/experiments_YYYYMMDD.parquet`) y guardar allí cada lote diario. Un
+archivo Parquet debe incluir:
+
+| Campo | Descripción |
+| --- | --- |
+| `experiment_id` | UUID o hash del ensayo (alineado con el cuaderno físico). |
+| `recipe_id`, `process_id` | Claves que vinculan el ensayo con la receta generada. |
+| `environment` | `lab`, `iss_sim`, `analog_field`, etc. |
+| `operator_id` | Astronauta/técnico responsable del ensayo. |
+| `started_at`, `finished_at` | Timestamps ISO8601 para trazabilidad. |
+| `raw_measurements` | JSON con lecturas crudas (temperatura, presión, torque…). |
+| `verdict` | `pass`, `fail`, `inconclusive`. |
+| `next_actions` | Texto breve con follow-up (p.ej. repetir con ajuste). |
+
+## Integración con pipelines
+
+Una vez confirmada la implementación, los pasos previstos son:
+
+1. Registrar cada corrida en el Parquet del día usando la tabla anterior.
+2. Ejecutar `scripts/ingest_feedback.py` para promover las corridas con
+   mediciones consolidadas al dataset gold (creando el directorio destino si
+   hiciera falta).
+3. Archivar los Parquet diarios en `data/logs/` o en el almacenamiento que se
+   defina para auditorías y respaldos.
+
+## Próximos pasos
+
+* Validar con operaciones si habrá personal para cargar y mantener estos
+  registros.
+* Ajustar los scripts y automatizaciones existentes según el almacenamiento que
+  seleccione el equipo.
+* Integrar la documentación aprobada en los manuales operativos una vez que el
+  flujo se ponga en marcha.


### PR DESCRIPTION
## Summary
- mover la guía de registro de experimentos a una propuesta externa pendiente de confirmación
- actualizar la documentación activa para señalar el estado y mantener coherencia con el pipeline de feedback

## Testing
- no se ejecutaron pruebas (cambios de documentación)


------
https://chatgpt.com/codex/tasks/task_e_68dd81c3f0648331b98827732c186c6f