### PR TITLE
Replace target configurator with native Streamlit controls

### DIFF
--- a/app/pages/2_Target_Designer.py
+++ b/app/pages/2_Target_Designer.py
@@ -6,9 +6,9 @@ import streamlit as st
 st.set_page_config(page_title="Objetivo", page_icon="🎯", layout="wide")
 
 from app.modules.io import load_targets
-from app.modules.luxe_components import target_configurator
+from app.modules.luxe_components import _compute_target_limits
 from app.modules.navigation import render_breadcrumbs, set_active_step
-from app.modules.ui_blocks import load_theme, section
+from app.modules.ui_blocks import load_theme
 
 current_step = set_active_step("target")
 
@@ -29,8 +29,113 @@ scenario_options = (
     "Daring Discoveries",
 )
 
-target = target_configurator(presets, scenario_options=scenario_options)
+preset_names = [preset["name"] for preset in presets if "name" in preset]
+if not preset_names:
+    st.error("Los presets cargados no contienen nombres válidos.")
+    st.stop()
 
-if target:
-    st.session_state["target"] = target
-    st.success("Objetivo listo. Abrí la página **3) Generador** para obtener recetas.")
+stored_target = st.session_state.get("target", {})
+default_name = stored_target.get("name", preset_names[0])
+default_index = preset_names.index(default_name) if default_name in preset_names else 0
+
+selected_name = st.selectbox("Preset objetivo", preset_names, index=default_index)
+selected_preset = next(p for p in presets if p.get("name") == selected_name)
+
+slider_limits = _compute_target_limits(presets)
+
+default_scenario = scenario_options[0] if scenario_options else ""
+scenario = stored_target.get("scenario", default_scenario)
+if scenario not in scenario_options:
+    scenario = default_scenario
+
+scenario = st.selectbox("Escenario del reto", scenario_options, index=scenario_options.index(scenario))
+
+crew_time_low = st.checkbox(
+    "Priorizar procesos de bajo tiempo de tripulación",
+    value=stored_target.get("crew_time_low", False),
+)
+
+rigidity_bounds = slider_limits["rigidity"]
+rigidity_default = float(stored_target.get("rigidity", selected_preset.get("rigidity", 0.0)))
+rigidity = st.slider(
+    "Rigidez deseada",
+    rigidity_bounds["min"],
+    rigidity_bounds["max"],
+    min(max(rigidity_default, rigidity_bounds["min"]), rigidity_bounds["max"]),
+    rigidity_bounds["step"],
+    help=rigidity_bounds["help"],
+)
+
+tightness_bounds = slider_limits["tightness"]
+tightness_default = float(stored_target.get("tightness", selected_preset.get("tightness", 0.0)))
+tightness = st.slider(
+    "Estanqueidad deseada",
+    tightness_bounds["min"],
+    tightness_bounds["max"],
+    min(max(tightness_default, tightness_bounds["min"]), tightness_bounds["max"]),
+    tightness_bounds["step"],
+    help=tightness_bounds["help"],
+)
+
+water_bounds = slider_limits["max_water_l"]
+water_default = float(stored_target.get("max_water_l", selected_preset.get("max_water_l", 0.0)))
+max_water = st.slider(
+    "Agua máxima (L)",
+    water_bounds["min"],
+    water_bounds["max"],
+    min(max(water_default, water_bounds["min"]), water_bounds["max"]),
+    water_bounds["step"],
+    help=water_bounds["help"],
+)
+
+energy_bounds = slider_limits["max_energy_kwh"]
+energy_default = float(
+    stored_target.get("max_energy_kwh", selected_preset.get("max_energy_kwh", 0.0))
+)
+max_energy = st.slider(
+    "Energía máxima (kWh)",
+    energy_bounds["min"],
+    energy_bounds["max"],
+    min(max(energy_default, energy_bounds["min"]), energy_bounds["max"]),
+    energy_bounds["step"],
+    help=energy_bounds["help"],
+)
+
+crew_bounds = slider_limits["max_crew_min"]
+crew_default = float(stored_target.get("max_crew_min", selected_preset.get("max_crew_min", crew_bounds["min"])))
+max_crew = st.number_input(
+    "Tiempo máximo de tripulación (min)",
+    min_value=float(crew_bounds["min"]),
+    max_value=float(crew_bounds["max"]),
+    value=float(min(max(crew_default, crew_bounds["min"]), crew_bounds["max"])),
+    step=float(crew_bounds["step"]),
+    help=crew_bounds["help"],
+)
+
+target = {
+    **selected_preset,
+    "name": selected_name,
+    "scenario": scenario,
+    "crew_time_low": crew_time_low,
+    "rigidity": rigidity,
+    "tightness": tightness,
+    "max_water_l": float(max_water),
+    "max_energy_kwh": float(max_energy),
+    "max_crew_min": float(max_crew),
+}
+
+st.session_state["target"] = target
+
+summary_cols = st.columns(3)
+summary_cols[0].metric("Rigidez", f"{rigidity:.2f}")
+summary_cols[1].metric("Estanqueidad", f"{tightness:.2f}")
+summary_cols[2].metric("Crew (min)", f"{max_crew:.0f}")
+
+st.caption("Límites de recursos establecidos")
+limits_table = {
+    "Recurso": ["Agua (L)", "Energía (kWh)"],
+    "Máximo": [f"{max_water:.2f}", f"{max_energy:.2f}"],
+}
+st.table(limits_table)
+
+st.success("Objetivo listo. Abrí la página **3) Generador** para obtener recetas.")

--- a/tests/pages/test_target_designer_limits.py
+++ b/tests/pages/test_target_designer_limits.py
@@ -1,0 +1,58 @@
+import numpy as np
+import pandas as pd
+
+import app.modules.luxe_components as luxe
+
+
+def _sample_presets():
+    return [
+        {
+            "name": "Preset A",
+            "rigidity": 0.4,
+            "tightness": 0.5,
+            "max_water_l": 0.45,
+            "max_energy_kwh": 0.52,
+            "max_crew_min": 45,
+        },
+        {
+            "name": "Preset B",
+            "rigidity": 0.6,
+            "tightness": 0.7,
+            "max_water_l": 0.5,
+            "max_energy_kwh": 0.65,
+            "max_crew_min": 60,
+        },
+    ]
+
+
+def _waste_df():
+    return pd.DataFrame(
+        {
+            "_source_volume_l": [1200, 2600, 8000, 10000],
+            "kg": [100.0, 240.0, 600.0, 180.0],
+        }
+    )
+
+
+def test_water_limits_follow_baseline(monkeypatch):
+    monkeypatch.setattr(luxe, "load_waste_df", lambda: _waste_df())
+
+    limits = luxe._compute_target_limits(_sample_presets())
+
+    volume_q90 = np.quantile(_waste_df()["_source_volume_l"], 0.9)
+    expected = round(volume_q90 * luxe._WATER_L_PER_VOLUME_L_BASELINE, 2)
+
+    assert limits["max_water_l"]["max"] == expected
+    assert "NASA baseline" in limits["max_water_l"]["help"]
+
+
+def test_energy_limits_follow_baseline(monkeypatch):
+    monkeypatch.setattr(luxe, "load_waste_df", lambda: _waste_df())
+
+    limits = luxe._compute_target_limits(_sample_presets())
+
+    mass_q90 = np.quantile(_waste_df()["kg"], 0.9)
+    expected = round(mass_q90 * luxe._ENERGY_KWH_PER_KG_BASELINE, 2)
+
+    assert limits["max_energy_kwh"]["max"] == expected
+    assert "NASA baseline" in limits["max_energy_kwh"]["help"]


### PR DESCRIPTION
## Summary
- swap the luxe target configurator for native Streamlit widgets that persist the active target in session state
- present the selected target metrics and resource limits with Streamlit-native components
- add page-level tests to confirm presets derive the correct water and energy bounds from NASA baselines

## Testing
- pytest tests/pages/test_target_designer_limits.py

------
https://chatgpt.com/codex/tasks/task_e_68ddc33457808331a89d49bf54677ae9