### PR TITLE
Replace custom comparatives with standard data tables

### DIFF
--- a/app/modules/page_data.py
+++ b/app/modules/page_data.py
@@ -1,0 +1,237 @@
+"""Helper utilities for building data tables shown in Streamlit pages.
+
+These helpers centralise the transformation of candidate payloads into
+``pandas`` objects so that Streamlit views can rely on simple, well-tested
+dataframes.  They are intentionally lightweight and avoid any Streamlit
+imports in order to remain easy to unit test.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from types import SimpleNamespace
+from typing import Iterable, Mapping, Sequence
+
+import pandas as pd
+
+
+MetricSource = Mapping[str, object] | SimpleNamespace | None
+
+
+def _safe_float(value: object | None) -> float | None:
+    """Convert ``value`` into a float when possible.
+
+    ``None`` and invalid inputs return ``None`` instead of propagating ``NaN``
+    so the calling code can decide how to display missing data.
+    """
+
+    if value is None:
+        return None
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return None
+    if pd.isna(number):  # type: ignore[arg-type]
+        return None
+    return float(number)
+
+
+def _value_from(source: MetricSource, attr: str) -> float | None:
+    """Fetch ``attr`` from ``source`` supporting mappings and namespaces."""
+
+    if source is None:
+        return None
+    if isinstance(source, Mapping):
+        return _safe_float(source.get(attr))
+    if hasattr(source, attr):
+        return _safe_float(getattr(source, attr))
+    return None
+
+
+def _format_interval(bounds: Sequence[object] | None) -> str:
+    """Return a compact string for a two-value confidence interval."""
+
+    if not isinstance(bounds, Sequence) or len(bounds) < 2:
+        return ""
+    lo = _safe_float(bounds[0])
+    hi = _safe_float(bounds[1])
+    if lo is None or hi is None:
+        return ""
+    return f"{lo:.3f} – {hi:.3f}"
+
+
+@dataclass
+class CandidateMetricConfig:
+    label: str
+    key: str
+
+
+_CANDIDATE_METRIC_CONFIG: tuple[CandidateMetricConfig, ...] = (
+    CandidateMetricConfig("Rigidez", "rigidity"),
+    CandidateMetricConfig("Estanqueidad", "tightness"),
+    CandidateMetricConfig("Energía (kWh)", "energy_kwh"),
+    CandidateMetricConfig("Agua (L)", "water_l"),
+    CandidateMetricConfig("Crew (min)", "crew_min"),
+)
+
+
+def build_candidate_metric_table(
+    props: MetricSource,
+    heuristics: MetricSource,
+    score: float | None,
+    confidence: Mapping[str, Sequence[object]] | None,
+    uncertainty: Mapping[str, object] | None,
+) -> pd.DataFrame:
+    """Return a dataframe summarising key metrics for the selected recipe."""
+
+    rows: list[dict[str, object]] = []
+
+    if score is not None:
+        rows.append(
+            {
+                "Indicador": "Score total",
+                "IA Rex-AI": float(score),
+                "Heurística": float("nan"),
+                "Δ (IA - Heurística)": float("nan"),
+                "CI 95%": "",
+                "σ": float("nan"),
+            }
+        )
+
+    confidence = confidence or {}
+    uncertainty = uncertainty or {}
+
+    for cfg in _CANDIDATE_METRIC_CONFIG:
+        ml_value = _value_from(props, cfg.key)
+        heur_value = _value_from(heuristics, cfg.key)
+        delta = None
+        if ml_value is not None and heur_value is not None:
+            delta = ml_value - heur_value
+
+        ci_text = _format_interval(confidence.get(cfg.key))
+        sigma = _safe_float(uncertainty.get(cfg.key))
+
+        rows.append(
+            {
+                "Indicador": cfg.label,
+                "IA Rex-AI": ml_value if ml_value is not None else float("nan"),
+                "Heurística": heur_value if heur_value is not None else float("nan"),
+                "Δ (IA - Heurística)": delta if delta is not None else float("nan"),
+                "CI 95%": ci_text,
+                "σ": sigma if sigma is not None else float("nan"),
+            }
+        )
+
+    df = pd.DataFrame(rows)
+    return df
+
+
+def build_resource_table(
+    props: MetricSource,
+    target_limits: Mapping[str, object] | None,
+) -> pd.DataFrame:
+    """Return a dataframe with resource usage against mission limits."""
+
+    limits = target_limits or {}
+
+    mapping = (
+        ("Energía (kWh)", "energy_kwh", limits.get("max_energy_kwh")),
+        ("Agua (L)", "water_l", limits.get("max_water_l")),
+        ("Crew (min)", "crew_min", limits.get("max_crew_min")),
+    )
+
+    rows: list[dict[str, object]] = []
+    for label, key, limit in mapping:
+        usage = _value_from(props, key)
+        limit_value = _safe_float(limit)
+        utilisation = float("nan")
+        if usage is not None and limit_value not in {None, 0}:
+            utilisation = (usage / limit_value) * 100
+        rows.append(
+            {
+                "Recurso": label,
+                "Uso": usage if usage is not None else float("nan"),
+                "Límite": limit_value if limit_value is not None else float("nan"),
+                "Utilización (%)": utilisation,
+            }
+        )
+
+    return pd.DataFrame(rows)
+
+
+def build_ranking_table(candidates: Iterable[Mapping[str, object]]) -> pd.DataFrame:
+    """Create a ranking dataframe for generator candidates."""
+
+    rows: list[dict[str, object]] = []
+    for idx, candidate in enumerate(candidates, start=1):
+        props = candidate.get("props")
+        aux = candidate.get("auxiliary") or {}
+        rows.append(
+            {
+                "Rank": idx,
+                "Score": _safe_float(candidate.get("score")),
+                "Proceso": f"{candidate.get('process_id', '')} · {candidate.get('process_name', '')}".strip(
+                    " ·"
+                ),
+                "Rigidez": _value_from(props, "rigidity"),
+                "Estanqueidad": _value_from(props, "tightness"),
+                "Energía (kWh)": _value_from(props, "energy_kwh"),
+                "Agua (L)": _value_from(props, "water_l"),
+                "Crew (min)": _value_from(props, "crew_min"),
+                "Seal": "✅" if aux.get("passes_seal", True) else "⚠️",
+                "Riesgo": aux.get("process_risk_label", "—"),
+            }
+        )
+
+    if not rows:
+        return pd.DataFrame(columns=[
+            "Rank",
+            "Score",
+            "Proceso",
+            "Rigidez",
+            "Estanqueidad",
+            "Energía (kWh)",
+            "Agua (L)",
+            "Crew (min)",
+            "Seal",
+            "Riesgo",
+        ])
+
+    df = pd.DataFrame(rows)
+    df.sort_values("Score", ascending=False, inplace=True)
+    df.reset_index(drop=True, inplace=True)
+    return df
+
+
+def build_export_kpi_table(df_plot: pd.DataFrame) -> pd.DataFrame:
+    """Aggregate KPIs for the export page."""
+
+    if df_plot.empty:
+        return pd.DataFrame(
+            [
+                {
+                    "KPI": "Opciones válidas",
+                    "Valor": 0.0,
+                }
+            ]
+        )
+
+    rows = [
+        {"KPI": "Opciones válidas", "Valor": float(len(df_plot))},
+        {"KPI": "Score máximo", "Valor": float(df_plot["Score"].max())},
+        {"KPI": "Mín. Agua", "Valor": float(df_plot["Agua (L)"].min())},
+        {"KPI": "Mín. Energía", "Valor": float(df_plot["Energía (kWh)"].min())},
+    ]
+
+    for column, label in [
+        ("ρ ref (g/cm³)", "ρ ref promedio"),
+        ("σₜ ref (MPa)", "σₜ ref promedio"),
+        ("σₜ Al (MPa)", "σₜ Al promedio"),
+    ]:
+        if column in df_plot:
+            series = pd.to_numeric(df_plot[column], errors="coerce").dropna()
+            if not series.empty:
+                rows.append({"KPI": label, "Valor": float(series.mean())})
+
+    return pd.DataFrame(rows)
+

--- a/tests/pages/test_page_data_tables.py
+++ b/tests/pages/test_page_data_tables.py
@@ -1,0 +1,76 @@
+from types import SimpleNamespace
+
+import pandas as pd
+import pytest
+
+from app.modules.page_data import (
+    build_candidate_metric_table,
+    build_export_kpi_table,
+    build_ranking_table,
+    build_resource_table,
+)
+
+
+def test_candidate_metric_table_includes_uncertainty_and_ci():
+    props = SimpleNamespace(
+        rigidity=0.82,
+        tightness=0.64,
+        energy_kwh=1.25,
+        water_l=0.42,
+        crew_min=38.0,
+    )
+    heur = {
+        "rigidity": 0.75,
+        "tightness": 0.6,
+        "energy_kwh": 1.4,
+        "water_l": 0.5,
+        "crew_min": 45.0,
+    }
+    ci = {"rigidity": (0.7, 0.9)}
+    uncertainty = {"rigidity": 0.055}
+
+    df = build_candidate_metric_table(props, heur, score=0.78, confidence=ci, uncertainty=uncertainty)
+
+    assert "Indicador" in df.columns
+    rigidity = df[df["Indicador"] == "Rigidez"].iloc[0]
+    assert rigidity["σ"] == pytest.approx(0.055)
+    assert rigidity["CI 95%"] == "0.700 – 0.900"
+    score_row = df[df["Indicador"] == "Score total"].iloc[0]
+    assert score_row["IA Rex-AI"] == pytest.approx(0.78)
+
+
+def test_resource_table_tracks_utilisation():
+    props = SimpleNamespace(energy_kwh=1.0, water_l=0.5, crew_min=30)
+    limits = {"max_energy_kwh": 2.0, "max_water_l": 1.0, "max_crew_min": 60}
+
+    df = build_resource_table(props, limits)
+    assert set(df["Recurso"]) == {"Energía (kWh)", "Agua (L)", "Crew (min)"}
+    energy_row = df[df["Recurso"] == "Energía (kWh)"].iloc[0]
+    assert energy_row["Utilización (%)"] == pytest.approx(50.0)
+
+
+def test_ranking_table_orders_by_score():
+    candidates = [
+        {"score": 0.6, "process_id": "P02", "process_name": "Laminar", "props": SimpleNamespace(rigidity=0.7, tightness=0.5, energy_kwh=1.4, water_l=0.6, crew_min=42)},
+        {"score": 0.8, "process_id": "P03", "process_name": "Sinter", "props": SimpleNamespace(rigidity=0.9, tightness=0.7, energy_kwh=1.1, water_l=0.4, crew_min=36), "auxiliary": {"passes_seal": False}},
+    ]
+
+    df = build_ranking_table(candidates)
+    assert df.iloc[0]["Score"] == pytest.approx(0.8)
+    assert df.iloc[0]["Seal"] == "⚠️"
+
+
+def test_export_kpi_table_collects_metrics():
+    df_plot = pd.DataFrame(
+        {
+            "Score": [0.7, 0.8],
+            "Energía (kWh)": [1.2, 1.0],
+            "Agua (L)": [0.5, 0.4],
+            "Crew (min)": [38, 36],
+            "ρ ref (g/cm³)": [1.1, 1.2],
+        }
+    )
+
+    kpi_df = build_export_kpi_table(df_plot)
+    assert "Opciones válidas" in kpi_df["KPI"].values
+    assert kpi_df[kpi_df["KPI"] == "Opciones válidas"]["Valor"].iloc[0] == pytest.approx(2.0)


### PR DESCRIPTION
## Summary
- add a shared `page_data` helper module that builds candidate metric, resource, ranking, and KPI tables for reuse across pages
- refactor the Results, Generator, and Pareto pages to drop luxe comparatives in favour of Streamlit dataframes and Altair charts while keeping safety, uncertainty, and consumption details visible
- add unit coverage for the new helper transformations to ensure the selected recipe, uncertainty, and resource summaries remain available to the UI

## Testing
- pytest tests/pages

------
https://chatgpt.com/codex/tasks/task_e_68ddc64519d88331bcdbb9ba20aea1a1