### PR TITLE
Fix problematic flag calculation in inventory builder page

### DIFF
--- a/app/pages/1_Inventory_Builder.py
+++ b/app/pages/1_Inventory_Builder.py
@@ -75,7 +75,7 @@ def _build_editable_df(source: pd.DataFrame) -> pd.DataFrame:
             "flags": (source[flags_col].astype(str) if flags_col else ""),
         }
     )
-    editable["_problematic"] = editable.apply(_is_problematic_row, axis=1)
+    editable["_problematic"] = problematic_mask(editable)
     return editable
 
 


### PR DESCRIPTION
## Summary
- compute the `_problematic` column in the inventory builder using the shared `problematic_mask`

## Testing
- streamlit run app/Home.py --server.headless true --global.developmentMode=false

------
https://chatgpt.com/codex/tasks/task_e_68dd8e7634d883319d24c2a772bc46ef