### PR TITLE
Refactor inventory builder editor and share formatting helpers

### DIFF
--- a/app/pages/1_Inventory_Builder.py
+++ b/app/pages/1_Inventory_Builder.py
@@ -3,11 +3,16 @@ import _bootstrap  # noqa: F401
 from datetime import datetime, timezone
 
 import altair as alt
-import math
 import streamlit as st
 import pandas as pd
-from st_aggrid import AgGrid, GridOptionsBuilder, GridUpdateMode, JsCode
-from app.modules.io import load_waste_df, save_waste_df
+from app.modules.io import (
+    format_aluminium_profile,
+    format_composition_summary,
+    format_mission_bundle,
+    format_polymer_profile,
+    load_waste_df,
+    save_waste_df,
+)
 from app.modules.navigation import set_active_step
 from app.modules.ui_blocks import load_theme, minimal_button
 from app.modules.problematic import problematic_mask
@@ -64,79 +69,6 @@ def _resolve_column(df: pd.DataFrame, names: tuple[str, ...], *, numeric: bool =
     if numeric:
         return pd.Series(0.0, index=df.index, dtype=float)
     return pd.Series("", index=df.index, dtype=str)
-
-
-def _safe_float(value: object) -> float | None:
-    try:
-        number = float(value)
-    except (TypeError, ValueError):
-        return None
-    if math.isnan(number):
-        return None
-    return number
-
-
-def _format_polymer_profile(row: pd.Series) -> str:
-    parts: list[str] = []
-
-    for column in POLYMER_SAMPLE_COLUMNS:
-        label = str(row.get(column) or "").strip()
-        if label:
-            parts.append(f"Ref {label}")
-            break
-
-    density = _safe_float(row.get("pc_density_density_g_per_cm3"))
-    if density:
-        parts.append(f"ρ {density:.2f} g/cm³")
-
-    tensile = _safe_float(row.get("pc_mechanics_tensile_strength_mpa"))
-    if tensile:
-        parts.append(f"σₜ {tensile:.0f} MPa")
-
-    modulus = _safe_float(row.get("pc_mechanics_modulus_gpa"))
-    if modulus:
-        parts.append(f"E {modulus:.1f} GPa")
-
-    glass_transition = _safe_float(row.get("pc_thermal_glass_transition_c"))
-    if glass_transition:
-        parts.append(f"Tg {glass_transition:.0f} °C")
-
-    ignition = _safe_float(row.get("pc_ignition_ignition_temperature_c"))
-    if ignition:
-        parts.append(f"Ign. {ignition:.0f} °C")
-
-    burn_time = _safe_float(row.get("pc_ignition_burn_time_min"))
-    if burn_time:
-        parts.append(f"Burn {burn_time:.1f} min")
-
-    return "||".join(parts)
-
-
-def _format_aluminium_profile(row: pd.Series) -> str:
-    parts: list[str] = []
-
-    route = str(row.get("aluminium_processing_route") or "").strip()
-    class_id = str(row.get("aluminium_class_id") or "").strip()
-    if route and class_id:
-        parts.append(f"{route} · Clase {class_id}")
-    elif route:
-        parts.append(route)
-    elif class_id:
-        parts.append(f"Clase {class_id}")
-
-    tensile = _safe_float(row.get("aluminium_tensile_strength_mpa"))
-    if tensile:
-        parts.append(f"σₜ {tensile:.0f} MPa")
-
-    yield_strength = _safe_float(row.get("aluminium_yield_strength_mpa"))
-    if yield_strength:
-        parts.append(f"σᵧ {yield_strength:.0f} MPa")
-
-    elongation = _safe_float(row.get("aluminium_elongation_pct"))
-    if elongation:
-        parts.append(f"ε {elongation:.0f}%")
-
-    return "||".join(parts)
 
 
 @st.cache_data
@@ -265,24 +197,6 @@ composition_cols = [
     if column.endswith("_pct") and column not in {"pct_mass", "pct_volume"} and not column.startswith("_source_")
 ]
 
-if composition_cols:
-    def _format_composition(row: pd.Series) -> str:
-        parts: list[str] = []
-        for column in composition_cols:
-            value = row.get(column)
-            if pd.isna(value) or float(value) <= 0:
-                continue
-            label = column.replace("_pct", "").replace("_", " ")
-            parts.append(f"{label} {float(value):.0f}%")
-        return ", ".join(parts)
-
-    df["composition_summary"] = df[composition_cols].apply(_format_composition, axis=1)
-else:
-    df["composition_summary"] = ""
-
-df["polymer_profile"] = df.apply(_format_polymer_profile, axis=1)
-df["aluminium_profile"] = df.apply(_format_aluminium_profile, axis=1)
-
 mission_columns = [column for column in df.columns if column.startswith("summary_")]
 mission_labels = {
     "summary_gateway_phase_i_mass_kg": "Gateway I",
@@ -291,20 +205,59 @@ mission_labels = {
     "summary_total_mass_kg": "Total NASA",
 }
 
-if mission_columns:
-    def _format_mission_bundle(row: pd.Series) -> str:
-        parts: list[str] = []
-        for column in mission_columns:
-            value = row.get(column)
-            if pd.isna(value) or float(value) <= 0:
-                continue
-            label = mission_labels.get(column, column.replace("summary_", "").replace("_", " "))
-            parts.append(f"{label}: {float(value):.1f} kg")
-        return " · ".join(parts)
+def _enrich_inventory_df(data: pd.DataFrame) -> pd.DataFrame:
+    enriched = data.copy()
 
-    df["nasa_mission_bundle"] = df[mission_columns].apply(_format_mission_bundle, axis=1)
-else:
-    df["nasa_mission_bundle"] = ""
+    string_columns = [
+        "id",
+        "category",
+        "material",
+        "material_family",
+        "flags",
+        "key_materials",
+        "notes",
+    ]
+    for column in string_columns:
+        if column in enriched.columns:
+            enriched[column] = enriched[column].fillna("").astype(str)
+
+    numeric_columns = {
+        "mass_kg",
+        "volume_l",
+        "moisture_pct",
+        "pct_mass",
+        "pct_volume",
+        "difficulty_factor",
+        *EXTERNAL_NUMERIC_COLUMNS,
+    }
+    for column in numeric_columns:
+        if column in enriched.columns:
+            enriched[column] = pd.to_numeric(enriched[column], errors="coerce").fillna(0.0)
+
+    if composition_cols:
+        enriched["composition_summary"] = enriched.apply(
+            lambda row: format_composition_summary(row, composition_cols),
+            axis=1,
+        )
+    else:
+        enriched["composition_summary"] = ""
+
+    enriched["polymer_profile"] = enriched.apply(format_polymer_profile, axis=1)
+    enriched["aluminium_profile"] = enriched.apply(format_aluminium_profile, axis=1)
+
+    if mission_columns:
+        enriched["nasa_mission_bundle"] = enriched.apply(
+            lambda row: format_mission_bundle(row, mission_columns, mission_labels),
+            axis=1,
+        )
+    else:
+        enriched["nasa_mission_bundle"] = ""
+
+    enriched["_problematic"] = problematic_mask(enriched)
+    return enriched
+
+
+df = _enrich_inventory_df(df)
 
 # --------------------- métricas “sabor laboratorio” ---------------------
 inventory_metrics = [
@@ -526,8 +479,8 @@ if "inventory_data" not in st.session_state:
 if "inventory_quick_filters" not in st.session_state:
     st.session_state["inventory_quick_filters"] = []
 
-if "inventory_grid_state" not in st.session_state:
-    st.session_state["inventory_grid_state"] = {}
+if "inventory_selection" not in st.session_state:
+    st.session_state["inventory_selection"] = {}
 
 # ------------------------------------------------------------------
 # Barra lateral de análisis instantáneo
@@ -568,6 +521,37 @@ sidebar.metric(
 )
 sidebar.caption(_format_baseline_caption(baseline_state))
 
+mass_by_category = (
+    session_df.groupby("category")["mass_kg"].sum().sort_values(ascending=False).head(6)
+)
+if not mass_by_category.empty:
+    sidebar.subheader("Distribución de masa (kg)")
+    sidebar.bar_chart(mass_by_category)
+
+volume_by_category = (
+    session_df.groupby("category")["volume_l"].sum().sort_values(ascending=False).head(6)
+)
+if not volume_by_category.empty:
+    sidebar.subheader("Volumen por categoría (L)")
+    sidebar.bar_chart(volume_by_category)
+
+if composition_cols:
+    composition_masses: dict[str, float] = {}
+    base_mass = pd.to_numeric(session_df.get("mass_kg"), errors="coerce").fillna(0.0)
+    for column in composition_cols:
+        fractions = pd.to_numeric(session_df.get(column), errors="coerce").fillna(0.0) / 100.0
+        component_mass = float((fractions * base_mass).sum())
+        if component_mass <= 0:
+            continue
+        label = column.replace("_pct", "").replace("_", " ")
+        composition_masses[label] = component_mass
+    if composition_masses:
+        composition_series = (
+            pd.Series(composition_masses).sort_values(ascending=False).head(6)
+        )
+        sidebar.subheader("Composición estimada (kg)")
+        sidebar.bar_chart(composition_series)
+
 sidebar.subheader("Recomendaciones IA")
 problematic_tags = session_df.loc[session_df["_problematic"], "flags"].fillna("")
 top_flags = (
@@ -585,29 +569,22 @@ else:
     sidebar.caption("Sin flags críticos detectados. ✨")
 
 sidebar.subheader("Filtros rápidos")
-sidebar.markdown(
-    "<style>div[data-baseweb='toggle']{margin-bottom:0.4rem;}"
-    "div[data-baseweb='toggle'] label{background:#111827;color:#f9fafb;padding:0.35rem 0.9rem;"
-    "border-radius:999px;font-size:0.85rem;box-shadow:0 0 0 1px #4b5563 inset;}"
-    "div[data-baseweb='toggle'] input:checked+label{background:#00a19d;color:#06141b;font-weight:600;}"
-    "</style>",
-    unsafe_allow_html=True,
-)
-
 all_flags = (
-    session_df["flags"].fillna("").str.split(r"[,;]\s*").explode().str.strip().replace("", pd.NA).dropna().unique()
+    session_df["flags"].fillna("")
+    .str.split(r"[,;]\s*")
+    .explode()
+    .str.strip()
+    .replace("", pd.NA)
+    .dropna()
+    .unique()
 )
-selected_filters = st.session_state["inventory_quick_filters"]
-
-for flag in all_flags:
-    toggle_key = f"inventory_flag_{flag}"
-    current_value = flag in selected_filters
-    toggled = sidebar.toggle(flag, value=current_value, key=toggle_key)
-    if toggled and not current_value:
-        selected_filters.append(flag)
-    if not toggled and current_value:
-        selected_filters = [f for f in selected_filters if f != flag]
-
+available_flags = sorted(all_flags.tolist()) if len(all_flags) else []
+default_flags = [flag for flag in st.session_state["inventory_quick_filters"] if flag in available_flags]
+selected_filters = sidebar.multiselect(
+    "Filtrar por flags",
+    options=available_flags,
+    default=default_flags,
+)
 st.session_state["inventory_quick_filters"] = selected_filters
 
 filtered_df = session_df.copy()
@@ -618,97 +595,21 @@ if selected_filters:
     filtered_df = filtered_df[mask]
 
 # ------------------------------------------------------------------
-# Configuración de AG Grid
+# Editor interactivo
 filtered_df = filtered_df.reset_index(drop=True)
+filtered_df["id"] = filtered_df["id"].astype(str)
 
-st.markdown(
-    """
-    <style>
-    .property-badge {
-        display: inline-flex;
-        align-items: center;
-        background: rgba(14,165,233,0.16);
-        color: #e0f2fe;
-        border-radius: 999px;
-        padding: 0.12rem 0.55rem;
-        margin: 0.05rem;
-        font-size: 0.75rem;
-        font-weight: 600;
-        letter-spacing: 0.01em;
-    }
-    .property-badge:nth-child(2n) {
-        background: rgba(16,185,129,0.18);
-        color: #d1fae5;
-    }
-    </style>
-    """,
-    unsafe_allow_html=True,
-)
+valid_ids = set(session_df["id"].astype(str))
+selection_state = {
+    key: bool(value)
+    for key, value in st.session_state["inventory_selection"].items()
+    if key in valid_ids
+}
+st.session_state["inventory_selection"] = selection_state
 
-flag_chip_renderer = JsCode(
-    """
-    function(params) {
-        if (!params.value) { return ''; }
-        const chips = String(params.value)
-            .split(/[;,]/)
-            .map(v => v.trim())
-            .filter(Boolean)
-            .map(flag => `<span class="flag-chip">${flag}</span>`);
-        return chips.join(' ');
-    }
-    """
-)
+filtered_df["_selected"] = filtered_df["id"].map(selection_state).fillna(False)
 
-property_badge_renderer = JsCode(
-    """
-    function(params){
-        if (!params.value) { return ''; }
-        const parts = String(params.value)
-            .split('||')
-            .map(v => v.trim())
-            .filter(Boolean);
-        return parts.map(part => `<span class="property-badge">${part}</span>`).join(' ');
-    }
-    """
-)
-
-tesla_gradient_style = JsCode(
-    """
-    function(params){
-        const base = {borderRadius: '8px', fontWeight: 500, paddingLeft: '6px'};
-        if (params.value === null || params.value === undefined || params.value === '') {
-            return {...base, backgroundColor: '#1f2937', color: '#9ca3af'};
-        }
-        const value = Number(params.value);
-        if (isNaN(value)) {
-            return {...base, backgroundColor: '#1f2937', color: '#f9fafb'};
-        }
-        if (value < 0) {
-            return {...base, backgroundColor: '#ffedef', color: '#cc0000'};
-        }
-        const clamp = Math.min(value / 10.0, 1.0);
-        const teal = Math.round(80 + 90 * clamp);
-        return {
-            ...base,
-            backgroundColor: `rgba(0, 161, 157, ${0.15 + clamp * 0.35})`,
-            color: `rgb(${50 + (1 - clamp) * 60}, ${teal}, ${150 + clamp * 80})`
-        };
-    }
-    """
-)
-
-problematic_row_style = JsCode(
-    """
-    function(params){
-        if (params.data && params.data._problematic) {
-            return {'backgroundColor': 'rgba(204,0,0,0.12)'};
-        }
-        return {};
-    }
-    """
-)
-
-grid_column_order = [
+editor_column_order = [
     "id",
     "category",
     "material",
@@ -730,169 +631,109 @@ grid_column_order = [
 ]
 
 for column in mission_columns:
-    if column not in grid_column_order:
-        grid_column_order.append(column)
+    if column not in editor_column_order:
+        editor_column_order.append(column)
 
 for column in composition_cols:
-    if column not in grid_column_order:
-        grid_column_order.append(column)
+    if column not in editor_column_order:
+        editor_column_order.append(column)
 
 for column in EXTERNAL_COLUMNS:
-    if column not in grid_column_order:
-        grid_column_order.append(column)
+    if column not in editor_column_order:
+        editor_column_order.append(column)
 
 source_columns = [column for column in filtered_df.columns if column.startswith("_source_")]
 for column in source_columns:
-    if column not in grid_column_order:
-        grid_column_order.append(column)
+    if column not in editor_column_order:
+        editor_column_order.append(column)
 
-grid_columns = [column for column in grid_column_order if column in filtered_df.columns]
-grid_df = filtered_df[grid_columns].copy()
+editor_column_order = ["_selected", *editor_column_order]
+editor_columns = [column for column in editor_column_order if column in filtered_df.columns]
+editor_df = filtered_df[editor_columns].copy()
 
-gb = GridOptionsBuilder.from_dataframe(grid_df)
-gb.configure_default_column(
-    editable=True,
-    groupable=True,
-    resizable=True,
-    sortable=True,
-    filter=True,
-    tooltipField="flags",
-)
-gb.configure_column("id", header_name="ID", pinned="left")
-gb.configure_column("category", header_name="Categoría NASA", rowGroup=True, hide=True)
-gb.configure_column("material", header_name="Subitem NASA")
-gb.configure_column("material_display", header_name="Resumen", editable=False)
-gb.configure_column("material_family", header_name="Familia material")
-gb.configure_column("mass_kg", header_name="Masa (kg)", type=["numericColumn"], cellStyle=tesla_gradient_style)
-gb.configure_column("volume_l", header_name="Volumen (L)", type=["numericColumn"], cellStyle=tesla_gradient_style)
-gb.configure_column("moisture_pct", header_name="Humedad (%)", type=["numericColumn"], cellStyle=tesla_gradient_style)
-gb.configure_column("difficulty_factor", header_name="Dificultad", type=["numericColumn"], cellStyle=tesla_gradient_style)
-gb.configure_column("flags", header_name="Flags", cellRenderer=flag_chip_renderer, editable=True)
-gb.configure_column("key_materials", header_name="Key materials", wrapText=True, autoHeight=True)
-gb.configure_column(
-    "polymer_profile",
-    header_name="Polímeros ref",
-    editable=False,
-    cellRenderer=property_badge_renderer,
-    autoHeight=True,
-    wrapText=True,
-)
-gb.configure_column(
-    "aluminium_profile",
-    header_name="Aluminio ref",
-    editable=False,
-    cellRenderer=property_badge_renderer,
-    autoHeight=True,
-    wrapText=True,
-)
-gb.configure_column("notes", header_name="Notas", wrapText=True, autoHeight=True)
-gb.configure_column("composition_summary", header_name="Composición NASA", editable=False, wrapText=True, autoHeight=True)
-gb.configure_column("nasa_mission_bundle", header_name="Masas por misión", editable=False, wrapText=True, autoHeight=True)
-gb.configure_column("density_kg_m3", header_name="Densidad (kg/m³)", type=["numericColumn"], editable=False)
-gb.configure_column("_problematic", header_name="Problemático", editable=False, hide=True)
+column_config = {
+    "_selected": st.column_config.CheckboxColumn("Seleccionar", help="Marcar lotes para edición en lote"),
+    "id": st.column_config.TextColumn("ID", disabled=True),
+    "mass_kg": st.column_config.NumberColumn("Masa (kg)", min_value=0.0, step=0.25, format="%.2f"),
+    "volume_l": st.column_config.NumberColumn("Volumen (L)", min_value=0.0, step=0.1, format="%.2f"),
+    "moisture_pct": st.column_config.NumberColumn("Humedad (%)", min_value=0.0, max_value=100.0, step=1.0),
+    "difficulty_factor": st.column_config.NumberColumn("Dificultad", min_value=0.0, step=0.5),
+    "flags": st.column_config.TextColumn("Flags"),
+    "key_materials": st.column_config.TextColumn("Materiales clave"),
+    "composition_summary": st.column_config.TextColumn(
+        "Composición NASA",
+        disabled=True,
+        help="Se calcula con los porcentajes NASA.*",
+    ),
+    "nasa_mission_bundle": st.column_config.TextColumn(
+        "Misiones NASA",
+        disabled=True,
+        help="Resumen de masa proyectada por misión",
+    ),
+    "polymer_profile": st.column_config.TextColumn(
+        "Perfil polímero",
+        disabled=True,
+        help="Datos de densidad, resistencia y laboratorio",
+    ),
+    "aluminium_profile": st.column_config.TextColumn("Perfil aluminio", disabled=True),
+    "_problematic": st.column_config.CheckboxColumn("Problemático", disabled=True),
+}
 
-for column in mission_columns:
-    if column in grid_df.columns:
-        header = f"{mission_labels.get(column, column)} (kg)"
-        gb.configure_column(column, header_name=header, editable=False, type=["numericColumn"], hide=True)
+editor_col, preview_col = st.columns((2.2, 1))
 
-for column in composition_cols:
-    if column in grid_df.columns:
-        header = column.replace("_pct", " (%)").replace("_", " ")
-        gb.configure_column(column, header_name=header, editable=False, hide=True)
-
-for column in EXTERNAL_COLUMNS:
-    if column in grid_df.columns:
-        gb.configure_column(column, header_name=column, editable=False, hide=True)
-
-for column in source_columns:
-    if column in grid_df.columns:
-        gb.configure_column(column, header_name=column, editable=False, hide=True)
-
-gb.configure_grid_options(
-    animateRows=True,
-    enableRangeSelection=True,
-    enableCellTextSelection=True,
-    rowClassRules={"problematic": "data._problematic === true"},
-    rowGroupPanelShow="always",
-)
-gb.configure_selection(selection_mode="multiple", use_checkbox=True)
-gb.configure_side_bar()
-
-grid_options = gb.build()
-
-if st.session_state["inventory_grid_state"]:
-    stored_state = st.session_state["inventory_grid_state"]
-    for key in ["columnState", "sortModel", "filterModel", "rowGroupPanelShow", "grouping"]:
-        if stored_state.get(key):
-            grid_options[key] = stored_state[key]
-
-st.markdown(
-    """
-    <style>
-    .flag-chip {
-        background: linear-gradient(120deg, rgba(0,161,157,0.25), rgba(17,24,39,0.15));
-        border-radius: 999px;
-        padding: 2px 8px;
-        margin-right: 4px;
-        color: #00d1c1;
-        font-weight: 600;
-        display: inline-block;
-        font-size: 0.75rem;
-    }
-    .ag-theme-streamlit .ag-row.problematic {
-        border-left: 3px solid #cc0000;
-    }
-    </style>
-    """,
-    unsafe_allow_html=True,
-)
-
-grid_col, preview_col = st.columns((2.2, 1))
-
-with grid_col:
-    grid_response = AgGrid(
-        grid_df,
-        gridOptions=grid_options,
-        update_mode=GridUpdateMode.MODEL_CHANGED | GridUpdateMode.SELECTION_CHANGED,
-        data_return_mode="AS_INPUT",
-        theme="streamlit",
-        allow_unsafe_jscode=True,
-        fit_columns_on_grid_load=True,
+with editor_col:
+    editor_result = st.data_editor(
+        editor_df,
+        column_config=column_config,
+        column_order=editor_columns,
+        hide_index=True,
+        key="inventory_editor",
+        num_rows="fixed",
+        use_container_width=True,
     )
 
-    st.session_state["inventory_grid_state"] = grid_response.get("grid_state", st.session_state["inventory_grid_state"])
+if not editor_result.empty:
+    editor_result = editor_result.copy()
+    editor_result["id"] = editor_result["id"].astype(str)
 
-    updated_df = pd.DataFrame(grid_response.get("data", grid_df))
-    if not updated_df.empty:
-        numeric_candidates = [
-            "mass_kg",
-            "volume_l",
-            "moisture_pct",
-            "pct_mass",
-            "pct_volume",
-            "difficulty_factor",
-            "density_kg_m3",
+    selection_updates = editor_result.set_index("id")["_selected"].fillna(False).astype(bool).to_dict()
+    st.session_state["inventory_selection"].update(selection_updates)
+
+    editable_result = editor_result.drop(
+        columns=[
+            column
+            for column in (
+                "_selected",
+                "composition_summary",
+                "nasa_mission_bundle",
+                "polymer_profile",
+                "aluminium_profile",
+                "_problematic",
+            )
+            if column in editor_result.columns
         ]
-        for column in numeric_candidates:
-            if column in updated_df.columns:
-                updated_df[column] = pd.to_numeric(updated_df[column], errors="coerce").fillna(0.0)
-        updated_df["_problematic"] = problematic_mask(updated_df)
-        if composition_cols and all(column in updated_df.columns for column in composition_cols):
-            updated_df["composition_summary"] = updated_df[composition_cols].apply(_format_composition, axis=1)
-        if mission_columns and all(column in updated_df.columns for column in mission_columns):
-            updated_df["nasa_mission_bundle"] = updated_df[mission_columns].apply(_format_mission_bundle, axis=1)
-        st.session_state["inventory_data"] = updated_df
+    )
 
-selected_rows = grid_response.get("selected_rows", []) if "grid_response" in locals() else []
-selected_ids = [row.get("id") for row in selected_rows]
+    live_df = st.session_state["inventory_data"].copy()
+    live_df["id"] = live_df["id"].astype(str)
+
+    live_df = live_df.set_index("id")
+    update_payload = editable_result.set_index("id")
+    live_df.update(update_payload)
+    live_df = live_df.reset_index()
+    live_df = _enrich_inventory_df(live_df)
+    st.session_state["inventory_data"] = live_df
+    session_df = live_df
+
+selection_state = st.session_state["inventory_selection"]
+selected_ids = [key for key, value in selection_state.items() if value]
 
 with preview_col:
     st.subheader("Vista lateral")
-    if selected_rows:
+    preview_df = session_df[session_df["id"].isin(selected_ids)].copy()
+    if not preview_df.empty:
         st.caption("Lotes seleccionados — edición contextual")
-        preview_df = pd.DataFrame(selected_rows)
-        preview_df["_problematic"] = problematic_mask(preview_df)
+
         preview_columns = [
             "id",
             "category",
@@ -905,29 +746,49 @@ with preview_col:
         preview_columns = [column for column in preview_columns if column in preview_df.columns]
         st.dataframe(
             preview_df[preview_columns]
-            .rename(columns={"mass_kg": "kg", "volume_l": "L", "composition_summary": "Composición", "nasa_mission_bundle": "Misiones"}),
+            .rename(
+                columns={
+                    "mass_kg": "kg",
+                    "volume_l": "L",
+                    "composition_summary": "Composición",
+                    "nasa_mission_bundle": "Misiones",
+                }
+            ),
             use_container_width=True,
             hide_index=True,
         )
 
-        st.markdown("**Flags representados**")
-        chips = []
-        for flags in preview_df.get("flags", pd.Series(dtype=str)).fillna(""):
-            chips.extend([f.strip() for f in str(flags).split(",") if f.strip()])
-        chips = sorted(set(chips))
-        if chips:
-            st.markdown(
-                " ".join([f"<span class='flag-chip'>{chip}</span>" for chip in chips]),
-                unsafe_allow_html=True,
+        selection_mass = float(preview_df.get("mass_kg", pd.Series(dtype=float)).sum())
+        selection_volume = float(preview_df.get("volume_l", pd.Series(dtype=float)).sum())
+        metric_a, metric_b = st.columns(2)
+        metric_a.metric("Masa selección (kg)", f"{selection_mass:.2f}")
+        metric_b.metric("Volumen selección (L)", f"{selection_volume:.1f}")
+
+        if "flags" in preview_df.columns:
+            unique_flags = (
+                preview_df["flags"].fillna("").str.split(r"[,;]\s*")
+                .explode()
+                .str.strip()
+                .replace("", pd.NA)
+                .dropna()
+                .unique()
             )
+        else:
+            unique_flags = []
+
+        if len(unique_flags) > 0:
+            st.markdown("**Flags representados**")
+            for flag in sorted(unique_flags):
+                st.write(f"• {flag}")
         else:
             st.caption("Sin flags adicionales en selección.")
 
-        if composition_cols and "composition_summary" in preview_df:
+        if composition_cols and "composition_summary" in preview_df.columns:
             st.markdown("**Composición NASA**")
             for _, row in preview_df.iterrows():
+                material_label = row.get("material") or row.get("category") or "Lote"
                 summary = row.get("composition_summary") or "—"
-                st.markdown(f"• **{row.get('material', row.get('category', 'Lote'))}**: {summary}")
+                st.write(f"• {material_label}: {summary}")
 
         if mission_columns:
             mission_summary = {
@@ -937,9 +798,7 @@ with preview_col:
             }
             if mission_summary:
                 st.markdown("**Masa proyectada por misión (selección)**")
-                mission_table = pd.DataFrame(
-                    {"Misión": mission_summary.keys(), "kg": mission_summary.values()}
-                )
+                mission_table = pd.DataFrame({"Misión": mission_summary.keys(), "kg": mission_summary.values()})
                 st.dataframe(mission_table, hide_index=True, use_container_width=True)
 
         processing_df = _load_processing_products()
@@ -974,8 +833,7 @@ with preview_col:
 
     st.markdown("---")
     st.subheader("Edición en lote")
-    help_text = "Aplicá cambios a todas las filas seleccionadas. Tooltips indican impacto." 
-    st.caption(help_text)
+    st.caption("Aplicá cambios a todas las filas seleccionadas. Tooltips indican impacto.")
     batch_disabled = not selected_ids
 
     with st.form("batch_edit_form"):
@@ -995,18 +853,27 @@ with preview_col:
 
     if submitted and selected_ids:
         live_df = st.session_state["inventory_data"].copy()
+        live_df["id"] = live_df["id"].astype(str)
         mask = live_df["id"].isin(selected_ids)
         if mass_delta != 0:
             live_df.loc[mask, "mass_kg"] = (live_df.loc[mask, "mass_kg"] + mass_delta).clip(lower=0)
         if new_flag:
             live_df.loc[mask, "flags"] = live_df.loc[mask, "flags"].fillna("").apply(
-                lambda text: ", ".join(sorted(set([*filter(None, map(str.strip, text.split(","))), new_flag.strip()])))
+                lambda text: ", ".join(
+                    sorted(
+                        set(
+                            [
+                                *filter(None, map(str.strip, str(text).split(","))),
+                                new_flag.strip(),
+                            ]
+                        )
+                    )
+                )
             )
-        live_df["_problematic"] = problematic_mask(live_df)
+        live_df = _enrich_inventory_df(live_df)
         st.session_state["inventory_data"] = live_df
         st.toast("Edición en lote aplicada.")
         _trigger_rerun()
-
 colA, colB = st.columns(2)
 with colA:
     button_state = "success" if save_success else "idle"


### PR DESCRIPTION
## Summary
- replace the inventory AgGrid with `st.data_editor`, preserving selection state for batch editing and contextual previews
- move polymer, aluminium, composition, and mission formatting helpers into `app.modules.io` for reuse across views
- refresh the sidebar analytics with native Streamlit metrics and bar charts fed by live mass, volume, and composition data

## Testing
- pytest *(fails: `polars` wheel bundled in environment lacks `read_csv`)*

------
https://chatgpt.com/codex/tasks/task_e_68ddc3fdb4b883318b7c6d34b7527bc5