### PR TITLE
Add shared schema module for reference column tuples

### DIFF
--- a/app/modules/schema.py
+++ b/app/modules/schema.py
@@ -1,0 +1,57 @@
+"""Shared schema constants for external reference columns."""
+
+POLYMER_SAMPLE_COLUMNS: tuple[str, ...] = (
+    "pc_density_sample_label",
+    "pc_mechanics_sample_label",
+    "pc_thermal_sample_label",
+    "pc_ignition_sample_label",
+)
+
+POLYMER_NUMERIC_COLUMNS: tuple[str, ...] = (
+    "pc_density_density_g_per_cm3",
+    "pc_density_density_kg_m3",
+    "pc_mechanics_tensile_strength_mpa",
+    "pc_mechanics_stress_mpa",
+    "pc_mechanics_yield_strength_mpa",
+    "pc_mechanics_modulus_gpa",
+    "pc_mechanics_strain_pct",
+    "pc_thermal_glass_transition_c",
+    "pc_thermal_onset_temperature_c",
+    "pc_thermal_heat_capacity_j_per_g_k",
+    "pc_thermal_heat_flow_w_per_g",
+    "pc_ignition_ignition_temperature_c",
+    "pc_ignition_burn_time_min",
+)
+
+POLYMER_METRIC_COLUMNS: tuple[str, ...] = (
+    "pc_density_density_g_per_cm3",
+    "pc_mechanics_tensile_strength_mpa",
+    "pc_mechanics_modulus_gpa",
+    "pc_thermal_glass_transition_c",
+    "pc_ignition_ignition_temperature_c",
+    "pc_ignition_burn_time_min",
+)
+
+POLYMER_LABEL_COLUMNS: tuple[str, ...] = (
+    "pc_density_sample_label",
+    "pc_mechanics_sample_label",
+    "pc_thermal_sample_label",
+    "pc_ignition_sample_label",
+)
+
+ALUMINIUM_SAMPLE_COLUMNS: tuple[str, ...] = (
+    "aluminium_processing_route",
+    "aluminium_class_id",
+)
+
+ALUMINIUM_NUMERIC_COLUMNS: tuple[str, ...] = (
+    "aluminium_tensile_strength_mpa",
+    "aluminium_yield_strength_mpa",
+    "aluminium_elongation_pct",
+)
+
+ALUMINIUM_LABEL_COLUMNS: tuple[str, ...] = (
+    "aluminium_processing_route",
+    "aluminium_class_id",
+)
+

--- a/app/pages/1_Inventory_Builder.py
+++ b/app/pages/1_Inventory_Builder.py
@@ -11,6 +11,12 @@ from app.modules.io import load_waste_df, save_waste_df
 from app.modules.navigation import set_active_step
 from app.modules.ui_blocks import load_theme, minimal_button
 from app.modules.problematic import problematic_mask
+from app.modules.schema import (
+    ALUMINIUM_NUMERIC_COLUMNS,
+    ALUMINIUM_SAMPLE_COLUMNS,
+    POLYMER_NUMERIC_COLUMNS,
+    POLYMER_SAMPLE_COLUMNS,
+)
 
 _SAVE_SUCCESS_FLAG = "_inventory_save_success"
 
@@ -41,40 +47,6 @@ st.caption(
 )
 
 # --------------------- helpers robustos de columnas ---------------------
-POLYMER_SAMPLE_COLUMNS = (
-    "pc_density_sample_label",
-    "pc_mechanics_sample_label",
-    "pc_thermal_sample_label",
-    "pc_ignition_sample_label",
-)
-
-POLYMER_NUMERIC_COLUMNS = (
-    "pc_density_density_g_per_cm3",
-    "pc_density_density_kg_m3",
-    "pc_mechanics_tensile_strength_mpa",
-    "pc_mechanics_stress_mpa",
-    "pc_mechanics_yield_strength_mpa",
-    "pc_mechanics_modulus_gpa",
-    "pc_mechanics_strain_pct",
-    "pc_thermal_glass_transition_c",
-    "pc_thermal_onset_temperature_c",
-    "pc_thermal_heat_capacity_j_per_g_k",
-    "pc_thermal_heat_flow_w_per_g",
-    "pc_ignition_ignition_temperature_c",
-    "pc_ignition_burn_time_min",
-)
-
-ALUMINIUM_SAMPLE_COLUMNS = (
-    "aluminium_processing_route",
-    "aluminium_class_id",
-)
-
-ALUMINIUM_NUMERIC_COLUMNS = (
-    "aluminium_tensile_strength_mpa",
-    "aluminium_yield_strength_mpa",
-    "aluminium_elongation_pct",
-)
-
 EXTERNAL_STRING_COLUMNS = POLYMER_SAMPLE_COLUMNS + ALUMINIUM_SAMPLE_COLUMNS
 EXTERNAL_NUMERIC_COLUMNS = POLYMER_NUMERIC_COLUMNS + ALUMINIUM_NUMERIC_COLUMNS
 EXTERNAL_COLUMNS = EXTERNAL_STRING_COLUMNS + EXTERNAL_NUMERIC_COLUMNS

--- a/app/pages/3_Generator.py
+++ b/app/pages/3_Generator.py
@@ -31,6 +31,12 @@ from app.modules.luxe_components import (
     RankingCockpit,
 )
 from app.modules.visualizations import ConvergenceScene
+from app.modules.schema import (
+    ALUMINIUM_LABEL_COLUMNS,
+    ALUMINIUM_NUMERIC_COLUMNS,
+    POLYMER_LABEL_COLUMNS,
+    POLYMER_METRIC_COLUMNS,
+)
 
 st.set_page_config(page_title="Rex-AI • Generador", page_icon="🤖", layout="wide")
 
@@ -61,33 +67,6 @@ TARGET_DISPLAY = {
     "water_l": "Agua (L)",
     "crew_min": "Crew (min)",
 }
-
-POLYMER_NUMERIC_COLUMNS = (
-    "pc_density_density_g_per_cm3",
-    "pc_mechanics_tensile_strength_mpa",
-    "pc_mechanics_modulus_gpa",
-    "pc_thermal_glass_transition_c",
-    "pc_ignition_ignition_temperature_c",
-    "pc_ignition_burn_time_min",
-)
-
-POLYMER_LABEL_COLUMNS = (
-    "pc_density_sample_label",
-    "pc_mechanics_sample_label",
-    "pc_thermal_sample_label",
-    "pc_ignition_sample_label",
-)
-
-ALUMINIUM_NUMERIC_COLUMNS = (
-    "aluminium_tensile_strength_mpa",
-    "aluminium_yield_strength_mpa",
-    "aluminium_elongation_pct",
-)
-
-ALUMINIUM_LABEL_COLUMNS = (
-    "aluminium_processing_route",
-    "aluminium_class_id",
-)
 
 POLYMER_LABEL_MAP = {
     "density_g_cm3": "ρ ref (g/cm³)",
@@ -260,7 +239,7 @@ def _collect_external_profiles(candidate: Mapping[str, Any], inventory: pd.DataF
         unique_labels = sorted(dict.fromkeys(labels))
         return {"metrics": metrics, "labels": unique_labels}
 
-    polymer_section = _build_section(POLYMER_NUMERIC_COLUMNS, POLYMER_LABEL_COLUMNS)
+    polymer_section = _build_section(POLYMER_METRIC_COLUMNS, POLYMER_LABEL_COLUMNS)
     if polymer_section:
         payload["polymer"] = polymer_section
 

--- a/app/pages/4_Results_and_Tradeoffs.py
+++ b/app/pages/4_Results_and_Tradeoffs.py
@@ -24,6 +24,12 @@ from app.modules.data_sources import (
 )
 from app.modules.explain import score_breakdown
 from app.modules.io import load_waste_df
+from app.modules.schema import (
+    ALUMINIUM_LABEL_COLUMNS,
+    ALUMINIUM_NUMERIC_COLUMNS,
+    POLYMER_LABEL_COLUMNS,
+    POLYMER_METRIC_COLUMNS,
+)
 
 st.set_page_config(page_title="Rex-AI • Resultados", page_icon="📊", layout="wide")
 
@@ -78,33 +84,6 @@ def _get_value(source, attr, default=0.0):
         return source.get(attr, default)
     return default
 
-
-POLYMER_NUMERIC_COLUMNS = (
-    "pc_density_density_g_per_cm3",
-    "pc_mechanics_tensile_strength_mpa",
-    "pc_mechanics_modulus_gpa",
-    "pc_thermal_glass_transition_c",
-    "pc_ignition_ignition_temperature_c",
-    "pc_ignition_burn_time_min",
-)
-
-POLYMER_LABEL_COLUMNS = (
-    "pc_density_sample_label",
-    "pc_mechanics_sample_label",
-    "pc_thermal_sample_label",
-    "pc_ignition_sample_label",
-)
-
-ALUMINIUM_NUMERIC_COLUMNS = (
-    "aluminium_tensile_strength_mpa",
-    "aluminium_yield_strength_mpa",
-    "aluminium_elongation_pct",
-)
-
-ALUMINIUM_LABEL_COLUMNS = (
-    "aluminium_processing_route",
-    "aluminium_class_id",
-)
 
 POLYMER_LABEL_MAP = {
     "density_g_cm3": "ρ ref (g/cm³)",
@@ -187,7 +166,7 @@ def _collect_external_profiles(candidate: dict, inventory: pd.DataFrame) -> dict
 
         return {"metrics": metrics, "labels": sorted(dict.fromkeys(labels))}
 
-    polymer = _section(POLYMER_NUMERIC_COLUMNS, POLYMER_LABEL_COLUMNS)
+    polymer = _section(POLYMER_METRIC_COLUMNS, POLYMER_LABEL_COLUMNS)
     if polymer:
         payload["polymer"] = polymer
 

--- a/tests/modules/test_schema.py
+++ b/tests/modules/test_schema.py
@@ -1,0 +1,53 @@
+from app.modules import schema
+
+
+def test_schema_exposes_polymer_columns() -> None:
+    assert schema.POLYMER_SAMPLE_COLUMNS == (
+        "pc_density_sample_label",
+        "pc_mechanics_sample_label",
+        "pc_thermal_sample_label",
+        "pc_ignition_sample_label",
+    )
+
+    assert schema.POLYMER_NUMERIC_COLUMNS == (
+        "pc_density_density_g_per_cm3",
+        "pc_density_density_kg_m3",
+        "pc_mechanics_tensile_strength_mpa",
+        "pc_mechanics_stress_mpa",
+        "pc_mechanics_yield_strength_mpa",
+        "pc_mechanics_modulus_gpa",
+        "pc_mechanics_strain_pct",
+        "pc_thermal_glass_transition_c",
+        "pc_thermal_onset_temperature_c",
+        "pc_thermal_heat_capacity_j_per_g_k",
+        "pc_thermal_heat_flow_w_per_g",
+        "pc_ignition_ignition_temperature_c",
+        "pc_ignition_burn_time_min",
+    )
+
+    assert schema.POLYMER_METRIC_COLUMNS == (
+        "pc_density_density_g_per_cm3",
+        "pc_mechanics_tensile_strength_mpa",
+        "pc_mechanics_modulus_gpa",
+        "pc_thermal_glass_transition_c",
+        "pc_ignition_ignition_temperature_c",
+        "pc_ignition_burn_time_min",
+    )
+
+
+def test_schema_exposes_aluminium_columns() -> None:
+    assert schema.ALUMINIUM_SAMPLE_COLUMNS == (
+        "aluminium_processing_route",
+        "aluminium_class_id",
+    )
+
+    assert schema.ALUMINIUM_NUMERIC_COLUMNS == (
+        "aluminium_tensile_strength_mpa",
+        "aluminium_yield_strength_mpa",
+        "aluminium_elongation_pct",
+    )
+
+    assert schema.ALUMINIUM_LABEL_COLUMNS == (
+        "aluminium_processing_route",
+        "aluminium_class_id",
+    )


### PR DESCRIPTION
## Summary
- extract shared polymer and aluminium column tuples into a new `app/modules/schema.py`
- update the inventory, generator, and results pages to import the shared schema constants
- add unit tests that assert the schema module exposes the expected constants

## Testing
- pytest tests/modules/test_schema.py

------
https://chatgpt.com/codex/tasks/task_e_68ddb9796e7883318ba0f79d5580c518