### PR TITLE
Use shared problematic mask helper in io module

### DIFF
--- a/app/modules/io.py
+++ b/app/modules/io.py
@@ -12,6 +12,7 @@ import polars as pl
 from .generator import prepare_waste_frame
 from .data_sources import official_features_bundle
 from .paths import DATA_ROOT
+from .problematic import problematic_mask
 
 DATA_DIR = DATA_ROOT
 
@@ -135,19 +136,7 @@ def _load_waste_df_cached() -> pd.DataFrame:
             result[source_column] = values
 
     if "_problematic" not in result.columns:
-        flags_lower = result.get("flags", "").astype(str).str.lower()
-        category_lower = result.get("category", "").astype(str).str.lower()
-        material_lower = result.get("material", "").astype(str).str.lower()
-        problem_mask = (
-            category_lower.str.contains("pouches")
-            | category_lower.str.contains("foam")
-            | category_lower.str.contains("eva")
-            | category_lower.str.contains("glove")
-            | material_lower.str.contains("aluminum")
-        )
-        for tag in PROBLEM_TAGS.keys():
-            problem_mask = problem_mask | flags_lower.str.contains(tag)
-        result["_problematic"] = problem_mask
+        result["_problematic"] = problematic_mask(result)
 
     return result
 

--- a/tests/modules/test_io.py
+++ b/tests/modules/test_io.py
@@ -1,0 +1,22 @@
+"""Tests for the io module helpers."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from app.modules.io import load_waste_df
+from app.modules.problematic import problematic_mask
+
+
+def test_problematic_column_matches_helper() -> None:
+    df = load_waste_df()
+
+    assert "_problematic" in df.columns, "load_waste_df should populate the _problematic column"
+
+    helper_mask = problematic_mask(df)
+
+    pd.testing.assert_series_equal(
+        df["_problematic"],
+        helper_mask,
+        check_names=False,
+    )


### PR DESCRIPTION
## Summary
- refactor the waste loader to populate the `_problematic` column with the shared `problematic_mask`
- add regression coverage to ensure the loader and helper produce identical problematic masks

## Testing
- pytest tests/modules/test_io.py

------
https://chatgpt.com/codex/tasks/task_e_68ddb977f8748331bccb0e0c71b70859