### PR TITLE
Refactor mission analytics pages with simplified components

### DIFF
--- a/app/pages/6_Pareto_and_Export.py
+++ b/app/pages/6_Pareto_and_Export.py
@@ -1,28 +1,25 @@
-# app/pages/6_Pareto_and_Export.py
+"""Streamlined Pareto exploration and export centre."""
+
 import _bootstrap  # noqa: F401
 
-import io
-import json
-from datetime import datetime
+import math
+from typing import Iterable
 
-import numpy as np
-import pandas as pd
-import plotly.express as px
-import plotly.graph_objects as go
 import streamlit as st
-import altair as alt
-from plotly.colors import sample_colorscale
 
 from app.modules.analytics import pareto_front
-from app.modules.explain import compare_table
 from app.modules.exporters import candidate_to_csv, candidate_to_json
-from app.modules.navigation import render_breadcrumbs, set_active_step
-from app.modules.safety import check_safety, safety_badge  # recalcular badge al seleccionar
-from app.modules.ui_blocks import futuristic_button, load_theme
 from app.modules.io import load_waste_df
-from app.modules.page_data import build_export_kpi_table
+from app.modules.navigation import render_breadcrumbs, set_active_step
+from app.modules.page_data import (
+    build_candidate_export_table,
+    build_export_kpi_table,
+    build_material_summary_table,
+)
+from app.modules.safety import check_safety, safety_badge
+from app.modules.ui_blocks import layout_stack, load_theme
 
-# ⚠️ PRIMERA llamada
+
 st.set_page_config(page_title="Pareto & Export", page_icon="📤", layout="wide")
 
 current_step = set_active_step("export")
@@ -31,1273 +28,187 @@ load_theme()
 
 render_breadcrumbs(current_step)
 
-# Columnas externas (polímeros / aluminio)
-POLYMER_NUMERIC_COLUMNS = (
-    "pc_density_density_g_per_cm3",
-    "pc_mechanics_tensile_strength_mpa",
-    "pc_mechanics_modulus_gpa",
-    "pc_thermal_glass_transition_c",
-    "pc_ignition_ignition_temperature_c",
-    "pc_ignition_burn_time_min",
-)
 
-ALUMINIUM_NUMERIC_COLUMNS = (
-    "aluminium_tensile_strength_mpa",
-    "aluminium_yield_strength_mpa",
-    "aluminium_elongation_pct",
-)
-
-POLYMER_LABEL_MAP = {
-    "density_g_cm3": "ρ ref (g/cm³)",
-    "tensile_mpa": "σₜ ref (MPa)",
-    "modulus_gpa": "E ref (GPa)",
-    "glass_c": "Tg (°C)",
-    "ignition_c": "Ignición (°C)",
-    "burn_min": "Burn (min)",
-}
-
-ALUMINIUM_LABEL_MAP = {
-    "tensile_mpa": "σₜ Al (MPa)",
-    "yield_mpa": "σᵧ Al (MPa)",
-    "elongation_pct": "ε Al (%)",
-}
-
-
-def _collect_external_profiles(candidate: dict, inventory: pd.DataFrame) -> dict[str, dict[str, float]]:
-    if not isinstance(candidate, dict) or inventory.empty:
-        return {}
-
-    ids = {str(value).strip() for value in candidate.get("source_ids", []) if str(value).strip()}
-    if not ids:
-        return {}
-
-    mask = pd.Series(False, index=inventory.index)
-    if "id" in inventory.columns:
-        mask |= inventory["id"].astype(str).isin(ids)
-    if "_source_id" in inventory.columns:
-        mask |= inventory["_source_id"].astype(str).isin(ids)
-
-    subset = inventory.loc[mask]
-    if subset.empty:
-        return {}
-
-    payload: dict[str, dict[str, float]] = {}
-
-    def _aggregate(section_columns: tuple[str, ...], mapping: dict[str, str]) -> dict[str, float] | None:
-        relevant = [column for column in section_columns if column in subset.columns]
-        if not relevant:
-            return None
-
-        rows = subset[relevant].apply(pd.to_numeric, errors="coerce")
-        if not rows.notna().any().any():
-            return None
-
-        section_metrics: dict[str, float] = {}
-        for column in relevant:
-            series = pd.to_numeric(subset[column], errors="coerce")
-            if not series.notna().any():
-                continue
-            value = float(series.mean())
-            if column == "pc_density_density_g_per_cm3":
-                section_metrics.setdefault("density_g_cm3", value)
-            elif column == "pc_mechanics_tensile_strength_mpa":
-                section_metrics.setdefault("tensile_mpa", value)
-            elif column == "pc_mechanics_modulus_gpa":
-                section_metrics.setdefault("modulus_gpa", value)
-            elif column == "pc_thermal_glass_transition_c":
-                section_metrics.setdefault("glass_c", value)
-            elif column == "pc_ignition_ignition_temperature_c":
-                section_metrics.setdefault("ignition_c", value)
-            elif column == "pc_ignition_burn_time_min":
-                section_metrics.setdefault("burn_min", value)
-            elif column == "aluminium_tensile_strength_mpa":
-                section_metrics.setdefault("tensile_mpa", value)
-            elif column == "aluminium_yield_strength_mpa":
-                section_metrics.setdefault("yield_mpa", value)
-            elif column == "aluminium_elongation_pct":
-                section_metrics.setdefault("elongation_pct", value)
-
-        if not section_metrics:
-            return None
-
-        ordered_metrics: dict[str, float] = {}
-        for key in mapping.keys():
-            if key in section_metrics:
-                ordered_metrics[key] = section_metrics[key]
-        for key, value in section_metrics.items():
-            ordered_metrics.setdefault(key, value)
-        return ordered_metrics
-
-    polymer_metrics = _aggregate(POLYMER_NUMERIC_COLUMNS, POLYMER_LABEL_MAP)
-    if polymer_metrics:
-        payload["polymer"] = polymer_metrics
-
-    aluminium_metrics = _aggregate(ALUMINIUM_NUMERIC_COLUMNS, ALUMINIUM_LABEL_MAP)
-    if aluminium_metrics:
-        payload["aluminium"] = aluminium_metrics
-
-    return payload
-
-
-# ======== estado requerido ========
-cands  = st.session_state.get("candidates", [])
-target = st.session_state.get("target", None)
-state_sel = st.session_state.get("selected", None)
-
-st.session_state.setdefault("export_history", [])
-st.session_state.setdefault("export_wizard_step", 1)
-st.session_state.setdefault("selected_export_format", "Plan JSON")
-st.session_state.setdefault("last_export_payload", None)
-st.session_state.setdefault("selected_option_number", None)
-st.session_state.setdefault("export_payload_cache", {})
-
-selected_candidate = state_sel["data"] if state_sel else None
-safety_flags = state_sel["safety"] if state_sel else None
-
-if selected_candidate and not st.session_state.get("selected_option_number"):
+def _safe_float(value: object, fallback: float | None = None) -> float | None:
     try:
-        matched_idx = next(idx for idx, cand in enumerate(cands, start=1) if cand is selected_candidate)
-        st.session_state["selected_option_number"] = matched_idx
-    except StopIteration:
-        pass
-
-safety_summary = safety_badge(safety_flags) if safety_flags else {"level": "Sin datos", "detail": "Seleccioná un candidato."}
-
-if not cands or not target:
-    st.warning("Generá opciones en **3) Generador** primero.")
-    st.stop()
-
-inventory_df = load_waste_df()
-
-
-
-def render_safety_badges_html(flags) -> str:
-    if not flags:
-        return "<span class='safety-badge'>Sin evaluación</span>"
-    badges = []
-    checklist = [
-        (not getattr(flags, "pfas", False), "PFAS sweep"),
-        (not getattr(flags, "microplastics", False), "Microplásticos"),
-        (not getattr(flags, "incineration", False), "Incineración"),
-    ]
-    for ok, label in checklist:
-        state = "OK" if ok else "Revisar"
-        css = "safety-badge ok" if ok else "safety-badge alert"
-        badges.append(f"<span class='{css}'>{label}: {state}</span>")
-    return "".join(badges)
-
-# ======== HERO ========
-st.title("📤 Pareto & Export")
-st.caption(
-    "Explorá el trade-off Energía ↔ Agua ↔ Crew con datos reales de tus candidatos y exportá el plan enlazado al objetivo definido en 2) Target."
-)
-st.markdown(
-    "- Paso 1: Explorá el frente Pareto con los filtros inferiores.\n"
-    "- Paso 2: Seleccioná la opción priorizada por la misión.\n"
-    "- Paso 3: Exportá el plan para compartirlo con la tripulación."
-)
-
-# ======== tabla base (derivada de candidates reales) ========
-df_raw = compare_table(cands, target, crew_time_low=target.get("crew_time_low", False)).copy()
-
-# Enlazar métricas externas por Opción
-external_profiles_by_option: dict[int, dict[str, dict[str, float]]] = {}
-for idx, candidate in enumerate(cands, start=1):
-    profiles = _collect_external_profiles(candidate, inventory_df)
-    if profiles:
-        external_profiles_by_option[idx] = profiles
-
-
-def _metric_for(option_value: object, section: str, key: str) -> float:
-    try:
-        option_number = int(option_value)
-    except (TypeError, ValueError):
-        return float("nan")
-
-    section_payload = external_profiles_by_option.get(option_number, {}).get(section, {})
-    value = section_payload.get(key)
-    if value is None:
-        return float("nan")
-    try:
-        return float(value)
-    except (TypeError, ValueError):
-        return float("nan")
-
-
-external_columns = [
-    ("polymer", "density_g_cm3", "ρ ref (g/cm³)", 3),
-    ("polymer", "tensile_mpa", "σₜ ref (MPa)", 1),
-    ("polymer", "modulus_gpa", "E ref (GPa)", 2),
-    ("polymer", "glass_c", "Tg (°C)", 1),
-    ("polymer", "ignition_c", "Ignición (°C)", 0),
-    ("polymer", "burn_min", "Burn (min)", 1),
-    ("aluminium", "tensile_mpa", "σₜ Al (MPa)", 1),
-    ("aluminium", "yield_mpa", "σᵧ Al (MPa)", 1),
-    ("aluminium", "elongation_pct", "ε Al (%)", 1),
-]
-
-option_series = pd.to_numeric(df_raw.get("Opción"), errors="coerce") if "Opción" in df_raw else pd.Series(dtype=float)
-for section, key, label, _precision in external_columns:
-    df_raw[label] = option_series.map(lambda opt: _metric_for(opt, section, key))
-
-# Normalización robusta de nombres
-rename_map = {}
-for col in df_raw.columns:
-    low = col.lower().strip()
-    if low in ["energia (kwh)", "energía (kwh)", "energia kwh"]: rename_map[col] = "Energía (kWh)"
-    if low in ["agua (l)", "agua l", "agua"]: rename_map[col] = "Agua (L)"
-    if low in ["crew (min)", "crew min", "crew"]: rename_map[col] = "Crew (min)"
-    if low in ["masa (kg)", "masa kg", "kg"]: rename_map[col] = "Masa (kg)"
-    if low in ["opción","opcion"]: rename_map[col] = "Opción"
-    if low == "materiales": rename_map[col] = "Materiales"
-    if low == "proceso": rename_map[col] = "Proceso"
-    if low == "score": rename_map[col] = "Score"
-df_raw.rename(columns=rename_map, inplace=True)
-
-# Tipos y saneo
-for k in ["Score","Energía (kWh)","Agua (L)","Crew (min)","Masa (kg)"]:
-    if k in df_raw: df_raw[k] = pd.to_numeric(df_raw[k], errors="coerce")
-if "Materiales" in df_raw:
-    df_raw["Materiales"] = df_raw["Materiales"].apply(
-        lambda v: ", ".join(v) if isinstance(v, (list,tuple)) else (str(v) if pd.notna(v) else "")
-    )
-
-df_plot = df_raw.dropna(subset=["Energía (kWh)","Agua (L)","Crew (min)","Score"]).copy()
-
-# ======== KPIs ========
-kpi_df = build_export_kpi_table(df_plot)
-st.subheader("Indicadores del lote")
-kpi_style = kpi_df.style.format({"Valor": "{:.3f}"})
-try:
-    kpi_style = kpi_style.hide(axis="index")
-except AttributeError:
-    kpi_style = kpi_style.hide_index()
-st.dataframe(kpi_style, use_container_width=True)
-
-kpi_chart = alt.Chart(kpi_df).mark_bar(color="#38bdf8").encode(
-    x=alt.X("Valor:Q", title="Valor"),
-    y=alt.Y("KPI:N", sort="-x"),
-    tooltip=["KPI", alt.Tooltip("Valor", format=".3f")],
-).properties(height=220)
-st.altair_chart(kpi_chart, use_container_width=True)
-
-# ======== What-If de límites ========
-st.markdown("### 🎛️ What-If (filtro visual)")
-
-what_if_presets = {
-    "Residence": {
-        "label": "Residence Renovations (volumen alto)",
-        "button_label": "Residence",
-        "energy": 1.8,
-        "water": 0.28,
-        "crew": 36.0,
-        "insight": "Favorece piezas voluminosas optimizando agua y minutos de tripulación.",
-    },
-    "Daring": {
-        "label": "Daring Discoveries (reuso de carbono)",
-        "button_label": "Daring",
-        "energy": 1.1,
-        "water": 0.15,
-        "crew": 28.0,
-        "insight": "Maximiza el reuso de carbono con operaciones de baja energía y agua controlada.",
-    },
-}
-
-def _safe_float(value, fallback: float = 0.0) -> float:
-    try:
-        return float(value)
+        number = float(value)
     except (TypeError, ValueError):
         return fallback
-
-target_signature = (
-    round(_safe_float(target.get("max_energy_kwh", 0.0)), 3),
-    round(_safe_float(target.get("max_water_l", 0.0)), 3),
-    round(_safe_float(target.get("max_crew_min", 0.0)), 1),
-    str(target.get("scenario", "")),
-)
-
-if st.session_state.get("__what_if_signature") != target_signature:
-    st.session_state["__what_if_energy"] = _safe_float(target.get("max_energy_kwh", 0.0))
-    st.session_state["__what_if_water"] = _safe_float(target.get("max_water_l", 0.0))
-    st.session_state["__what_if_crew"] = _safe_float(target.get("max_crew_min", 0.0))
-    st.session_state["__what_if_signature"] = target_signature
-    st.session_state["__what_if_active_preset"] = None
+    if math.isnan(number):
+        return fallback
+    return number
 
 
-def _apply_what_if_preset(preset_key: str) -> None:
-    preset_cfg = what_if_presets[preset_key]
-    st.session_state["__what_if_energy"] = _safe_float(preset_cfg["energy"], 0.0)
-    st.session_state["__what_if_water"] = _safe_float(preset_cfg["water"], 0.0)
-    st.session_state["__what_if_crew"] = _safe_float(preset_cfg["crew"], 0.0)
-    st.session_state["__what_if_active_preset"] = preset_key
+candidates: Iterable[dict] = st.session_state.get("candidates", [])
+target = st.session_state.get("target")
+selected_state = st.session_state.get("selected")
 
+if not candidates or not target:
+    st.warning("Generá candidatos en **3 · Generador** y definí un objetivo en **2 · Target Designer**.")
+    st.stop()
 
-preset_cols = st.columns([1.3, 1, 1])
-with preset_cols[0]:
-    st.caption(
-        "Activá límites sugeridos NASA según el foco del escenario y ajustá manualmente si lo necesitás."
-    )
-for col, preset_key in zip(preset_cols[1:], ("Residence", "Daring")):
-    with col:
-        cfg = what_if_presets[preset_key]
-        if st.button(cfg["button_label"], use_container_width=True):
-            _apply_what_if_preset(preset_key)
-        st.caption(
-            f"≤ {cfg['energy']:.2f} kWh · {cfg['water']:.2f} L · {cfg['crew']:.0f} min"
-        )
-
-f1, f2, f3 = st.columns(3)
-with f1:
-    lim_e = st.number_input(
-        "Límite de Energía (kWh)",
-        min_value=0.0,
-        max_value=999.0,
-        value=_safe_float(
-            st.session_state.get("__what_if_energy", target.get("max_energy_kwh", 0.0))
-        ),
-        step=0.1,
-        key="__what_if_energy",
-    )
-with f2:
-    lim_w = st.number_input(
-        "Límite de Agua (L)",
-        min_value=0.0,
-        max_value=999.0,
-        value=_safe_float(
-            st.session_state.get("__what_if_water", target.get("max_water_l", 0.0))
-        ),
-        step=0.1,
-        key="__what_if_water",
-    )
-with f3:
-    lim_c = st.number_input(
-        "Límite de Crew (min)",
-        min_value=0.0,
-        max_value=999.0,
-        value=_safe_float(
-            st.session_state.get("__what_if_crew", target.get("max_crew_min", 0.0))
-        ),
-        step=1.0,
-        key="__what_if_crew",
-    )
-
-current_limits = {
-    "energy": _safe_float(lim_e),
-    "water": _safe_float(lim_w),
-    "crew": _safe_float(lim_c),
-}
-
-matched_preset = None
-for preset_name, preset_cfg in what_if_presets.items():
-    if (
-        abs(current_limits["energy"] - _safe_float(preset_cfg["energy"])) < 1e-6
-        and abs(current_limits["water"] - _safe_float(preset_cfg["water"])) < 1e-6
-        and abs(current_limits["crew"] - _safe_float(preset_cfg["crew"])) < 1e-6
-    ):
-        matched_preset = preset_name
-        break
-
-st.session_state["__what_if_active_preset"] = matched_preset
-
-mask_ok = (
-    (df_plot["Energía (kWh)"] <= current_limits["energy"])
-    & (df_plot["Agua (L)"] <= current_limits["water"])
-    & (df_plot["Crew (min)"] <= current_limits["crew"])
-)
-df_view = df_plot.copy()
-df_view["Dentro_límites"] = np.where(mask_ok, "Dentro de límites", "Excede límites")
-
-# ======== Frontera de Pareto ========
-try:
-    front_idx = pareto_front(df_plot)
-    front_mask = df_plot.index.isin(front_idx)
-except Exception:
-    # fallback estable si el usuario sube columnas raras
-    front_mask = df_plot["Score"].rank(ascending=False, method="first") <= 5
-df_view["Pareto"] = np.where(front_mask, "Pareto", "No Pareto")
-df_view["ScorePos"] = np.clip(df_view["Score"].fillna(0.0), 0.01, None)
-table_pareto = df_view[df_view["Pareto"] == "Pareto"].sort_values("Score", ascending=False)
-pareto_options = table_pareto["Opción"].astype(int).tolist() if "Opción" in table_pareto else []
-
+selected_candidate = selected_state["data"] if isinstance(selected_state, dict) else None
+selected_badge = selected_state.get("safety") if isinstance(selected_state, dict) else None
 selected_option_number = st.session_state.get("selected_option_number")
 
-# ======== Sidebar – Flight Plans & Previews ========
-sidebar = st.sidebar
-sidebar.markdown("<div class='sidebar-flight'><h2>🛫 Flight Plans</h2></div>", unsafe_allow_html=True)
+inventory_df = load_waste_df()
+export_df = build_candidate_export_table(candidates, inventory_df)
 
-flash_event = st.session_state.pop("flight_flash", None)
-if flash_event:
-    sidebar.markdown(
-        f"<div class='flight-alert animate'>Flight plan #{flash_event.get('option', '—')} listo para export. Revisá la Nebula preview.</div>",
-        unsafe_allow_html=True,
+with layout_stack():
+    st.title("📤 Pareto & Export")
+    st.caption(
+        "Explorá la frontera de Pareto con límites reales y exportá el plan priorizado "
+        "para compartirlo con la tripulación."
     )
 
-if table_pareto.empty:
-    sidebar.info("Generá candidatos para visualizar planes de vuelo.")
-else:
-    for _, row in table_pareto.head(4).iterrows():
-        option_number = int(row.get("Opción", 0))
-        energy = row.get("Energía (kWh)", 0.0)
-        water = row.get("Agua (L)", 0.0)
-        crew = row.get("Crew (min)", 0.0)
-        score_val = row.get("Score", 0.0)
-        rho_val = row.get("ρ ref (g/cm³)")
-        tensile_val = row.get("σₜ ref (MPa)")
-        tensile_al_val = row.get("σₜ Al (MPa)")
+kpi_df = build_export_kpi_table(export_df)
+if not kpi_df.empty:
+    kpi_lookup = {row["KPI"]: row["Valor"] for _, row in kpi_df.iterrows()}
+    metrics = [
+        ("Opciones válidas", kpi_lookup.get("Opciones válidas")),
+        ("Score máximo", kpi_lookup.get("Score máximo")),
+        ("Mín. Agua", kpi_lookup.get("Mín. Agua")),
+        ("Mín. Energía", kpi_lookup.get("Mín. Energía")),
+    ]
+    metric_columns = st.columns(len(metrics))
+    for column, (label, value) in zip(metric_columns, metrics):
+        display = "—" if value is None or (isinstance(value, float) and math.isnan(value)) else f"{value:.3f}"
+        column.metric(label, display)
 
-        def _fmt(value: object, precision: int, suffix: str) -> str:
-            try:
-                return f"{float(value):.{precision}f}{suffix}"
-            except (TypeError, ValueError):
-                return "—"
-
-        active_cls = " active" if selected_option_number and option_number == int(selected_option_number) else ""
-        sidebar.markdown(
-            f"<div class='flight-card{active_cls}'>"
-            f"<strong>Plan #{option_number}</strong>"
-            f"<span>Score: {score_val:.2f}</span>"
-            f"<span>Energía: {energy:.2f} kWh · Agua: {water:.2f} L · Crew: {crew:.1f} min</span>"
-            f"<span>ρ ref {_fmt(rho_val, 3, ' g/cm³')} · σₜ {_fmt(tensile_val, 1, ' MPa')} · σₜ Al {_fmt(tensile_al_val, 1, ' MPa')}</span>"
-            "</div>",
-            unsafe_allow_html=True,
+limits_container = st.container()
+with limits_container:
+    st.subheader("Límites activos")
+    defaults = {
+        "energy": _safe_float(target.get("max_energy_kwh"), fallback=_safe_float(export_df["Energía (kWh)"].max())),
+        "water": _safe_float(target.get("max_water_l"), fallback=_safe_float(export_df["Agua (L)"].max())),
+        "crew": _safe_float(target.get("max_crew_min"), fallback=_safe_float(export_df["Crew (min)"].max())),
+    }
+    col_energy, col_water, col_crew = st.columns(3)
+    with col_energy:
+        limit_energy = st.number_input(
+            "Máximo de energía (kWh)",
+            min_value=0.0,
+            value=defaults["energy"] or 0.0,
+            step=0.05,
+            key="export_limit_energy",
+        )
+    with col_water:
+        limit_water = st.number_input(
+            "Máximo de agua (L)",
+            min_value=0.0,
+            value=defaults["water"] or 0.0,
+            step=0.05,
+            key="export_limit_water",
+        )
+    with col_crew:
+        limit_crew = st.number_input(
+            "Máximo de crew (min)",
+            min_value=0.0,
+            value=defaults["crew"] or 0.0,
+            step=1.0,
+            key="export_limit_crew",
         )
 
-if selected_candidate:
-    props = selected_candidate.get("props")
-    materials = ", ".join(selected_candidate.get("materials", [])[:3])
-    if selected_candidate.get("materials") and len(selected_candidate["materials"]) > 3:
-        materials += "…"
-    profile_payload: dict[str, dict[str, float]] = {}
-    try:
-        if selected_option_number:
-            profile_payload = external_profiles_by_option.get(int(selected_option_number), {}) or {}
-    except (TypeError, ValueError):
-        profile_payload = {}
+filtered_df = export_df.copy()
+filtered_df = filtered_df[
+    (filtered_df["Energía (kWh)"].le(limit_energy) | filtered_df["Energía (kWh)"].isna())
+    & (filtered_df["Agua (L)"].le(limit_water) | filtered_df["Agua (L)"].isna())
+    & (filtered_df["Crew (min)"].le(limit_crew) | filtered_df["Crew (min)"].isna())
+]
 
-    def _format_profile_section(metrics: dict[str, float]) -> str:
-        if not metrics:
-            return "—"
-        formatted: list[str] = []
-        for key, label in (
-            ("density_g_cm3", "ρ ref"),
-            ("tensile_mpa", "σₜ"),
-            ("modulus_gpa", "E"),
-            ("glass_c", "Tg"),
-            ("ignition_c", "Ign"),
-            ("burn_min", "Burn"),
-            ("yield_mpa", "σᵧ"),
-            ("elongation_pct", "ε"),
-        ):
-            value = metrics.get(key)
-            if value is None:
-                continue
-            suffix = ""
-            if key == "density_g_cm3":
-                suffix = " g/cm³"
-            elif key in {"tensile_mpa", "yield_mpa"}:
-                suffix = " MPa"
-            elif key in {"glass_c", "ignition_c"}:
-                suffix = " °C"
-            elif key == "burn_min":
-                suffix = " min"
-            elif key == "elongation_pct":
-                suffix = " %"
-            try:
-                formatted.append(f"{label} {float(value):.2f}{suffix}")
-            except (TypeError, ValueError):
-                continue
-        return " · ".join(formatted) if formatted else "—"
+pareto_indices: list[int] = []
+if not filtered_df.empty:
+    required = ["Energía (kWh)", "Agua (L)", "Crew (min)", "Score"]
+    if all(column in filtered_df.columns for column in required):
+        pareto_indices = pareto_front(filtered_df[required])
+filtered_df["En Pareto"] = filtered_df.index.isin(pareto_indices)
 
-    polymer_preview = _format_profile_section(profile_payload.get("polymer", {}))
-    aluminium_preview = _format_profile_section(profile_payload.get("aluminium", {}))
-    sidebar.markdown(
-        "<h3 style='margin-top:14px;'>Nebula preview</h3>",
-        unsafe_allow_html=True,
+option_numbers = filtered_df["Opción"].dropna().astype(int).tolist()
+if option_numbers:
+    default_index = 0
+    if selected_option_number in option_numbers:
+        default_index = option_numbers.index(int(selected_option_number))
+    chosen_option = st.selectbox(
+        "Seleccioná el plan prioritario",
+        option_numbers,
+        index=default_index,
+        key="export_active_option",
     )
-    sidebar.markdown(
-        "<div class='safety-badges'>" + render_safety_badges_html(safety_flags) + "</div>",
-        unsafe_allow_html=True,
-    )
-    if props:
-        sidebar.markdown(
-            """
-            <div class='nebula-preview'>
-              <strong>{label}</strong><br/>
-              Proceso: {proc}<br/>
-              Materiales: {mats}<br/>
-              Score: {score:.2f} · Energía: {energy:.2f} kWh · Agua: {water:.2f} L · Crew: {crew:.1f} min
-              <br/>Polímero: {poly}<br/>Aluminio: {alum}
-            </div>
-            """.format(
-                label=f"Plan #{selected_option_number or '—'}",
-                proc=f"{selected_candidate.get('process_id', '')} {selected_candidate.get('process_name', '')}".strip(),
-                mats=materials or "—",
-                score=selected_candidate.get("score", 0.0),
-                energy=getattr(props, "energy_kwh", 0.0),
-                water=getattr(props, "water_l", 0.0),
-                crew=getattr(props, "crew_min", 0.0),
-                poly=polymer_preview,
-                alum=aluminium_preview,
-            ),
-            unsafe_allow_html=True,
-        )
+    if chosen_option != selected_option_number:
+        idx = chosen_option - 1
+        if 0 <= idx < len(candidates):
+            candidate = candidates[idx]
+            materials = [str(item) for item in candidate.get("materials", [])]
+            process_name = str(candidate.get("process_name") or "")
+            process_id = str(candidate.get("process_id") or "")
+            flags = check_safety(materials, process_name, process_id)
+            badge = safety_badge(flags)
+            badge.update(
+                {
+                    "pfas": bool(getattr(flags, "pfas", False)),
+                    "microplastics": bool(getattr(flags, "microplastics", False)),
+                    "incineration": bool(getattr(flags, "incineration", False)),
+                }
+            )
+            st.session_state["selected"] = {"data": candidate, "safety": badge}
+            selected_candidate = candidate
+            selected_badge = badge
+        st.session_state["selected_option_number"] = chosen_option
+        selected_option_number = chosen_option
 
-    fmt_choice = st.session_state.get("selected_export_format", "Plan JSON")
-    sidebar.caption(f"Formato seleccionado: {fmt_choice}")
-    try:
-        if fmt_choice == "Plan JSON" and safety_flags:
-            preview = candidate_to_json(selected_candidate, target, safety_flags).decode("utf-8")
-            preview_lines = preview.splitlines()
-            sidebar.code("\n".join(preview_lines[:10]) + ("\n…" if len(preview_lines) > 10 else ""), language="json")
-        elif fmt_choice == "Resumen CSV":
-            csv_text = candidate_to_csv(selected_candidate).decode("utf-8")
-            preview_lines = csv_text.splitlines()
-            sidebar.code("\n".join(preview_lines[:8]) + ("\n…" if len(preview_lines) > 8 else ""), language="csv")
-        elif fmt_choice == "Pareto CSV":
-            sidebar.dataframe(table_pareto.head(6), use_container_width=True, hide_index=True)
-    except Exception as preview_error:
-        sidebar.warning(f"No se pudo generar preview: {preview_error}")
+selected_series = filtered_df["Opción"].fillna(0).astype(int)
+filtered_df["Seleccionado"] = selected_series == int(selected_option_number or 0)
 
-
-tab_pareto, tab_trials, tab_objectives, tab_export = st.tabs(
-    ["🌌 Pareto Explorer", "🔮 Predicciones de ensayo (demo)", "🎯 Objetivos por eje", "📦 Export Center"]
+st.subheader("Opciones dentro de límites")
+st.dataframe(
+    filtered_df,
+    use_container_width=True,
+    hide_index=True,
 )
 
-# ---------- TAB 1: Pareto Explorer ----------
-with tab_pareto:
-    st.markdown('<h3 class="section-title">Explorador 3D</h3>', unsafe_allow_html=True)
-    usable = df_view.dropna(subset=["Energía (kWh)","Agua (L)","Crew (min)","ScorePos"]).copy()
+materials_df = build_material_summary_table(candidates)
+if not materials_df.empty:
+    st.subheader("Top residuos aportados")
+    st.dataframe(materials_df, use_container_width=True, hide_index=True)
 
-    if usable.empty:
-        st.info("No hay suficientes datos para graficar.")
-    else:
-        active_preset = st.session_state.get("__what_if_active_preset")
-        explanation_lines: list[str] = []
-        for preset_key, preset_cfg in what_if_presets.items():
-            preset_mask = (
-                (df_view["Pareto"] == "Pareto")
-                & (df_view["Energía (kWh)"] <= _safe_float(preset_cfg["energy"]))
-                & (df_view["Agua (L)"] <= _safe_float(preset_cfg["water"]))
-                & (df_view["Crew (min)"] <= _safe_float(preset_cfg["crew"]))
-            )
-            subset = df_view[preset_mask].sort_values("Score", ascending=False)
-            if subset.empty:
-                detail = (
-                    "sin candidatos Pareto dentro de los límites sugeridos "
-                    f"(≤ {preset_cfg['energy']:.2f} kWh · {preset_cfg['water']:.2f} L · {preset_cfg['crew']:.0f} min)."
-                )
-            else:
-                top_row = subset.iloc[0]
-                option_raw = top_row.get("Opción")
-                option_label = (
-                    f"Plan #{int(option_raw)}" if pd.notna(option_raw) else "Plan destacado"
-                )
-                detail = (
-                    f"{option_label} lidera con Score {top_row['Score']:.2f}, "
-                    f"{top_row['Energía (kWh)']:.2f} kWh, {top_row['Agua (L)']:.2f} L y "
-                    f"{top_row['Crew (min)']:.1f} min. {preset_cfg['insight']}"
-                )
-                if subset.shape[0] > 1:
-                    detail += f" ({subset.shape[0]} planes dentro de límites.)"
-            marker = "⭐" if preset_key == active_preset else "•"
-            explanation_lines.append(
-                f"- {marker} **{preset_cfg['label']}**: {detail}"
-            )
+if selected_candidate and isinstance(selected_badge, dict):
+    st.subheader("Estado del plan seleccionado")
+    st.markdown(
+        f"**Opción #{int(selected_option_number)}** — {selected_candidate.get('process_name', 'Proceso')}"
+    )
+    st.caption(f"Seguridad: {selected_badge.get('level', '—')} · {selected_badge.get('detail', '')}")
+else:
+    st.info("Seleccioná un plan para habilitar la exportación.")
 
-        st.markdown("#### Dominio Pareto por escenario")
-        st.markdown("\n".join(explanation_lines))
-        st.caption("⭐ indica el preset aplicado en los filtros What-If.")
+st.markdown("---")
 
-        if "Opción" in usable:
-            usable["Opción"] = pd.to_numeric(usable["Opción"], errors="coerce")
-
-        pareto_points = usable[usable["Pareto"] == "Pareto"].copy()
-        other_points = usable[usable["Pareto"] != "Pareto"].copy()
-
-        def _color_scale(values: pd.Series, scale: str) -> list[str]:
-            if values.empty:
-                return []
-            vals = values.fillna(values.mean() if not values.empty else 0.0)
-            vmin, vmax = float(vals.min()), float(vals.max())
-            if abs(vmax - vmin) < 1e-9:
-                norm = [0.5] * len(vals)
-            else:
-                norm = ((vals - vmin) / (vmax - vmin)).clip(0.0, 1.0).tolist()
-            return sample_colorscale(scale, norm)
-
-        def _safe_series(df: pd.DataFrame, key: str) -> pd.Series:
-            if key in df:
-                return df[key]
-            return pd.Series(np.nan, index=df.index)
-
-        def _hover_matrix(df: pd.DataFrame) -> np.ndarray:
-            if df.empty:
-                return np.empty((0, 5), dtype=object)
-            option_series = pd.to_numeric(_safe_series(df, "Opción"), errors="coerce")
-            score_series = pd.to_numeric(_safe_series(df, "Score"), errors="coerce")
-            rho_series = pd.to_numeric(_safe_series(df, "ρ ref (g/cm³)"), errors="coerce")
-            tensile_series = pd.to_numeric(_safe_series(df, "σₜ ref (MPa)"), errors="coerce")
-            tensile_al_series = pd.to_numeric(_safe_series(df, "σₜ Al (MPa)"), errors="coerce")
-
-            def _fmt(values: pd.Series, precision: int, suffix: str = "") -> np.ndarray:
-                formatted: list[str] = []
-                for value in values:
-                    if pd.isna(value):
-                        formatted.append("—")
-                    else:
-                        formatted.append(f"{value:.{precision}f}{suffix}")
-                return np.array(formatted, dtype=object)
-
-            option_text = np.where(option_series.notna(), option_series.fillna(0).astype(int).astype(str), "—")
-            return np.column_stack(
-                [
-                    option_text,
-                    _fmt(score_series, 2),
-                    _fmt(rho_series, 3, " g/cm³"),
-                    _fmt(tensile_series, 1, " MPa"),
-                    _fmt(tensile_al_series, 1, " MPa"),
-                ]
-            )
-
-        fig3d = go.Figure()
-
-        if not other_points.empty:
-            fig3d.add_trace(
-                go.Scatter3d(
-                    x=other_points["Energía (kWh)"],
-                    y=other_points["Agua (L)"],
-                    z=other_points["Crew (min)"],
-                    mode="markers",
-                    name="Candidatos",
-                    marker=dict(
-                        size=6,
-                        color=_color_scale(other_points["Score"], "Viridis"),
-                        opacity=0.45,
-                        line=dict(width=1.2, color="rgba(148,163,184,0.4)"),
-                        symbol="circle",
-                    ),
-                    hovertemplate=(
-                        "<b>Opción %{customdata[0]}</b><br>Score %{customdata[1]}<br>"
-                        "ρ ref %{customdata[2]}<br>σₜ %{customdata[3]}<br>σₜ Al %{customdata[4]}<extra></extra>"
-                    ),
-                    customdata=_hover_matrix(other_points),
-                )
-            )
-
-        if not pareto_points.empty:
-            pareto_colors = _color_scale(pareto_points["Score"], "IceFire")
-            fig3d.add_trace(
-                go.Scatter3d(
-                    x=pareto_points["Energía (kWh)"],
-                    y=pareto_points["Agua (L)"],
-                    z=pareto_points["Crew (min)"],
-                    mode="markers",
-                    name="Pareto Prime",
-                    marker=dict(
-                        size=11,
-                        color=pareto_colors,
-                        opacity=0.98,
-                        symbol="diamond",
-                        line=dict(width=3, color="rgba(240,249,255,0.9)"),
-                        lighting=dict(ambient=0.62, diffuse=0.9, specular=0.88, roughness=0.2, fresnel=0.25),
-                        lightposition=dict(x=200, y=120, z=140),
-                    ),
-                    hovertemplate=(
-                        "<b>Plan %{customdata[0]}</b><br>Score %{customdata[1]}<br>"
-                        "ρ ref %{customdata[2]} · σₜ %{customdata[3]} · σₜ Al %{customdata[4]}<br>"
-                        "Energía %{x:.2f} kWh<br>Agua %{y:.2f} L<br>Crew %{z:.1f} min<extra></extra>"
-                    ),
-                    customdata=_hover_matrix(pareto_points),
-                )
-            )
-
-            score_min = float(pareto_points["ScorePos"].min()) if not pareto_points.empty else 0.0
-            score_max = float(pareto_points["ScorePos"].max()) if not pareto_points.empty else 1.0
-            size_span = max(score_max - score_min, 0.01)
-            halo_sizes = 18 + 20 * (pareto_points["ScorePos"] - score_min) / size_span
-            fig3d.add_trace(
-                go.Scatter3d(
-                    x=pareto_points["Energía (kWh)"],
-                    y=pareto_points["Agua (L)"],
-                    z=pareto_points["Crew (min)"],
-                    mode="markers",
-                    name="Nebula halo",
-                    marker=dict(
-                        size=halo_sizes,
-                        color="rgba(125,211,252,0.18)",
-                        opacity=0.22,
-                    ),
-                    hoverinfo="skip",
-                    showlegend=False,
-                )
-            )
-
-            # Nebula cloud around Pareto points
-            x_vals = pareto_points["Energía (kWh)"].to_numpy()
-            y_vals = pareto_points["Agua (L)"].to_numpy()
-            z_vals = pareto_points["Crew (min)"].to_numpy()
-            x_span = max(float(usable["Energía (kWh)"].max() - usable["Energía (kWh)"].min()), 1e-3)
-            y_span = max(float(usable["Agua (L)"].max() - usable["Agua (L)"].min()), 1e-3)
-            z_span = max(float(usable["Crew (min)"].max() - usable["Crew (min)"].min()), 1e-3)
-            nebula_points = []
-            for option, xv, yv, zv in zip(pareto_points.get("Opción", []), x_vals, y_vals, z_vals):
-                rng = np.random.default_rng(int(option * 997) if not pd.isna(option) else 42)
-                spread = np.array([x_span, y_span, z_span]) * 0.04
-                cloud = rng.normal(loc=[xv, yv, zv], scale=np.maximum(spread, 1e-3), size=(24, 3))
-                nebula_points.append(cloud)
-            if nebula_points:
-                nebula = np.vstack(nebula_points)
-                fig3d.add_trace(
-                    go.Scatter3d(
-                        x=nebula[:, 0],
-                        y=nebula[:, 1],
-                        z=nebula[:, 2],
-                        mode="markers",
-                        marker=dict(size=3, opacity=0.18, color="rgba(148,197,255,0.18)"),
-                        hoverinfo="skip",
-                        showlegend=False,
-                    )
-                )
-
-        # Highlight selected candidate in scene
-        if selected_option_number:
-            selected_trace = usable[usable.get("Opción") == int(selected_option_number)] if "Opción" in usable else pd.DataFrame()
-            if not selected_trace.empty:
-                fig3d.add_trace(
-                    go.Scatter3d(
-                        x=selected_trace["Energía (kWh)"],
-                        y=selected_trace["Agua (L)"],
-                        z=selected_trace["Crew (min)"],
-                        mode="markers",
-                        name="Seleccionado",
-                        marker=dict(
-                            size=14,
-                            color="rgba(74,222,128,0.95)",
-                            line=dict(width=4, color="rgba(255,255,255,0.95)"),
-                            opacity=1.0,
-                            symbol="circle",
-                        ),
-                        hovertemplate=(
-                            "<b>Seleccionado %{customdata[0]}</b><br>"
-                            "Score %{customdata[1]}<br>ρ ref %{customdata[2]} · σₜ %{customdata[3]} · σₜ Al %{customdata[4]}"
-                            "<extra></extra>"
-                        ),
-                        customdata=_hover_matrix(selected_trace),
-                    )
-                )
-
-        # Illuminated axes
-        x_min, x_max = float(usable["Energía (kWh)"].min()), float(usable["Energía (kWh)"].max())
-        y_min, y_max = float(usable["Agua (L)"].min()), float(usable["Agua (L)"].max())
-        z_min, z_max = float(usable["Crew (min)"].min()), float(usable["Crew (min)"].max())
-        axis_lines = [
-            ([x_min, x_max], [y_min, y_min], [z_min, z_min]),
-            ([x_min, x_min], [y_min, y_max], [z_min, z_min]),
-            ([x_min, x_min], [y_min, y_min], [z_min, z_max]),
-        ]
-        for idx, (xs, ys, zs) in enumerate(axis_lines):
-            fig3d.add_trace(
-                go.Scatter3d(
-                    x=xs,
-                    y=ys,
-                    z=zs,
-                    mode="lines",
-                    line=dict(color="rgba(148,197,255,0.85)", width=6),
-                    hoverinfo="skip",
-                    showlegend=False,
-                    name=f"axis-{idx}",
-                )
-            )
-
-        fig3d.update_layout(
-            height=540,
-            margin=dict(l=0, r=0, b=0, t=24),
-            paper_bgcolor="rgba(4,7,20,1)",
-            scene=dict(
-                xaxis=dict(
-                    title="Energía (kWh)",
-                    backgroundcolor="rgba(8,12,35,0.92)",
-                    gridcolor="rgba(96,165,250,0.12)",
-                    zerolinecolor="rgba(148,197,255,0.6)",
-                    showbackground=True,
-                    showspikes=True,
-                    spikecolor="rgba(125,211,252,0.8)",
-                    spikethickness=2,
-                    tickfont=dict(color="#cbd5f5"),
-                    titlefont=dict(color="#bae6fd"),
-                ),
-                yaxis=dict(
-                    title="Agua (L)",
-                    backgroundcolor="rgba(6,11,32,0.9)",
-                    gridcolor="rgba(96,165,250,0.12)",
-                    zerolinecolor="rgba(148,197,255,0.6)",
-                    showbackground=True,
-                    showspikes=True,
-                    spikecolor="rgba(56,189,248,0.75)",
-                    spikethickness=2,
-                    tickfont=dict(color="#cbd5f5"),
-                    titlefont=dict(color="#bae6fd"),
-                ),
-                zaxis=dict(
-                    title="Crew (min)",
-                    backgroundcolor="rgba(5,9,28,0.9)",
-                    gridcolor="rgba(96,165,250,0.12)",
-                    zerolinecolor="rgba(148,197,255,0.6)",
-                    showbackground=True,
-                    showspikes=True,
-                    spikecolor="rgba(14,165,233,0.8)",
-                    spikethickness=2,
-                    tickfont=dict(color="#cbd5f5"),
-                    titlefont=dict(color="#bae6fd"),
-                ),
-                camera=dict(eye=dict(x=1.65, y=1.72, z=1.45)),
-                dragmode="orbit",
-                aspectmode="cube",
-            ),
-            legend=dict(
-                bgcolor="rgba(8,12,35,0.82)",
-                font=dict(color="#e0f2fe"),
-                orientation="h",
-                yanchor="bottom",
-                y=0.01,
-                x=0.02,
-            ),
+if selected_candidate:
+    st.subheader("Exportar")
+    badge_payload = selected_badge or {}
+    json_data = candidate_to_json(selected_candidate, target, badge_payload)
+    csv_data = candidate_to_csv(selected_candidate)
+    pareto_payload = filtered_df.to_csv(index=False).encode("utf-8")
+    col_json, col_csv, col_pareto = st.columns(3)
+    with col_json:
+        st.download_button(
+            "⬇️ Plan JSON",
+            data=json_data,
+            file_name=f"flight_plan_{int(selected_option_number):02d}.json",
+            mime="application/json",
         )
-
-        st.plotly_chart(
-            fig3d,
-            use_container_width=True,
-            config={"displaylogo": False, "modeBarButtonsToRemove": ["resetCameraDefault3d"], "scrollZoom": True},
+    with col_csv:
+        st.download_button(
+            "⬇️ Resumen CSV",
+            data=csv_data,
+            file_name=f"candidate_{int(selected_option_number):02d}_summary.csv",
+            mime="text/csv",
         )
-
-    st.markdown("""
-<div class="legend">
-<b>Cómo leerlo (criollo):</b> querés puntos <b>abajo/izquierda</b> (menos energía/agua) y <b>adelante</b> (menos crew).
-La capa “Pareto” marca los que no pueden mejorarse en un eje sin empeorar otro.
-</div>
-""", unsafe_allow_html=True)
-
-    density_series = pd.to_numeric(df_view.get("ρ ref (g/cm³)"), errors="coerce").dropna()
-    polymer_tensile_series = pd.to_numeric(df_view.get("σₜ ref (MPa)"), errors="coerce").dropna()
-    aluminium_tensile_series = pd.to_numeric(df_view.get("σₜ Al (MPa)"), errors="coerce").dropna()
-    if not density_series.empty or not polymer_tensile_series.empty or not aluminium_tensile_series.empty:
-        st.markdown('<h4 class="section-title">Propiedades externas (NASA)</h4>', unsafe_allow_html=True)
-        metric_cols = st.columns(3)
-        if not density_series.empty:
-            with metric_cols[0]:
-                density_fig = px.histogram(
-                    pd.DataFrame({"ρ ref (g/cm³)": density_series}),
-                    x="ρ ref (g/cm³)",
-                    nbins=14,
-                    title="Densidad",
-                )
-                density_fig.update_layout(height=280, margin=dict(l=10, r=10, t=40, b=10))
-                st.plotly_chart(density_fig, use_container_width=True)
-        if not polymer_tensile_series.empty:
-            with metric_cols[1]:
-                tensile_fig = px.histogram(
-                    pd.DataFrame({"σₜ ref (MPa)": polymer_tensile_series}),
-                    x="σₜ ref (MPa)",
-                    nbins=14,
-                    title="σₜ polímero",
-                )
-                tensile_fig.update_layout(height=280, margin=dict(l=10, r=10, t=40, b=10))
-                st.plotly_chart(tensile_fig, use_container_width=True)
-        if not aluminium_tensile_series.empty:
-            with metric_cols[2]:
-                tensile_al_fig = px.histogram(
-                    pd.DataFrame({"σₜ Al (MPa)": aluminium_tensile_series}),
-                    x="σₜ Al (MPa)",
-                    nbins=14,
-                    title="σₜ aluminio",
-                )
-                tensile_al_fig.update_layout(height=280, margin=dict(l=10, r=10, t=40, b=10))
-                st.plotly_chart(tensile_al_fig, use_container_width=True)
-        st.caption(
-            "Distribuciones calculadas sobre candidatos filtrados. Úsalas para balancear densidad vs. resistencia en la selección."
+    with col_pareto:
+        st.download_button(
+            "⬇️ Tabla filtrada",
+            data=pareto_payload,
+            file_name="pareto_filtrado.csv",
+            mime="text/csv",
         )
-
-    st.markdown('<h4 class="section-title">Tabla — Frontera de Pareto</h4>', unsafe_allow_html=True)
-    if not table_pareto.empty:
-        columns_to_show = [
-            "Opción",
-            "Score",
-            "Proceso",
-            "Materiales",
-            "Energía (kWh)",
-            "Agua (L)",
-            "Crew (min)",
-            "ρ ref (g/cm³)",
-            "σₜ ref (MPa)",
-            "σₜ Al (MPa)",
-        ]
-        available_columns = [column for column in columns_to_show if column in table_pareto.columns]
-        st.dataframe(
-            table_pareto[available_columns],
-            use_container_width=True, hide_index=True
-        )
-    else:
-        st.info("No hay puntos en la frontera con datos completos.")
-
-    st.markdown('<h4 class="section-title">Seleccionar candidato</h4>', unsafe_allow_html=True)
-    opciones = table_pareto["Opción"].astype(int).tolist()
-    if opciones:
-        pick_opt = st.selectbox("Elegí Opción #", opciones, index=0, key="pick_from_pareto")
-        select_state_key = "pareto_select_state"
-        select_trigger_key = "pareto_select_trigger"
-        select_feedback_key = "pareto_select_feedback"
-        button_state = st.session_state.get(select_state_key, "idle")
-        if futuristic_button(
-            "✅ Usar como seleccionado",
-            key="pareto_select_button",
-            state=button_state,
-            width="full",
-            help_text="Habilita export JSON/CSV en la pestaña",
-            loading_label="Sincronizando…",
-            success_label="Listo para exportar",
-            error_label="Revisar opción",
-            enable_vibration=True,
-            status_hints={
-                "idle": "",
-                "loading": "Checando seguridad",
-                "success": "Disponible en Export Center",
-                "error": "Revisá la opción seleccionada",
-            },
-            mode="cinematic",
-        ):
-            st.session_state[select_state_key] = "loading"
-            st.session_state[select_trigger_key] = True
-            st.session_state["pareto_select_value"] = st.session_state.get("pick_from_pareto", pick_opt)
-            st.session_state.pop(select_feedback_key, None)
-            st.experimental_rerun()
-    else:
-        st.info("No hay puntos en la frontera con datos completos.")
-
-    if st.session_state.get("pareto_select_trigger"):
-        current_selection = st.session_state.get(
-            "pareto_select_value", st.session_state.get("pick_from_pareto")
-        )
-        try:
-            pick_value = int(current_selection) if current_selection is not None else None
-        except (TypeError, ValueError):
-            pick_value = None
-        message_level = "error"
-        message_text = "No se pudo interpretar la opción seleccionada."
-        if pick_value is not None:
-            idx = pick_value - 1
-    if pareto_options:
-        default_index = 0
-        if selected_option_number and int(selected_option_number) in pareto_options:
-            default_index = pareto_options.index(int(selected_option_number))
-        pick_opt = st.selectbox("Elegí Opción #", pareto_options, index=default_index, key="pick_from_pareto")
-        if st.button("✅ Usar como seleccionado"):
-            idx = int(pick_opt) - 1
-            if 0 <= idx < len(cands):
-                selected = cands[idx]
-                flags = check_safety(selected["materials"], selected["process_name"], selected["process_id"])
-                st.session_state["selected"] = {"data": selected, "safety": flags}
-                message_level = "success"
-                message_text = (
-                    f"Candidato #{pick_value} seleccionado. Abrí **4) Resultados** o **5) Comparar & Explicar**."
-                )
-                st.session_state["selected_option_number"] = pick_opt
-                st.session_state["flight_flash"] = {"option": pick_opt}
-                st.session_state["export_wizard_step"] = 1
-                st.session_state["last_export_payload"] = None
-                st.success(f"Candidato #{pick_opt} seleccionado. Abrí **4) Resultados** o **5) Comparar & Explicar**.")
-            else:
-                message_level = "warning"
-                message_text = "Opción fuera de rango respecto a la lista de candidates."
-        st.session_state["pareto_select_feedback"] = (message_level, message_text)
-        st.session_state["pareto_select_state"] = "success" if message_level == "success" else "error"
-        st.session_state["pareto_select_trigger"] = False
-        st.session_state.pop("pareto_select_value", None)
-
-    feedback_state = st.session_state.get("pareto_select_feedback")
-    if feedback_state:
-        level, message = feedback_state
-        if level == "success":
-            st.success(message)
-        elif level == "warning":
-            st.warning(message)
-        elif level == "error":
-            st.error(message)
-
-# ---------- TAB 2: Predicciones de ensayo (demo conectada a datos) ----------
-with tab_trials:
-    st.markdown('<h3 class="section-title">Score predictions — barras de confianza</h3>', unsafe_allow_html=True)
-    st.caption("Usa los **scores reales** y les aplica un ±CI porcentual para visualizar la variabilidad esperable (demo).")
-
-    ci_pct = st.slider("Intervalo de confianza (± % de Score)", 5, 50, 20, step=5)
-    top_n  = st.slider("Top-N por Score", 3, max(3, len(df_view)), min(8, len(df_view)))
-
-    df_trials = df_view.sort_values("Score", ascending=False).head(top_n).copy()
-    if df_trials.empty:
-        st.info("No hay candidatos suficientes para graficar.")
-    else:
-        yerr = (df_trials["Score"].abs() * (ci_pct/100.0)).clip(lower=0.05)
-        density_vals = pd.to_numeric(df_trials.get("ρ ref (g/cm³)"), errors="coerce")
-        tensile_vals = pd.to_numeric(df_trials.get("σₜ ref (MPa)"), errors="coerce")
-        tensile_al_vals = pd.to_numeric(df_trials.get("σₜ Al (MPa)"), errors="coerce")
-
-        def _format_hover(values: pd.Series, precision: int, suffix: str = "") -> np.ndarray:
-            formatted: list[str] = []
-            for value in values:
-                if pd.isna(value):
-                    formatted.append("—")
-                else:
-                    formatted.append(f"{value:.{precision}f}{suffix}")
-            return np.array(formatted, dtype=object)
-
-        customdata = np.column_stack(
-            [
-                df_trials["Opción"].astype(str).to_numpy(),
-                _format_hover(density_vals, 3, " g/cm³"),
-                _format_hover(tensile_vals, 1, " MPa"),
-                _format_hover(tensile_al_vals, 1, " MPa"),
-            ]
-        )
-
-        fig = go.Figure()
-        fig.add_trace(go.Scatter(
-            x=df_trials["Opción"].astype(str),
-            y=df_trials["Score"],
-            error_y=dict(type='data', array=yerr, thickness=1.2, width=4),
-            mode="markers",
-            marker=dict(size=10),
-            name="Predicted trial score",
-            customdata=customdata,
-            hovertemplate=(
-                "<b>Opción %{customdata[0]}</b><br>Score %{y:.2f}<br>"
-                "ρ ref %{customdata[1]}<br>σₜ %{customdata[2]}<br>σₜ Al %{customdata[3]}<extra></extra>"
-            ),
-        ))
-        fig.update_layout(yaxis_title="Score ± CI", xaxis_title="Opción", height=420, margin=dict(l=10,r=10,t=10,b=10))
-        st.plotly_chart(fig, use_container_width=True)
-
-    st.markdown("""
-<div class="legend"><b>Interpretación:</b> si dos opciones se solapan mucho en su CI, tal vez requieras otra señal (p. ej., menos agua) para decidir.
-</div>
-""", unsafe_allow_html=True)
-
-# ---------- TAB 3: Objetivos por eje ----------
-with tab_objectives:
-    st.markdown('<h3 class="section-title">Métricas por componente del objetivo</h3>', unsafe_allow_html=True)
-    col1, col2, col3 = st.columns(3)
-    if "Energía (kWh)" in df_view:
-        with col1:
-            st.markdown("**Energía (kWh)**")
-            e_fig = px.histogram(df_view, x="Energía (kWh)")
-            e_fig.update_layout(height=280, margin=dict(l=10,r=10,t=10,b=10))
-            st.plotly_chart(e_fig, use_container_width=True)
-    if "Agua (L)" in df_view:
-        with col2:
-            st.markdown("**Agua (L)**")
-            w_fig = px.histogram(df_view, x="Agua (L)")
-            w_fig.update_layout(height=280, margin=dict(l=10,r=10,t=10,b=10))
-            st.plotly_chart(w_fig, use_container_width=True)
-    if "Crew (min)" in df_view:
-        with col3:
-            st.markdown("**Crew (min)**")
-            c_fig = px.histogram(df_view, x="Crew (min)")
-            c_fig.update_layout(height=280, margin=dict(l=10,r=10,t=10,b=10))
-            st.plotly_chart(c_fig, use_container_width=True)
-
-    st.markdown("""
-<div class="legend"><b>Ejemplo:</b> si tu objetivo prioriza tiempo de tripulación,
-mirá la cola izquierda del histograma de <i>Crew (min)</i> y elegí opciones con menor valor.
-</div>
-""", unsafe_allow_html=True)
-
-# ---------- TAB 4: Export Center ----------
-with tab_export:
-    st.markdown('<h3 class="section-title">🧭 Mission Export Assistant</h3>', unsafe_allow_html=True)
-
-    if not selected_candidate:
-        st.info("Seleccioná primero un plan en la pestaña **Pareto Explorer** para habilitar el asistente.")
-    else:
-        st.markdown(
-            "<div class='safety-badges'>" + render_safety_badges_html(safety_flags) + "</div>",
-            unsafe_allow_html=True,
-        )
-        st.caption(f"Estado de seguridad: {safety_summary['level']} — {safety_summary['detail']}")
-
-        step_labels = ["1️⃣ Formato", "2️⃣ Previsualizar", "3️⃣ Confirmar"]
-        current_step = st.session_state.get("export_wizard_step", 1)
-        step_choice = st.radio(
-            "Asistente de exportación",
-            step_labels,
-            index=max(0, min(len(step_labels) - 1, current_step - 1)),
-            horizontal=True,
-            key="export_step_radio",
-        )
-        current_step = step_labels.index(step_choice) + 1
-        st.session_state["export_wizard_step"] = current_step
-
-        format_options = ["Plan JSON", "Resumen CSV", "Pareto CSV"]
-        if st.session_state["selected_export_format"] not in format_options:
-            st.session_state["selected_export_format"] = "Plan JSON"
-
-        def generate_payload(fmt: str):
-            if fmt == "Plan JSON":
-                if not safety_flags:
-                    raise ValueError("Se requiere evaluación de seguridad para exportar JSON.")
-                data = candidate_to_json(selected_candidate, target, safety_flags)
-                filename = f"flight_plan_{int(selected_option_number or 0):02d}.json"
-                mime = "application/json"
-            elif fmt == "Resumen CSV":
-                data = candidate_to_csv(selected_candidate)
-                filename = f"candidate_{int(selected_option_number or 0):02d}_summary.csv"
-                mime = "text/csv"
-            elif fmt == "Pareto CSV":
-                dataset = table_pareto if not table_pareto.empty else df_view
-                data = dataset.to_csv(index=False).encode("utf-8")
-                filename = "pareto_frontier.csv"
-                mime = "text/csv"
-            else:
-                raise ValueError(f"Formato no soportado: {fmt}")
-            return data, mime, filename
-
-        with st.container():
-            st.markdown("<div class='wizard-container'>", unsafe_allow_html=True)
-            if current_step == 1:
-                st.markdown(
-                    """
-                    <div class='wizard-panel'>
-                      <h4>Paso 1 — Elegí tu carga útil</h4>
-                      <p>Seleccioná el formato con el que vas a compartir el plan. Podés moverte de paso cuando quieras.</p>
-                    </div>
-                    """,
-                    unsafe_allow_html=True,
-                )
-                fmt_index = format_options.index(st.session_state.get("selected_export_format", "Plan JSON"))
-                fmt_choice = st.radio(
-                    "Formato de export",
-                    format_options,
-                    index=fmt_index,
-                    key="export_format_selector",
-                )
-                st.session_state["selected_export_format"] = fmt_choice
-                if st.button("Siguiente ➡️", key="wizard_next_1", use_container_width=True):
-                    st.session_state["export_wizard_step"] = 2
-                    current_step = 2
-            elif current_step == 2:
-                fmt_choice = st.session_state.get("selected_export_format", "Plan JSON")
-                st.markdown(
-                    """
-                    <div class='wizard-panel'>
-                      <h4>Paso 2 — Nebula preview</h4>
-                      <p>Verificá los datos renderizados con el formato seleccionado antes de autorizar la exportación.</p>
-                    </div>
-                    """,
-                    unsafe_allow_html=True,
-                )
-                try:
-                    payload_bytes, _, _ = generate_payload(fmt_choice)
-                    if fmt_choice == "Plan JSON":
-                        st.json(json.loads(payload_bytes.decode("utf-8")))
-                    elif fmt_choice == "Resumen CSV":
-                        preview_df = pd.read_csv(io.StringIO(payload_bytes.decode("utf-8")))
-                        st.dataframe(preview_df, use_container_width=True, hide_index=True)
-                    elif fmt_choice == "Pareto CSV":
-                        st.dataframe(table_pareto if not table_pareto.empty else df_view, use_container_width=True, hide_index=True)
-                except Exception as preview_error:
-                    st.warning(f"No se pudo generar la previsualización: {preview_error}")
-
-                col_back, col_next = st.columns([1, 1])
-                with col_back:
-                    if st.button("⬅️ Volver", key="wizard_back_2", use_container_width=True):
-                        st.session_state["export_wizard_step"] = 1
-                        current_step = 1
-                with col_next:
-                    if st.button("Continuar ➡️", key="wizard_next_2", use_container_width=True):
-                        st.session_state["export_wizard_step"] = 3
-                        current_step = 3
-            else:
-                fmt_choice = st.session_state.get("selected_export_format", "Plan JSON")
-                st.markdown(
-                    """
-                    <div class='wizard-panel'>
-                      <h4>Paso 3 — Checklist & confirmación</h4>
-                      <p>Confirmá la exportación desde la consola translúcida. Podés volver atrás para ajustar.</p>
-                    </div>
-                    """,
-                    unsafe_allow_html=True,
-                )
-                st.markdown("<div class='translucent-panel'>", unsafe_allow_html=True)
-                st.markdown(
-                    f"""
-                    <h4 style='margin-top:0;'>Checklist operativo</h4>
-                    <ul>
-                      <li>Formato elegido: <b>{fmt_choice}</b></li>
-                      <li>Plan vinculado: <b>#{selected_option_number or '—'}</b> — {selected_candidate.get('process_name', 'sin proceso')}</li>
-                      <li>Seguridad: <b>{safety_summary['level']}</b> · {safety_summary['detail']}</li>
-                    </ul>
-                    """,
-                    unsafe_allow_html=True,
-                )
-                st.markdown(
-                    "<div class='safety-badges'>" + render_safety_badges_html(safety_flags) + "</div>",
-                    unsafe_allow_html=True,
-                )
-                col_confirm, col_back = st.columns([1.2, 1])
-                confirm_clicked = False
-                with col_confirm:
-                    confirm_clicked = st.button("🚀 Generar paquete", key="wizard_confirm", use_container_width=True)
-                with col_back:
-                    if st.button("⬅️ Ajustar", key="wizard_back_3", use_container_width=True):
-                        st.session_state["export_wizard_step"] = 2
-                        current_step = 2
-
-                if confirm_clicked:
-                    try:
-                        payload_bytes, mime, filename = generate_payload(fmt_choice)
-                        timestamp = datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S UTC")
-                        st.session_state["last_export_payload"] = {
-                            "data": payload_bytes,
-                            "mime": mime,
-                            "filename": filename,
-                            "format": fmt_choice,
-                            "timestamp": timestamp,
-                        }
-                        history = st.session_state.get("export_history", [])
-                        history.insert(
-                            0,
-                            {
-                                "timestamp": timestamp,
-                                "plan": f"#{selected_option_number or '—'}",
-                                "format": fmt_choice,
-                                "safety": safety_summary["level"],
-                            },
-                        )
-                        st.session_state["export_history"] = history[:12]
-                        st.success(f"Paquete {fmt_choice} listo para descargar.")
-                    except Exception as export_error:
-                        st.warning(f"No se pudo generar el paquete: {export_error}")
-
-                payload = st.session_state.get("last_export_payload")
-                if payload and payload.get("format") == fmt_choice:
-                    st.download_button(
-                        "⬇️ Descargar misión",
-                        data=payload["data"],
-                        file_name=payload["filename"],
-                        mime=payload["mime"],
-                        key="export_download_button",
-                    )
-
-                st.markdown("</div>", unsafe_allow_html=True)
-            st.markdown("</div>", unsafe_allow_html=True)
-
-        st.markdown("### 📜 Historial de exportaciones")
-        history = st.session_state.get("export_history", [])
-        if history:
-            hist_df = pd.DataFrame(history)
-            ordered_cols = [c for c in ["timestamp", "plan", "format", "safety"] if c in hist_df.columns]
-            if ordered_cols:
-                hist_df = hist_df[ordered_cols]
-            st.markdown(
-                "<div class='history-table'>" + hist_df.to_html(index=False, escape=False) + "</div>",
-                unsafe_allow_html=True,
-            )
-        else:
-            st.caption("Aún no generaste exportaciones en esta sesión.")
+else:
+    st.caption("Los botones de exportación se activan al elegir un plan prioritario.")

--- a/app/pages/7_Scenario_Playbooks.py
+++ b/app/pages/7_Scenario_Playbooks.py
@@ -1,13 +1,17 @@
-# app/pages/7_Scenario_Playbooks.py
+"""Simplified scenario playbooks with actionable summaries."""
+
 import _bootstrap  # noqa: F401
 
+from typing import Iterable
+
+import pandas as pd
 import streamlit as st
 
 from app.modules.navigation import render_breadcrumbs, set_active_step
-from app.modules.scenarios import PLAYBOOKS  # dict: {scenario: Playbook(name, summary, steps=[...])}
-from app.modules.ui_blocks import load_theme
+from app.modules.scenarios import PLAYBOOKS
+from app.modules.ui_blocks import layout_stack, load_theme
 
-# ⚠️ Debe ser la primera llamada
+
 st.set_page_config(page_title="Scenario Playbooks", page_icon="📚", layout="wide")
 
 current_step = set_active_step("playbooks")
@@ -16,7 +20,7 @@ load_theme()
 
 render_breadcrumbs(current_step)
 
-FEATURED_PLAYBOOKS = ("Residence Renovations", "Daring Discoveries")
+FEATURED_PLAYBOOKS: tuple[str, ...] = ("Residence Renovations", "Daring Discoveries")
 GENERATOR_FILTER_PRESETS: dict[str, dict[str, bool]] = {
     "Residence Renovations": {
         "showroom_only_safe": True,
@@ -32,332 +36,117 @@ GENERATOR_FILTER_PRESETS: dict[str, dict[str, bool]] = {
     },
 }
 
-# ======== Estado compartido ========
-target      = st.session_state.get("target", None)
-state_sel   = st.session_state.get("selected", None)
-candidato   = state_sel["data"] if state_sel else None
-props       = candidato["props"] if candidato else None
 
-# ======== Selector de Playbook ========
+def _ordered_scenarios(options: Iterable[str]) -> list[str]:
+    favourites = [name for name in FEATURED_PLAYBOOKS if name in options]
+    remainder = [name for name in options if name not in favourites]
+    return favourites + remainder
+
+
+target = st.session_state.get("target")
+state_sel = st.session_state.get("selected")
+selected_candidate = state_sel.get("data") if isinstance(state_sel, dict) else None
+props = selected_candidate.get("props") if isinstance(selected_candidate, dict) else None
+
 if not target:
-    st.info("Definí primero el escenario en **2) Target Designer**.")
+    st.info("Definí un objetivo en **2 · Target Designer** para habilitar los playbooks.")
     st.stop()
 
-scenario_default = target.get("scenario", next(iter(PLAYBOOKS.keys())))
-scenarios = list(PLAYBOOKS.keys())
-ordered_scenarios = [s for s in FEATURED_PLAYBOOKS if s in scenarios]
-ordered_scenarios.extend([s for s in scenarios if s not in ordered_scenarios])
+with layout_stack():
+    st.title("📚 Scenario Playbooks")
+    st.caption("Procedimientos listos para ejecutar según el escenario operativo seleccionado.")
 
+scenarios = list(PLAYBOOKS.keys())
+if not scenarios:
+    st.warning("No hay playbooks configurados en `app/modules/scenarios.py`.")
+    st.stop()
+
+scenario_default = str(target.get("scenario") or scenarios[0])
+ordered_scenarios = _ordered_scenarios(scenarios)
 if scenario_default not in ordered_scenarios:
     scenario_default = ordered_scenarios[0]
 
-featured_indices = [
-    idx + 1 for idx, name in enumerate(ordered_scenarios) if name in FEATURED_PLAYBOOKS
-]
-
-
-def build_radio_hud_css(feature_positions: list[int]) -> str:
-    """Return HUD-like styling for the radio selector, highlighting featured playbooks."""
-
-    base_styles = """
-    div[data-testid="stRadio"] > div[role="radiogroup"]{
-        display:flex;
-        gap:0.6rem;
-        flex-wrap:wrap;
-    }
-    div[data-testid="stRadio"] > div[role="radiogroup"] label{
-        cursor:pointer;
-        display:flex;
-        align-items:center;
-        gap:0.5rem;
-        padding:0.55rem 1.35rem;
-        border-radius:14px;
-        border:1px solid rgba(148,163,184,0.35);
-        background:rgba(15,23,42,0.62);
-        color:#e2e8f0;
-        font-weight:600;
-        letter-spacing:0.04em;
-        text-transform:uppercase;
-        box-shadow:inset 0 0 0 1px rgba(148,163,184,0.18);
-        transition:all .2s ease;
-        position:relative;
-    }
-    div[data-testid="stRadio"] > div[role="radiogroup"] label:hover{
-        border-color:rgba(148,163,184,0.75);
-        box-shadow:0 12px 24px rgba(15,23,42,0.48), inset 0 0 0 1px rgba(148,163,184,0.32);
-    }
-    div[data-testid="stRadio"] > div[role="radiogroup"] label::after{
-        content:"";
-        position:absolute;
-        inset:0;
-        border-radius:14px;
-        opacity:0;
-        transition:opacity .2s ease;
-        background:radial-gradient(circle at 30% 30%, rgba(148,197,255,0.32), transparent 70%);
-        mix-blend-mode:screen;
-    }
-    div[data-testid="stRadio"] > div[role="radiogroup"] label:has(input:checked)::after{
-        opacity:1;
-    }
-    div[data-testid="stRadio"] > div[role="radiogroup"] label:has(input:checked){
-        border:1px solid rgba(96,165,250,0.85);
-        box-shadow:0 18px 32px rgba(15,23,42,0.62), inset 0 0 0 1px rgba(96,165,250,0.55);
-        background:linear-gradient(135deg, rgba(59,130,246,0.45), rgba(56,189,248,0.25));
-        color:#0ea5e9;
-    }
-    """
-
-    feature_styles = "".join(
-        f"""
-        div[data-testid=\"stRadio\"] > div[role=\"radiogroup\"] > div:nth-child({index}) label {{
-            border-color:rgba(250,204,21,0.65);
-            box-shadow:0 16px 28px rgba(15,23,42,0.55), inset 0 0 0 1px rgba(250,204,21,0.35);
-            background:linear-gradient(135deg, rgba(250,204,21,0.22), rgba(56,189,248,0.08));
-            color:#f8fafc;
-        }}
-        div[data-testid=\"stRadio\"] > div[role=\"radiogroup\"] > div:nth-child({index}) label:hover {{
-            border-color:rgba(250,204,21,0.85);
-            box-shadow:0 20px 34px rgba(15,23,42,0.65), inset 0 0 0 1px rgba(250,204,21,0.45);
-        }}
-        div[data-testid=\"stRadio\"] > div[role=\"radiogroup\"] > div:nth-child({index}) label:has(input:checked) {{
-            border-color:rgba(253,224,71,0.95);
-            box-shadow:0 24px 38px rgba(15,23,42,0.7), inset 0 0 0 1px rgba(253,224,71,0.65);
-            color:#0f172a;
-            background:linear-gradient(135deg, rgba(253,224,71,0.65), rgba(56,189,248,0.32));
-        }}
-        """
-        for index in feature_positions
-    )
-
-    return base_styles + feature_styles
-
-st.markdown(
-    f"""
-    <style>
-    .hero {{border-radius:16px; background: radial-gradient(900px 260px at 20% -10%, rgba(80,120,255,.10), transparent);}}
-    .step{{border:1px dashed var(--bd); border-radius:14px; padding:14px; margin-bottom:12px;}}
-    .step h4{{margin:0 0 6px 0;}}
-    .mono{{font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, \"Liberation Mono\", monospace;}}
-    .why-panel{{border:1px solid var(--bd); border-radius:16px; padding:16px; background:linear-gradient(135deg, rgba(59,130,246,0.12), rgba(13,148,136,0.10)); box-shadow:0 16px 28px rgba(15,23,42,0.22);}}
-    .why-panel h4{{margin:0 0 8px 0; font-size:1.05rem;}}
-    .why-panel p{{margin:0 0 10px 0; font-size:0.92rem; line-height:1.45;}}
-    .why-panel ul{{margin:0; padding-left:18px; font-size:0.88rem; line-height:1.5;}}
-    {build_radio_hud_css(featured_indices)}
-    </style>
-    """,
-    unsafe_allow_html=True,
+scenario = st.selectbox(
+    "Escenario de misión",
+    ordered_scenarios,
+    index=ordered_scenarios.index(scenario_default),
 )
 
-# ======== HERO ========
-st.markdown(
-    """
-<div class="hero">
-  <h1 style="margin:0 0 6px 0">📚 Scenario Playbooks</h1>
-  <div class="small">
-    Procedimientos guiados para ejecutar la receta seleccionada en contextos de misión.
-    <b>Residence Renovations</b> y <b>Daring Discoveries</b> son nuestros playbooks ganadores:
-    maximizan la eficiencia de recursos y la adopción operativa en misiones reales.
-    Cada playbook es una lista de pasos accionables, con material y recursos provenientes de tus datos reales.
-  </div>
-  <div class="legend" style="margin-top:8px">
-    <span class="pill info">1) Elegí el playbook</span>
-    <span class="pill info">2) Revisá pasos + recursos</span>
-    <span class="pill ok">3) Ejecutá & registra feedback</span>
-  </div>
-</div>
-""",
-    unsafe_allow_html=True,
-)
-
-st.markdown("### 🎯 Escenario operativo")
-
-if not target:
-    st.info("Definí primero el escenario en **2) Target Designer**.")
+playbook = PLAYBOOKS.get(scenario)
+if not playbook:
+    st.warning("No se encontró el playbook seleccionado.")
     st.stop()
 
-scenario_default = target.get("scenario", None)
-scenarios = list(PLAYBOOKS.keys())
-ordered_scenarios = [s for s in FEATURED_PLAYBOOKS if s in scenarios]
-ordered_scenarios.extend([s for s in scenarios if s not in ordered_scenarios])
+summary_columns = st.columns(2)
+with summary_columns[0]:
+    st.subheader(playbook.name)
+    st.write(playbook.summary)
 
-if scenario_default not in ordered_scenarios:
-    scenario_default = ordered_scenarios[0]
-
-if scenario_default not in FEATURED_PLAYBOOKS:
-    scenario_default = next((s for s in ordered_scenarios if s in FEATURED_PLAYBOOKS), ordered_scenarios[0])
-col_sel, col_help = st.columns([1.5, 1.0])
-with col_sel:
-    st.caption("Seleccioná un playbook destacado o cambiá a otro escenario de misión.")
-    scenario = st.radio(
-        "Playbooks disponibles",
-        options=ordered_scenarios,
-        index=ordered_scenarios.index(scenario_default),
-        key="playbook_selector",
-        horizontal=True,
-    )
-
-pb = PLAYBOOKS.get(scenario)
-
-with col_help:
-    if pb:
-        st.markdown(
-            """
-<div class="block">
-<b>Playbooks ganadores:</b> Residence Renovations simplifica remodelaciones internas con protocolos de ahorro de agua y crew;
-Daring Discoveries desbloquea iteraciones científicas rápidas manteniendo consumo energético bajo control.
-</div>
-""",
-            unsafe_allow_html=True,
-        )
-        highlights = "".join(
-            f"<li><strong>{step.title}</strong>: {step.detail}</li>"
-            for step in pb.steps[:3]
-        ) or ""
-        st.markdown(
-            f"""
-<div class="block why-panel">
-  <h4>🏆 Por qué gana</h4>
-  <p>{pb.summary}</p>
-  <ul>{highlights}</ul>
-</div>
-""",
-            unsafe_allow_html=True,
-        )
-    st.markdown("""
-<div class="block">
-<b>¿Qué es un playbook?</b><br/>
-Un <i>procedimiento de laboratorio</i> curado para un contexto concreto. Trae pasos,
-checklist y pistas de seguridad. Ideal para entrenar aprendices y estandarizar corridas.
-</div>
-""", unsafe_allow_html=True)
-if not pb:
-    st.warning("No encontré el playbook seleccionado.")
-    st.stop()
-
-filters_payload = GENERATOR_FILTER_PRESETS.get(pb.name, {})
-
-with col_sel:
-    if st.button(
-        f"⚡ Abrir generador con filtros de {pb.name}",
-        use_container_width=True,
-    ):
-        st.session_state["_playbook_generator_filters"] = {
-            "scenario": pb.name,
-            "filters": filters_payload,
-        }
-        st.session_state["mission_active_step"] = "generator"
-        st.switch_page("pages/3_Generator.py")
-
-# ======== Brief del Playbook + Estado de datos ========
-st.markdown("### 🧪 Brief del escenario")
-bL, bR = st.columns([1.3, 1.0])
-
-with bL:
-    st.subheader(pb.name)
-    st.markdown(pb.summary)
-
-with bR:
-    st.markdown("**Estado de datos**")
+with summary_columns[1]:
+    st.subheader("Estado de la misión")
     st.markdown(
-        f"""
-- Target: **{target.get('name','-')}**
-- Límites → Agua: **{target.get('max_water_l','-')} L** · Energía: **{target.get('max_energy_kwh','-')} kWh** · Crew: **{target.get('max_crew_min','-')} min**
-- Candidato seleccionado: **{('Opción con ' + candidato['process_id'] + ' ' + candidato['process_name']) if candidato else '— (seleccioná en 3/6)'}**
         """
+        - Target activo: **{target_name}**
+        - Límite de energía: **{energy} kWh**
+        - Límite de agua: **{water} L**
+        - Límite de crew: **{crew} min**
+        """.format(
+            target_name=target.get("name", "—"),
+            energy=target.get("max_energy_kwh", "—"),
+            water=target.get("max_water_l", "—"),
+            crew=target.get("max_crew_min", "—"),
+        )
     )
 
-# ======== Herramientas rápidas (conecta a datos reales si hay candidato) ========
-st.markdown("### 🧰 Herramientas rápidas")
+st.subheader("Filtros recomendados")
+filters_payload = GENERATOR_FILTER_PRESETS.get(playbook.name, {})
+if filters_payload:
+    st.json(filters_payload, expanded=False)
+else:
+    st.caption("Este playbook no define filtros automáticos para el generador.")
 
-t1, t2, t3, t4 = st.columns(4)
-with t1:
-    st.markdown('<div class="kpi"><h3>Masa final</h3><div class="v">{}</div></div>'.format(
-        f"{props.mass_final_kg:.2f} kg" if props else "—"
-    ), unsafe_allow_html=True)
-with t2:
-    st.markdown('<div class="kpi"><h3>Energía por corrida</h3><div class="v">{}</div></div>'.format(
-        f"{props.energy_kwh:.2f} kWh" if props else "—"
-    ), unsafe_allow_html=True)
-with t3:
-    st.markdown('<div class="kpi"><h3>Agua por corrida</h3><div class="v">{}</div></div>'.format(
-        f"{props.water_l:.2f} L" if props else "—"
-    ), unsafe_allow_html=True)
-with t4:
-    st.markdown('<div class="kpi"><h3>Crew por corrida</h3><div class="v">{}</div></div>'.format(
-        f"{props.crew_min:.0f} min" if props else "—"
-    ), unsafe_allow_html=True)
+if st.button("Abrir generador con estos filtros"):
+    st.session_state["_playbook_generator_filters"] = {"scenario": playbook.name, "filters": filters_payload}
+    st.session_state["mission_active_step"] = "generator"
+    st.switch_page("pages/3_Generator.py")
 
-st.caption("Estos valores vienen del **candidato activo** (seleccionalo en 3) Generador o en 6) Pareto).")
+st.subheader("Recursos del candidato activo")
+metric_columns = st.columns(4)
+metrics = [
+    ("Masa final (kg)", getattr(props, "mass_final_kg", None)),
+    ("Energía por corrida (kWh)", getattr(props, "energy_kwh", None)),
+    ("Agua por corrida (L)", getattr(props, "water_l", None)),
+    ("Crew por corrida (min)", getattr(props, "crew_min", None)),
+]
+for column, (label, value) in zip(metric_columns, metrics):
+    text = "—"
+    if value is not None:
+        text = f"{float(value):.2f}" if "Crew" not in label else f"{float(value):.0f}"
+    column.metric(label, text)
+if not props:
+    st.caption("Seleccioná un candidato en **3 · Generador** para ver métricas reales.")
 
-# ======== Paso a paso (tarjetas) ========
-st.markdown("### 📋 Pasos del playbook")
-for i, step in enumerate(pb.steps, start=1):
-    c1, c2 = st.columns([0.08, 1.0], vertical_alignment="center")
-    with c1:
-        st.markdown(f"<div class='pill info'>Paso {i}</div>", unsafe_allow_html=True)
-    with c2:
-        st.markdown(f"<div class='step'><h4>{step.title}</h4><div class='small'>{step.detail}</div></div>", unsafe_allow_html=True)
-
-# ======== Mini-estimador de turnos (para aprendices) ========
-st.markdown("### ⏱️ Estimador de turnos (didáctico)")
-st.caption("Para dimensionar rápidamente una operación. No reemplaza al simulador de capacidad (página 9).")
-
-eL, eR = st.columns([1.2, 1.0])
-with eL:
-    batches = st.number_input("Corridas planificadas", 1, 200, 6, 1)
-    if props:
-        total_crew = batches * float(props.crew_min)
-        total_kwh  = batches * float(props.energy_kwh)
-        total_w    = batches * float(props.water_l)
-        st.markdown(f"""
-- **Crew total:** **{total_crew:.0f} min**  
-- **Energía total:** **{total_kwh:.2f} kWh**  
-- **Agua total:** **{total_w:.2f} L**
-""")
-    else:
-        st.info("Seleccioná un candidato para ver números reales.")
-
-with eR:
-    st.markdown("""
-<div class="block">
-<b>En criollo:</b> si una corrida te consume 25 min de tripulación, y querés 6 corridas, vas a necesitar ~150 min.
-Compará contra el límite del target y planificá los turnos.
-</div>
-""", unsafe_allow_html=True)
-
-# ======== Checklist de ejecución (imprimible) ========
-st.markdown("### ✅ Checklist de ejecución")
-cl = st.text_area(
-    "Lista imprimible (editable)",
-    value=(
-        f"- Verificar disponibilidad de materiales (incluyendo **MGS-1** si el proceso es sinterizado)\n"
-        f"- Preparar equipo del proceso ({candidato['process_id']} {candidato['process_name']})\n"
-        f"- Registrar lote, hora y operador\n"
-        f"- Post-procesado y control visual del producto\n"
-        f"- Cargar feedback en **8) Feedback & Impact**"
-    ) if candidato else
-    "- Seleccionar candidato en 3) Generador o 6) Pareto\n- Preparar equipo del proceso\n- Registrar lote, hora y operador\n- Cargar feedback en 8)"
+st.subheader("Pasos del playbook")
+steps_df = pd.DataFrame(
+    {
+        "Paso": list(range(1, len(playbook.steps) + 1)),
+        "Actividad": [step.title for step in playbook.steps],
+        "Detalle": [step.detail for step in playbook.steps],
+    }
 )
-st.download_button("⬇️ Descargar checklist (.txt)", data=cl.encode("utf-8"),
-                   file_name="scenario_checklist.txt", mime="text/plain")
+st.dataframe(steps_df, use_container_width=True, hide_index=True)
 
-# ======== Glosario & valor (aprendices) ========
-st.markdown("### ℹ️ Glosario rápido (para aprendices)")
-gL, gR = st.columns(2)
-with gL:
-    st.markdown("""
-- **Playbook:** guía paso a paso para que dos personas ejecuten igual en días distintos.
-- **Crew (min):** minutos de tiempo humano necesario. En misiones, es oro.
-- **MGS-1:** regolito simulado. Mejora rigidez cuando sinterizamos.
-- **Frontera de Pareto:** conjunto de opciones que no se pueden mejorar en un eje sin empeorar otro.
-""")
-with gR:
-    st.markdown("""
-- **Target:** lo que querés fabricar + límites (energía/agua/crew).
-- **Score:** cuán bien se ajusta al target, penalizando recursos.
-- **Trazabilidad:** guardamos IDs y flags de los residuos para auditoría.
-- **Feedback:** lo que nos decís tras probar; ajusta futuras decisiones.
-""")
-
-st.markdown("---")
-st.caption("Tip: si un paso te resulta lento, registralo en **8) Feedback & Impact** — el sistema aprende de esos cuellos de botella.")
+st.subheader("Checklist editable")
+default_lines = [
+    "- Verificar disponibilidad de materiales",
+    "- Preparar equipo de proceso",
+    "- Registrar lote, hora y operador",
+    "- Cargar feedback en 8) Feedback & Impact",
+]
+checklist_value = st.text_area("Checklist", "\n".join(default_lines), height=160)
+st.download_button(
+    "Descargar checklist (.txt)",
+    data=checklist_value.encode("utf-8"),
+    file_name="scenario_checklist.txt",
+    mime="text/plain",
+)

--- a/app/pages/8_Feedback_and_Impact.py
+++ b/app/pages/8_Feedback_and_Impact.py
@@ -1,13 +1,28 @@
-# app/pages/8_Feedback_and_Impact.py
+"""Consolidated feedback capture and mission impact tracking."""
+
 import _bootstrap  # noqa: F401
 
-# ⚠️ Debe ser la PRIMERA llamada Streamlit:
+from datetime import datetime
+
+import pandas as pd
 import streamlit as st
 
-st.set_page_config(page_title="Feedback & Impact", page_icon="📝", layout="wide")
-
+from app.modules.impact import (
+    FeedbackEntry,
+    ImpactEntry,
+    append_feedback,
+    append_impact,
+    load_feedback_df,
+    load_impact_df,
+    parse_extra_blob,
+    summarize_impact,
+)
 from app.modules.navigation import render_breadcrumbs, set_active_step
-from app.modules.ui_blocks import load_theme
+from app.modules.page_data import build_feedback_summary_table
+from app.modules.ui_blocks import layout_stack, load_theme
+
+
+st.set_page_config(page_title="Feedback & Impact", page_icon="📝", layout="wide")
 
 current_step = set_active_step("feedback")
 
@@ -15,560 +30,135 @@ load_theme()
 
 render_breadcrumbs(current_step)
 
-import pandas as pd
-from datetime import datetime
-from io import StringIO
-from typing import Any
 
-from app.modules.impact import (
-    ImpactEntry,
-    FeedbackEntry,
-    append_impact,
-    append_feedback,
-    load_impact_df,
-    load_feedback_df,
-    parse_extra_blob,
-    summarize_impact,
-)
-from app.modules.data_sources import (
-    load_regolith_thermal_profiles,
-    regolith_observation_lines,
-)
-
-
-@st.cache_data(show_spinner=False)
-def _regolith_thermal_summary():
-    try:
-        bundle = load_regolith_thermal_profiles()
-    except Exception as exc:  # noqa: BLE001
-        st.warning(
-            "No se pudieron cargar los perfiles térmicos de regolito en este momento. "
-            "Intentá recargar la página o consultá al equipo de datos.",
-            icon="⚠️",
-        )
-        st.caption(f"Detalles técnicos: {exc}")
-        return {}
-
-    peaks = (
-        bundle.gas_peaks.to_dict("records")
-        if isinstance(bundle.gas_peaks, pd.DataFrame)
-        else []
-    )
-    events = (
-        bundle.mass_events.to_dict("records")
-        if isinstance(bundle.mass_events, pd.DataFrame)
-        else []
-    )
-    return {"peaks": peaks, "events": events}
-
-
-def _with_extra_columns(df: pd.DataFrame, rename_map: dict[str, str] | None = None) -> pd.DataFrame:
-    if df is None or df.empty:
+def _expand_extra_columns(df: pd.DataFrame) -> pd.DataFrame:
+    if df is None or df.empty or "extra" not in df.columns:
         return df
-    work = df.copy()
-    rename_map = rename_map or {}
-    rename_existing = {col: rename_map[col] for col in rename_map if col in work.columns}
-    if rename_existing:
-        work = work.rename(columns=rename_existing)
-    if "extra" not in work.columns:
-        work["extra"] = [{} for _ in range(len(work))]
-        return work
-    meta_df = pd.DataFrame([parse_extra_blob(val) for val in work["extra"]])
-    if meta_df.empty:
-        return work
-    if rename_map:
-        meta_df = meta_df.rename(columns={col: rename_map.get(col, col) for col in meta_df.columns})
-    for column in meta_df.columns:
-        if column in work.columns:
-            work[column] = work[column].fillna(meta_df[column])
-        else:
-            work[column] = meta_df[column]
-    return work
-
-# ========= estilos SpaceX/NASA-like =========
-# (Se cargan desde app/static/theme.css vía el tema global)
-
-# ========= estado compartido =========
-target       = st.session_state.get("target", None)
-state_sel    = st.session_state.get("selected", None)
-candidato    = state_sel["data"] if state_sel else None
-props        = candidato["props"] if candidato else None
-regolith_pct = (candidato.get("regolith_pct", 0.0) if candidato else 0.0)
-scenario_label = ""
-if target:
-    scenario_label = str(target.get("scenario") or "").strip()
-scenario_key = scenario_label.casefold()
-thermo_summary = _regolith_thermal_summary() if regolith_pct > 0 else None
-regolith_observations = regolith_observation_lines(regolith_pct, thermo_summary)
+    extras = pd.DataFrame([parse_extra_blob(value) for value in df["extra"]])
+    merged = pd.concat([df.drop(columns=["extra"]), extras], axis=1)
+    return merged
 
 
-def _scenario_side_hints(scenario_key: str) -> list[str]:
-    base_map: dict[str, list[str]] = {
-        "residence renovations": [
-            "Priorizar paneles compactados que recuperen volumen habitable.",
-            "Registrar rigidez en marcos reforzados y sellado de bordes laminados.",
-            "Comparar tiempo de prensado vs. minutos de crew para futuras corridas.",
-        ],
-        "daring discoveries": [
-            "Validar unión del carbono recuperado con la matriz polimérica.",
-            "Inspeccionar fijación de mallas/filtros tras compactación o sinterizado.",
-            "Documentar cualquier cambio en conductividad o manejo de polvo fino.",
-        ],
-    }
-    return base_map.get(scenario_key, [])
+def _format_metric(value: float | int | None, precision: int = 2) -> str:
+    if value is None:
+        return "—"
+    return f"{value:.{precision}f}"
 
 
-_FEEDBACK_FIELD_KEYS = {
-    "overall": "feedback_overall",
-    "rigidity": "feedback_rigidity",
-    "porosity": "feedback_porosity",
-    "surface": "feedback_surface",
-    "bonding": "feedback_bonding",
-    "ease": "feedback_ease",
-    "failure": "feedback_failure",
-    "issues": "feedback_issues",
-    "notes": "feedback_notes",
-}
+target = st.session_state.get("target")
+selected_state = st.session_state.get("selected")
+selected_candidate = selected_state.get("data") if isinstance(selected_state, dict) else None
+props = selected_candidate.get("props") if isinstance(selected_candidate, dict) else None
+selected_option_number = st.session_state.get("selected_option_number")
 
+impact_df = load_impact_df() or pd.DataFrame()
+feedback_df = load_feedback_df() or pd.DataFrame()
+expanded_impact_df = _expand_extra_columns(impact_df)
+expanded_feedback_df = _expand_extra_columns(feedback_df)
 
-_PRESET_BASES: dict[str, dict[str, Any]] = {
-    "Residence checklist": {
-        "fields": {
-            "overall": 8,
-            "rigidity": 8,
-            "porosity": 4,
-            "surface": 7,
-            "bonding": 8,
-            "ease": 7,
-            "failure": "Delaminación",
-        },
-        "issues": [
-            "Verificar microcanales en paneles laminados post-prensado.",
-            "Confirmar rigidez de bordes reforzados con regolito y CTB.",
-        ],
-        "notes": [
-            "Checklist: documentar tiempo/temperatura de prensado y uso de refuerzos CTB.",
-            "Ventilar el horno al escalar temperatura para evitar degradación de espumas.",
-        ],
-    },
-    "Daring checklist": {
-        "fields": {
-            "overall": 7,
-            "rigidity": 7,
-            "porosity": 5,
-            "surface": 6,
-            "bonding": 8,
-            "ease": 6,
-            "failure": "Agarre insuficiente",
-        },
-        "issues": [
-            "Revisar zonas con falta de unión por exceso de carbono en la mezcla.",
-            "Inspeccionar fijación de mallas/filtros conductivos tras compactación.",
-        ],
-        "notes": [
-            "Checklist: registrar % de carbono añadido y presión/tiempo de compactación.",
-            "Medir continuidad eléctrica o sellos anti-polvo según aplique.",
-        ],
-    },
-}
+impact_summary = summarize_impact(impact_df if not impact_df.empty else pd.DataFrame())
+feedback_summary_df = build_feedback_summary_table(expanded_feedback_df)
 
+with layout_stack():
+    st.title("📝 Feedback & Impact")
+    st.caption("Registra corridas reales, consolida el feedback y cuantificá el impacto en la misión.")
 
-def _build_feedback_preset(name: str, *, regolith_lines: list[str]) -> dict[str, Any]:
-    preset = _PRESET_BASES.get(name)
-    if not preset:
-        return {}
+metric_cols = st.columns(4)
+metric_cols[0].metric("Corridas registradas", impact_summary.get("runs", 0))
+metric_cols[1].metric("Kg totales", _format_metric(impact_summary.get("kg")))
+metric_cols[2].metric("kWh totales", _format_metric(impact_summary.get("kwh")))
+metric_cols[3].metric("Crew total (min)", _format_metric(impact_summary.get("crew_min"), precision=0))
 
-    payload: dict[str, Any] = dict(preset.get("fields", {}))
-    issues_lines = list(preset.get("issues", []))
-    notes_lines = list(preset.get("notes", []))
+if not feedback_summary_df.empty:
+    st.subheader("Impacto del feedback")
+    st.dataframe(feedback_summary_df, use_container_width=True, hide_index=True)
+else:
+    st.caption("Aún no se registró feedback cuantitativo.")
 
-    if regolith_lines:
-        rego_issue = [f"Revisá: {line}" for line in regolith_lines[:2]]
-        rego_notes = [f"TG/EGA: {line}" for line in regolith_lines]
-        issues_lines.extend(rego_issue)
-        notes_lines.extend(rego_notes)
+st.subheader("Corridas registradas")
+if expanded_impact_df.empty:
+    st.info("Todavía no hay registros de impacto. Usá el formulario para agregar la primera corrida.")
+else:
+    impact_preview = expanded_impact_df.sort_values("ts_iso", ascending=False).head(20)
+    st.dataframe(impact_preview, use_container_width=True, hide_index=True)
 
-    payload["issues"] = "\n".join(f"- {line}" for line in issues_lines)
-    payload["notes"] = "\n".join(f"- {line}" for line in notes_lines)
-    return payload
+st.subheader("Feedback recientes")
+if expanded_feedback_df.empty:
+    st.caption("Sin feedback registrado por el momento.")
+else:
+    feedback_preview = expanded_feedback_df.sort_values("ts_iso", ascending=False).head(20)
+    st.dataframe(feedback_preview, use_container_width=True, hide_index=True)
 
-# ========= HERO =========
-st.markdown("""
-<div class="hero">
-  <h1 style="margin:0 0 6px 0">📝 Feedback & Impact (HIL — Human-in-the-Loop)</h1>
-  <div class="small">
-    Esta consola registra el <b>impacto real</b> de cada corrida y el <b>feedback técnico</b> de materiales
-    (rigidez, porosidad, superficie, unión, fallas), para que Rex-AI aprenda día a día.
-    Todo conecta con tus datos: target, candidato y proceso seleccionados.
-  </div>
-  <div class="legend" style="margin-top:8px">
-    <span class="pill info">1) Registra impacto</span>
-    <span class="pill info">2) Envia feedback de materiales</span>
-    <span class="pill ok">3) Visualiza métricas acumuladas</span>
-  </div>
-</div>
-""", unsafe_allow_html=True)
+st.markdown("---")
 
-# ========= Panel A: Registrar IMPACTO de la corrida =========
-st.markdown("### A) Registrar impacto de la corrida")
-
-colA, colB = st.columns([1.2, 1.0])
-with colA:
-    if not candidato or not target:
-        st.info("Seleccioná un candidato en **3) Generador** / **6) Pareto** para habilitar registro con datos reales.")
-    else:
-        st.markdown("**Contexto**")
-        st.write(f"- Escenario: **{scenario_label or '-'}**")
-        st.write(f"- Target: **{target.get('name','-')}**")
-        st.write(f"- Proceso: **{candidato['process_id']} {candidato['process_name']}**")
-        st.write(f"- Materiales: **{', '.join(candidato['materials'])}**")
-        if regolith_pct > 0:
-            st.write(f"- MGS-1 (regolito): **{regolith_pct*100:.0f}%** de la mezcla")
-            thermo = thermo_summary or {}
-            peak_lines: list[str] = []
-            for peak in thermo.get("peaks", []):
-                species = peak.get("species_label") or peak.get("species") or "Pico"
-                temperature = peak.get("temperature_c")
-                signal = peak.get("signal_ppb")
-                temp_txt = f"{temperature:.0f} °C" if isinstance(temperature, (int, float)) else "temperatura clave"
-                signal_txt = f" (~{signal:.2f} ppb eq.)" if isinstance(signal, (int, float)) else ""
-                peak_lines.append(f"    - {species}: pico a {temp_txt}{signal_txt}")
-            event_lines: list[str] = []
-            for event in thermo.get("events", []):
-                label = event.get("event", "")
-                temperature = event.get("temperature_c")
-                temp_txt = f"{temperature:.0f} °C" if isinstance(temperature, (int, float)) else "el perfil térmico"
-                mass_pct = event.get("mass_pct")
-                if isinstance(mass_pct, (int, float)) and label.startswith("mass_"):
-                    event_lines.append(f"    - Masa ≤ {mass_pct:.1f}% cerca de {temp_txt}")
-                elif label == "max_mass_loss_rate":
-                    event_lines.append(f"    - Mayor tasa de desgasificación cerca de {temp_txt}")
-            if peak_lines or event_lines:
-                st.markdown("**Guía térmica NASA (TG/EGA):**")
-                if peak_lines:
-                    st.markdown("- Pico gases:\n" + "\n".join(peak_lines))
-                if event_lines:
-                    st.markdown("- Eventos TG:\n" + "\n".join(event_lines))
-                st.caption(
-                    "Utilizá estos picos para saber cuándo ventilar el horno y revisar porosidad/estanqueidad en la pieza."
-                )
-
-with colB:
-    if props:
-        st.markdown("**Recursos/outputs de la corrida (predicción base)**")
-        c1,c2,c3,c4,c5 = st.columns(5)
-        c1.metric("Masa (kg)", f"{props.mass_final_kg:.2f}")
-        c2.metric("kWh", f"{props.energy_kwh:.2f}")
-        c3.metric("Agua (L)", f"{props.water_l:.2f}")
-        c4.metric("Crew (min)", f"{props.crew_min:.0f}")
-        c5.metric("Score", f"{candidato['score']:.2f}")
-
-st.markdown("")
-colBtn1, colBtn2 = st.columns([1,2])
-with colBtn1:
-    if candidato and target and st.button("💾 Guardar impacto de esta corrida", type="primary"):
-        p = props
+with st.form("impact_form"):
+    st.subheader("Registrar impacto de una corrida")
+    scenario = st.selectbox(
+        "Escenario",
+        [target.get("scenario", "-")] if isinstance(target, dict) else ["-"],
+    )
+    default_mass = float(getattr(props, "mass_final_kg", 0.0) or 0.0)
+    default_energy = float(getattr(props, "energy_kwh", 0.0) or 0.0)
+    default_water = float(getattr(props, "water_l", 0.0) or 0.0)
+    default_crew = float(getattr(props, "crew_min", 0.0) or 0.0)
+    col_mass, col_energy, col_water, col_crew = st.columns(4)
+    mass_value = col_mass.number_input("Masa final (kg)", min_value=0.0, value=default_mass, step=0.05)
+    energy_value = col_energy.number_input("Energía (kWh)", min_value=0.0, value=default_energy, step=0.01)
+    water_value = col_water.number_input("Agua (L)", min_value=0.0, value=default_water, step=0.01)
+    crew_value = col_crew.number_input("Crew (min)", min_value=0.0, value=default_crew, step=1.0)
+    impact_notes = st.text_area("Notas de la corrida", "")
+    submit_impact = st.form_submit_button("Guardar impacto")
+    if submit_impact:
+        candidate_materials = (selected_candidate.get("materials") if isinstance(selected_candidate, dict) else []) or []
+        candidate_weights = (selected_candidate.get("weights") if isinstance(selected_candidate, dict) else []) or []
+        process_id = str(selected_candidate.get("process_id", "")) if isinstance(selected_candidate, dict) else ""
+        process_name = str(selected_candidate.get("process_name", "")) if isinstance(selected_candidate, dict) else ""
+        score_value = selected_candidate.get("score", 0.0) if isinstance(selected_candidate, dict) else 0.0
         entry = ImpactEntry(
-            ts_iso=datetime.utcnow().isoformat(),
-            scenario=target.get("scenario","-"),
-            target_name=target.get("name","-"),
-            materials="|".join(candidato.get("materials", [])),
-            weights="|".join(map(str, candidato.get("weights", []))),
-            process_id=candidato.get("process_id","-"),
-            process_name=candidato.get("process_name","-"),
-            mass_final_kg=float(p.mass_final_kg),
-            energy_kwh=float(p.energy_kwh),
-            water_l=float(p.water_l),
-            crew_min=float(p.crew_min),
-            score=float(candidato.get("score", 0.0)),
-            extra={"regolith_pct": round(float(regolith_pct), 4)}
+            ts_iso=datetime.utcnow().isoformat() + "Z",
+            scenario=str(scenario),
+            target_name=str(target.get("name", "-")) if isinstance(target, dict) else "-",
+            materials="|".join(map(str, candidate_materials)),
+            weights="|".join(map(str, candidate_weights)),
+            process_id=process_id,
+            process_name=process_name,
+            mass_final_kg=float(mass_value),
+            energy_kwh=float(energy_value),
+            water_l=float(water_value),
+            crew_min=float(crew_value),
+            score=float(score_value or 0.0),
+            extra={"notes": impact_notes},
         )
         append_impact(entry)
-        st.success("Impacto registrado en el log.")
+        st.success("Impacto registrado.")
+        st.experimental_rerun()
 
-with colBtn2:
-    st.caption("Tip: registra impacto tras cada corrida para construir una curva de aprendizaje de materiales (y detectar desvíos).")
-
-st.markdown("---")
-
-# ========= Panel B: Feedback TÉCNICO de MATERIALES =========
-st.markdown("### B) Feedback técnico (materiales) — nivel laboratorio")
-
-col_feedback, col_reco = st.columns([1.45, 0.85])
-
-with col_feedback:
-    default_state = {
-        "feedback_astronaut": "",
-        "feedback_option_idx": 1,
-        "feedback_overall": 8,
-        "feedback_rigidity": 8,
-        "feedback_porosity": 3,
-        "feedback_surface": 7,
-        "feedback_bonding": 7,
-        "feedback_ease": 8,
-        "feedback_failure": "-",
-        "feedback_issues": "",
-        "feedback_notes": "",
-        "feedback_preset_last_applied": None,
-        "feedback_last_scenario": None,
-    }
-    for key, default in default_state.items():
-        st.session_state.setdefault(key, default)
-
-    preset_options = ["Manual", "Residence checklist", "Daring checklist"]
-    preset_key = "feedback_preset_select"
-    if preset_key not in st.session_state:
-        st.session_state[preset_key] = "Manual"
-
-    desired_preset = "Manual"
-    if scenario_key == "residence renovations":
-        desired_preset = "Residence checklist"
-    elif scenario_key == "daring discoveries":
-        desired_preset = "Daring checklist"
-
-    if st.session_state.get("feedback_last_scenario") != scenario_key:
-        st.session_state["feedback_last_scenario"] = scenario_key
-        st.session_state[preset_key] = desired_preset
-        st.session_state["feedback_preset_last_applied"] = None
-
-    selected_preset = st.selectbox(
-        "📋 Checklist sugerida",
-        preset_options,
-        key=preset_key,
-        help="Precarga sliders y notas con recomendaciones según el escenario detectado.",
-    )
-
-    last_applied = st.session_state.get("feedback_preset_last_applied")
-    if selected_preset != "Manual" and selected_preset != last_applied:
-        preset_payload = _build_feedback_preset(selected_preset, regolith_lines=regolith_observations)
-        if preset_payload:
-            for field, value in preset_payload.items():
-                state_key = _FEEDBACK_FIELD_KEYS.get(field)
-                if state_key is not None:
-                    st.session_state[state_key] = value
-        st.session_state["feedback_preset_last_applied"] = selected_preset
-    elif selected_preset == "Manual" and last_applied not in (None, "Manual"):
-        st.session_state["feedback_preset_last_applied"] = "Manual"
-
-    failure_options = ["-", "Fragil", "Dúctil", "Delaminación", "Agarre insuficiente", "Fatiga"]
-    if st.session_state.get("feedback_failure") not in failure_options:
-        st.session_state["feedback_failure"] = failure_options[0]
-
-    with st.form("feedback_form"):
-        col1, col2, col3 = st.columns(3)
-        with col1:
-            astronaut = st.text_input("Operador / Astronauta", key="feedback_astronaut")
-            option_idx = st.number_input(
-                "Opción elegida #",
-                min_value=1,
-                step=1,
-                value=int(st.session_state.get("feedback_option_idx", 1)),
-                key="feedback_option_idx",
-            )
-            overall = st.slider(
-                "Satisfacción global",
-                0,
-                10,
-                st.session_state.get("feedback_overall", 8),
-                help="0=Malísimo, 10=Excelente",
-                key="feedback_overall",
-            )
-        with col2:
-            rigidity_score = st.slider(
-                "Rigidez percibida",
-                0,
-                10,
-                st.session_state.get("feedback_rigidity", 8),
-                key="feedback_rigidity",
-            )
-            porosity = st.slider(
-                "Porosidad / compactación",
-                0,
-                10,
-                st.session_state.get("feedback_porosity", 3),
-                help="0=baja porosidad (mejor), 10=muy poroso",
-                key="feedback_porosity",
-            )
-            surface = st.slider(
-                "Calidad de superficie",
-                0,
-                10,
-                st.session_state.get("feedback_surface", 7),
-                key="feedback_surface",
-            )
-        with col3:
-            bonding = st.slider(
-                "Unión entre capas / partículas",
-                0,
-                10,
-                st.session_state.get("feedback_bonding", 7),
-                key="feedback_bonding",
-            )
-            failure = st.selectbox(
-                "Modo de falla observado",
-                failure_options,
-                key="feedback_failure",
-            )
-            ease_score = st.slider(
-                "Facilidad de proceso (ejecución)",
-                0,
-                10,
-                st.session_state.get("feedback_ease", 8),
-                key="feedback_ease",
-            )
-
-        issues = st.text_area(
-            "Problemas específicos (bordes, olor, slip, etc.)",
-            key="feedback_issues",
+with st.form("feedback_form"):
+    st.subheader("Registrar feedback operativo")
+    astronaut = st.text_input("Operador o equipo", value="")
+    overall = st.slider("Satisfacción general", 0, 10, 8)
+    rigidity_ok = st.checkbox("Rigidez dentro de lo esperado", value=True)
+    ease_ok = st.checkbox("Proceso fácil de ejecutar", value=True)
+    issues_text = st.text_area("Issues detectados", "")
+    notes_text = st.text_area("Notas adicionales", "")
+    submit_feedback = st.form_submit_button("Guardar feedback")
+    if submit_feedback:
+        entry = FeedbackEntry(
+            ts_iso=datetime.utcnow().isoformat() + "Z",
+            astronaut=astronaut or "-",
+            scenario=str(target.get("scenario", "-")) if isinstance(target, dict) else "-",
+            target_name=str(target.get("name", "-")) if isinstance(target, dict) else "-",
+            option_idx=int(selected_option_number or 0),
+            rigidity_ok=bool(rigidity_ok),
+            ease_ok=bool(ease_ok),
+            issues=issues_text,
+            notes=notes_text,
+            extra={
+                "feedback_overall": overall,
+                "feedback_rigidity": 10 if rigidity_ok else 5,
+                "feedback_ease": 10 if ease_ok else 5,
+            },
         )
-        notes = st.text_area(
-            "Notas libres / setup / parámetros",
-            key="feedback_notes",
-        )
-
-        submitted = st.form_submit_button("Enviar feedback")
-        if submitted:
-            entry = FeedbackEntry(
-                ts_iso=datetime.utcnow().isoformat(),
-                astronaut=astronaut or "anon",
-                scenario=target.get("scenario","-") if target else "-",
-                target_name=target.get("name","-") if target else "-",
-                option_idx=int(option_idx),
-                rigidity_ok=bool(rigidity_score >= 6),
-                ease_ok=bool(ease_score >= 6),
-                issues=issues,
-                notes=notes,
-                # campos extendidos en `.extra` (si tu dataclass no los tiene, se guardan como texto)
-                extra={
-                    "overall": overall,
-                    "porosity": porosity,
-                    "surface": surface,
-                    "bonding": bonding,
-                    "failure": failure,
-                }
-            )
-            append_feedback(entry)
-            st.success("Feedback guardado. Rex-AI utilizará estas señales para ajustar pesos/penalizaciones y recomendaciones.")
-
-with col_reco:
-    st.markdown("#### Observaciones sugeridas")
-    if scenario_label:
-        st.caption(f"Escenario detectado: {scenario_label}")
-    if regolith_pct > 0:
-        st.caption(f"Mezcla con MGS-1: {regolith_pct * 100:.0f}%")
-
-    scenario_hints = _scenario_side_hints(scenario_key)
-    combined: list[str] = []
-    seen: set[str] = set()
-    for hint in scenario_hints + regolith_observations:
-        if hint and hint not in seen:
-            combined.append(hint)
-            seen.add(hint)
-
-    if combined:
-        st.markdown("\n".join(f"- {hint}" for hint in combined))
-    else:
-        st.info("Seleccioná un target con escenario para ver recomendaciones automáticas.")
-
-st.markdown("---")
-
-# ========= Panel C: Impacto ACUMULADO y ANALÍTICA =========
-st.markdown("### C) Panel de impacto acumulado (conecta a tus logs)")
-
-idf = load_impact_df()
-fdf = load_feedback_df()
-sumy = summarize_impact(idf) if idf is not None and len(idf) else {"runs":0,"kg":0,"kwh":0,"water_l":0,"crew_min":0}
-
-k1,k2,k3,k4,k5 = st.columns(5)
-k1.metric("Corridas", int(sumy["runs"]))
-k2.metric("Kg valorizados", f"{sumy['kg']:.2f} kg")
-k3.metric("Energía total", f"{sumy['kwh']:.2f} kWh")
-k4.metric("Agua total", f"{sumy['water_l']:.2f} L")
-k5.metric("Crew total", f"{sumy['crew_min']:.0f} min")
-
-if idf is not None and len(idf):
-    # Normalizamos timestamp a día para tendencias
-    tmp = idf.copy()
-    tmp["date"] = pd.to_datetime(tmp["ts_iso"]).dt.date
-
-    cL, cR = st.columns([1.1, 1.0])
-
-    with cL:
-        st.markdown("**Tendencia diaria (kg / kWh / L / crew)**")
-        trend = tmp.groupby("date").agg({
-            "mass_final_kg":"sum",
-            "energy_kwh":"sum",
-            "water_l":"sum",
-            "crew_min":"sum"
-        }).reset_index().rename(columns={
-            "mass_final_kg":"Kg",
-            "energy_kwh":"kWh",
-            "water_l":"Agua (L)",
-            "crew_min":"Crew (min)"
-        })
-        st.line_chart(trend.set_index("date"))
-
-    with cR:
-        st.markdown("**Distribución por proceso (n corridas)**")
-        dist = tmp.groupby(["process_id","process_name"]).size().reset_index(name="runs").sort_values("runs", ascending=False)
-        st.bar_chart(dist.set_index("process_name")["runs"])
-        st.caption("¿Dónde estamos invirtiendo tiempo? ¿Vale la pena mover corridas a procesos más eficientes?")
-
-    st.markdown("**Detalle de corridas (impact log)**")
-    impact_display = _with_extra_columns(idf, {
-        "regolith_pct": "Regolith (%)",
-        "extra_regolith_pct": "Regolith (%)"
-    })
-    if "Regolith (%)" in impact_display.columns:
-        impact_display["Regolith (%)"] = impact_display["Regolith (%)"].apply(
-            lambda v: f"{float(v) * 100:.0f}%" if isinstance(v, str) and v.replace('.', '', 1).isdigit() else v
-        )
-    st.dataframe(impact_display, use_container_width=True, hide_index=True)
-
-    # Export
-    csv_buf = StringIO(); idf.to_csv(csv_buf, index=False)
-    st.download_button("⬇️ Descargar impacto (CSV)", data=csv_buf.getvalue().encode("utf-8"),
-                       file_name="impact_log.csv", mime="text/csv")
-else:
-    st.info("Aún no hay corridas registradas en el log de impacto.")
-
-st.markdown("---")
-
-st.markdown("### C.1) Feedback capturado (metadatos completos)")
-if fdf is not None and len(fdf):
-    feedback_display = _with_extra_columns(fdf, {
-        "overall": "Satisfacción", "porosity": "Porosidad",
-        "surface": "Superficie", "bonding": "Unión",
-        "failure": "Falla observada",
-        "extra_overall": "Satisfacción", "extra_porosity": "Porosidad",
-        "extra_surface": "Superficie", "extra_bonding": "Unión",
-        "extra_failure": "Falla observada"
-    })
-    # Para registros antiguos sin `extra`, mostramos '-'
-    for col in ["Satisfacción", "Porosidad", "Superficie", "Unión", "Falla observada"]:
-        if col in feedback_display.columns:
-            feedback_display[col] = feedback_display[col].replace({"": "-"}).fillna("-")
-    st.dataframe(feedback_display, use_container_width=True, hide_index=True)
-    csv_buf_fb = StringIO(); fdf.to_csv(csv_buf_fb, index=False)
-    st.download_button("⬇️ Descargar feedback (CSV)", data=csv_buf_fb.getvalue().encode("utf-8"),
-                       file_name="feedback_log.csv", mime="text/csv")
-else:
-    st.info("Aún no hay feedback registrado.")
-
-st.markdown("---")
-st.markdown("### D) Lectura rápida para aprendices (¿por qué esto importa?)")
-g1, g2 = st.columns(2)
-with g1:
-    st.markdown("""
-- **Impacto = realidad**: qué tanto residuo convertimos en producto y a qué costo (energía/agua/crew).
-- **Feedback ≠ opinión suelta**: capturamos señales de materiales (rigidez, porosidad, unión) que Rex-AI usa para ajustar decisiones.
-- **Efecto MGS-1**: cuando el proceso es sinterizado, verás en el log `extra=regolith_pct=XX`. El regolito sube rigidez pero puede abrir microcanales al liberar H₂O/CO₂: anotá si aumenta porosidad o si hubo que ventilar más el horno.
-""")
-with g2:
-    st.markdown("""
-- **Cómo usarlo**: tras cada corrida, registra impacto (1 click) y cuelga feedback (2 min).  
-- **Cómo leerlo**: mirá la tendencia diaria; si los kWh suben por pieza, hay algo en el setup.  
-- **Qué permite**: cerrar el loop *plan → ejecutar → medir → aprender* como en un banco de pruebas de SpaceX/NASA.
-""")
-
-st.caption("¿Ideas para nuevas métricas? Podemos agregar dureza Shore, módulo aparente, densidad aparente, etc., si pasan a formar parte de la captura del laboratorio.")
+        append_feedback(entry)
+        st.success("Feedback registrado.")
+        st.experimental_rerun()

--- a/app/pages/9_Capacity_Simulator.py
+++ b/app/pages/9_Capacity_Simulator.py
@@ -1,13 +1,16 @@
-# app/pages/9_Capacity_Simulator.py
+"""Lightweight capacity simulator driven by shared helpers."""
+
 import _bootstrap  # noqa: F401
 
-# ⚠️ Debe ser la PRIMERA llamada de Streamlit
+import pandas as pd
 import streamlit as st
 
-st.set_page_config(page_title="Capacity Simulator", page_icon="🧮", layout="wide")
-
+from app.modules.capacity import LineConfig, simulate
 from app.modules.navigation import render_breadcrumbs, set_active_step
-from app.modules.ui_blocks import load_theme
+from app.modules.ui_blocks import layout_stack, load_theme
+
+
+st.set_page_config(page_title="Capacity Simulator", page_icon="🧮", layout="wide")
 
 current_step = set_active_step("capacity")
 
@@ -15,271 +18,108 @@ load_theme()
 
 render_breadcrumbs(current_step)
 
-import math
-import numpy as np
-import pandas as pd
-import plotly.express as px
+target = st.session_state.get("target")
+selected_state = st.session_state.get("selected")
+selected_candidate = selected_state.get("data") if isinstance(selected_state, dict) else None
+props = selected_candidate.get("props") if isinstance(selected_candidate, dict) else None
 
-# Usamos tu módulo existente para mantener compatibilidad
-from app.modules.capacity import LineConfig, simulate
+with layout_stack():
+    st.title("🧮 Capacity Simulator")
+    st.caption("Evalúa la producción diaria frente a límites de recursos y downtime estimado.")
 
-# ============== Estilos SpaceX/NASA-like ==============
-st.markdown(
-    """
-    <style>
-    .callout{border-left:4px solid #8ab4ff; padding:10px 12px; background:rgba(138,180,255,.08); border-radius:8px;}
-    </style>
-    """,
-    unsafe_allow_html=True,
-)
+col_left, col_right = st.columns(2)
+with col_left:
+    shifts_per_sol = st.slider("Turnos por sol", 1, 6, 2)
+    num_sols = st.slider("Horizonte (soles)", 1, 120, 30)
+    batches_per_shift = st.number_input("Lotes por turno", min_value=1, value=3)
+    efficiency = st.slider("Eficiencia de la línea", 0.5, 1.2, 0.95, step=0.01)
+with col_right:
+    downtime_pct = st.slider("Downtime estimado (%)", 0, 40, 5)
+    energy_limit = st.number_input("Límite kWh por sol", min_value=0.0, value=float(target.get("max_energy_kwh", 250.0)) if isinstance(target, dict) else 250.0)
+    water_limit = st.number_input("Límite de agua (L) por sol", min_value=0.0, value=float(target.get("max_water_l", 30.0)) if isinstance(target, dict) else 30.0)
+    crew_limit = st.number_input("Límite de crew (min) por sol", min_value=0.0, value=float(target.get("max_crew_min", 600.0)) if isinstance(target, dict) else 600.0)
 
-# ============== Estado compartido con el resto de la app ==============
-target    = st.session_state.get("target", None)
-selected  = st.session_state.get("selected", None)
-cand      = selected["data"] if selected else None
-props     = cand["props"] if cand else None
+default_mass = float(getattr(props, "mass_final_kg", 1.0) or 1.0)
+default_energy = float(getattr(props, "energy_kwh", 1.2) or 1.2)
+default_water = float(getattr(props, "water_l", 0.1) or 0.1)
+default_crew = float(getattr(props, "crew_min", 25.0) or 25.0)
 
-# Defaults inteligentes (si hay candidato activo, usamos sus recursos por lote)
-default_kg_per_batch      = round(float(props.mass_final_kg), 2) if props else 0.95
-default_kwh_per_batch     = round(float(props.energy_kwh), 2)    if props else 1.20
-default_water_per_batch   = round(float(props.water_l), 2)       if props else 0.10
-default_crew_min_per_batch= round(float(props.crew_min), 1)      if props else 25.0
+resource_cols = st.columns(4)
+kg_per_batch = resource_cols[0].number_input("Kg por lote", min_value=0.01, value=default_mass, step=0.05)
+energy_per_batch = resource_cols[1].number_input("kWh por lote", min_value=0.0, value=default_energy, step=0.01)
+water_per_batch = resource_cols[2].number_input("Agua (L) por lote", min_value=0.0, value=default_water, step=0.01)
+crew_per_batch = resource_cols[3].number_input("Crew (min) por lote", min_value=0.0, value=default_crew, step=1.0)
 
-# ============== HERO ==============
-st.markdown("""
-<div class="hero">
-  <h1 style="margin:0 0 6px 0">🧮 Capacity Simulator — Mission Ops</h1>
-  <div class="small">
-    Planifica cuánta <b>producción</b> (kg) podés lograr en un horizonte de <b>soles</b> con
-    tus <b>recursos</b> (kWh, agua, minutos de crew) y tu línea de proceso. 
-    Trae por defecto los parámetros del candidato seleccionado (si lo hay) para cerrar el loop: <i>Generador → Resultados → Pareto → Capacidad</i>.
-  </div>
-  <div class="legend" style="margin-top:8px">
-    <span class="pill info">1) Define tus turnos y lotes</span>
-    <span class="pill info">2) Ajusta recursos por lote</span>
-    <span class="pill info">3) Aplica límites/downtime</span>
-    <span class="pill ok">4) Simula y compara contra la meta</span>
-  </div>
-</div>
-""", unsafe_allow_html=True)
+simulate_clicked = st.button("Simular", type="primary")
 
-# ============== Panel de Configuración (Inputs) ==============
-st.markdown("### 1) Configuración de la línea (como en el piso del hábitat)")
-
-cA, cB, cC = st.columns([1.2, 1.1, 1.0])
-
-with cA:
-    st.markdown("**Turnos y horizonte**")
-    shifts_per_sol = st.slider("Turnos por sol marciano", 1, 6, 2, help="Cantidad de turnos operativos por sol.")
-    num_sols       = st.slider("Soles simulados", 1, 180, 30, help="Ventana de planificación (soles).")
-    downtime_pct   = st.slider("Probabilidad de downtime (%)", 0, 30, 5, help="Tiempo improductivo por mantenimiento, setup, fallas.")
-    efficiency     = st.slider("Eficiencia de línea (×)", 0.70, 1.10, 0.95, 0.01,
-                               help="Factor que impacta kg por lote (p.ej., 0.9 = 90% de lo nominal).")
-
-with cB:
-    st.markdown("**Lotes y recursos por lote**")
-    batches_per_shift = st.number_input("Lotes por turno", 1, 200, 3, 1,
-                                        help="Cuántos ciclos completos de proceso haces en un turno.")
-    kg_min, kg_max = 0.05, 200.0
-    kg_default = min(kg_max, max(kg_min, float(default_kg_per_batch)))
-    kg_per_batch      = st.number_input("Kg por lote", kg_min, kg_max, kg_default, 0.05)
-
-    kwh_min, kwh_max = 0.0, 50.0
-    kwh_default = min(kwh_max, max(kwh_min, float(default_kwh_per_batch)))
-    energy_kwh_per_batch = st.number_input("kWh por lote", kwh_min, kwh_max, kwh_default, 0.01)
-
-    water_min, water_max = 0.0, 50.0
-    water_default = min(water_max, max(water_min, float(default_water_per_batch)))
-    water_l_per_batch = st.number_input("Agua (L) por lote", water_min, water_max, water_default, 0.01)
-
-    crew_min, crew_max = 0.0, 600.0
-    crew_default = min(crew_max, max(crew_min, float(default_crew_min_per_batch)))
-    crew_min_per_batch= st.number_input("Crew (min) por lote", crew_min, crew_max, crew_default, 1.0)
-
-with cC:
-    st.markdown("**Límites por sol (capas de seguridad)**")
-    limit_kwh  = st.number_input("Límite kWh/sol", 0.0, 10_000.0, 250.0, 1.0,
-                                 help="Tope de energía disponible por sol.")
-    limit_water= st.number_input("Límite Agua (L)/sol", 0.0, 10_000.0, 30.0, 0.5,
-                                 help="Tope de agua utilizable por sol.")
-    limit_crew = st.number_input("Límite Crew (min)/sol", 0.0, 10_000.0, 600.0, 10.0,
-                                 help="Tope de minutos de tripulación por sol.")
-    goal_kg    = st.number_input("Meta de producción (kg)", 0.0, 100_000.0, 250.0, 1.0,
-                                 help="Objetivo total para el horizonte.")
-
-st.markdown("---")
-
-# ============== Simulación (conectada a tus datos) ==============
-st.markdown("### 2) Simular")
-
-if st.button("▶️ Ejecutar simulación", type="primary"):
-    # 2.1: simulación base con tu módulo
-    cfg = LineConfig(
+if simulate_clicked:
+    config = LineConfig(
         batches_per_shift=int(batches_per_shift),
-        kg_per_batch=float(kg_per_batch) * float(efficiency),
-        energy_kwh_per_batch=float(energy_kwh_per_batch),
-        water_l_per_batch=float(water_l_per_batch),
-        crew_min_per_batch=float(crew_min_per_batch)
+        kg_per_batch=float(kg_per_batch) * efficiency,
+        energy_kwh_per_batch=float(energy_per_batch),
+        water_l_per_batch=float(water_per_batch),
+        crew_min_per_batch=float(crew_per_batch),
     )
-    base = simulate(cfg, shifts_per_sol=int(shifts_per_sol), num_sols=int(num_sols))
-    # base = {"batches","kg","kwh","water_l","crew_min"}
+    aggregate = simulate(config, shifts_per_sol=int(shifts_per_sol), num_sols=int(num_sols))
 
-    # 2.2: aplicar downtime y límites por sol (distribución diaria)
-    days = np.arange(1, int(num_sols)+1)
+    batches_per_day = config.batches_per_shift * int(shifts_per_sol)
+    base_kg = config.kg_per_batch * batches_per_day
+    base_kwh = config.energy_kwh_per_batch * batches_per_day
+    base_water = config.water_l_per_batch * batches_per_day
+    base_crew = config.crew_min_per_batch * batches_per_day
 
-    # producción teórica por sol (antes de límites/downtime)
-    batches_per_day = int(shifts_per_sol) * int(batches_per_shift)
-    kg_day_nom   = cfg.kg_per_batch * batches_per_day
-    kwh_day_nom  = cfg.energy_kwh_per_batch * batches_per_day
-    water_day_nom= cfg.water_l_per_batch * batches_per_day
-    crew_day_nom = cfg.crew_min_per_batch * batches_per_day
-
-    # downtime & jitter ligero para hacerlo realista
-    rng = np.random.default_rng(42)
-    downtime_mask = rng.random(size=len(days)) < (float(downtime_pct)/100.0)
-    jitter = rng.normal(1.0, 0.03, size=len(days))
-
-    kg_day   = kg_day_nom   * jitter * (~downtime_mask)
-    kwh_day  = kwh_day_nom  * jitter * (~downtime_mask)
-    water_day= water_day_nom* jitter * (~downtime_mask)
-    crew_day = crew_day_nom * jitter * (~downtime_mask)
-
-    # aplicar límites por sol
-    def apply_limits(k_kg, k_kwh, k_water, k_crew):
-        # verificamos el “recurso cuello de botella” y recortamos proporcionalmente
+    downtime_factor = 1.0 - (float(downtime_pct) / 100.0)
+    per_day_rows = []
+    cumulative_kg = 0.0
+    for day in range(1, int(num_sols) + 1):
+        kg_day = base_kg * downtime_factor
+        kwh_day = base_kwh * downtime_factor
+        water_day = base_water * downtime_factor
+        crew_day = base_crew * downtime_factor
         ratios = []
-        if limit_kwh  > 0: ratios.append(limit_kwh  / max(1e-6, k_kwh))
-        if limit_water> 0: ratios.append(limit_water/ max(1e-6, k_water))
-        if limit_crew > 0: ratios.append(limit_crew / max(1e-6, k_crew))
-        factor = min(1.0, *ratios) if ratios else 1.0
-        return (k_kg*factor, k_kwh*factor, k_water*factor, k_crew*factor, factor)
-
-    rows = []
-    for d, a,b,c,dcrew in zip(days, kg_day, kwh_day, water_day, crew_day):
-        out_kg, out_kwh, out_water, out_crew, util = apply_limits(a,b,c,dcrew)
-        rows.append({
-            "sol": int(d),
-            "kg": float(out_kg),
-            "kWh": float(out_kwh),
-            "Agua (L)": float(out_water),
-            "Crew (min)": float(out_crew),
-            "utilización vs. límites": float(util),
-            "downtime": bool(downtime_mask[d-1])
-        })
-    daily = pd.DataFrame(rows)
-    daily["kg_cum"] = daily["kg"].cumsum()
-
-    # 2.3: KPIs
-    col1, col2, col3, col4, col5 = st.columns(5)
-    col1.metric("Kg totales", f"{daily['kg'].sum():.2f}")
-    col2.metric("kWh totales", f"{daily['kWh'].sum():.2f}")
-    col3.metric("Agua total (L)", f"{daily['Agua (L)'].sum():.2f}")
-    col4.metric("Crew total (min)", f"{daily['Crew (min)'].sum():.0f}")
-    # Día en que se alcanza la meta (si se alcanza)
-    hit_goal_day = np.argmax(daily["kg_cum"].values >= goal_kg) + 1 if (daily["kg_cum"] >= goal_kg).any() else None
-    if hit_goal_day:
-        col5.metric("Meta alcanzada en sol", f"{hit_goal_day}")
-    else:
-        col5.metric("Meta alcanzada", "No", delta=f"Faltan {max(0.0, goal_kg - daily['kg'].sum()):.1f} kg")
-
-    # 2.4: Visualizaciones principales
-    a1, a2 = st.columns([1.3, 1.0])
-
-    with a1:
-        st.markdown("**Producción acumulada (kg) vs Meta**")
-        fig = px.line(daily, x="sol", y="kg_cum", markers=True)
-        fig.add_hline(y=goal_kg, line_dash="dash", line_color="#888", annotation_text="Meta (kg)")
-        fig.update_layout(height=360, xaxis_title="Sol", yaxis_title="Kg acumulados")
-        st.plotly_chart(fig, use_container_width=True)
-
-    with a2:
-        st.markdown("**Consumo por sol (kWh / Agua / Crew)**")
-        fig2 = px.line(
-            daily.melt(id_vars=["sol"], value_vars=["kWh","Agua (L)","Crew (min)"], var_name="Recurso", value_name="Valor"),
-            x="sol", y="Valor", color="Recurso", markers=True
+        if energy_limit:
+            ratios.append(energy_limit / max(kwh_day, 1e-6))
+        if water_limit:
+            ratios.append(water_limit / max(water_day, 1e-6))
+        if crew_limit:
+            ratios.append(crew_limit / max(crew_day, 1e-6))
+        limit_factor = min(1.0, *ratios) if ratios else 1.0
+        kg_day *= limit_factor
+        kwh_day *= limit_factor
+        water_day *= limit_factor
+        crew_day *= limit_factor
+        cumulative_kg += kg_day
+        per_day_rows.append(
+            {
+                "Sol": day,
+                "Kg": kg_day,
+                "kWh": kwh_day,
+                "Agua (L)": water_day,
+                "Crew (min)": crew_day,
+                "Utilización vs límites": limit_factor,
+                "Downtime aplicado": downtime_pct,
+            }
         )
-        fig2.update_layout(height=360, xaxis_title="Sol")
-        st.plotly_chart(fig2, use_container_width=True)
 
-    b1, b2 = st.columns([1.0, 1.0])
-    with b1:
-        st.markdown("**Utilización vs. límites (1 = al límite)**")
-        fig3 = px.area(daily, x="sol", y="utilización vs. límites")
-        fig3.add_hline(y=1.0, line_dash="dot", line_color="#999")
-        fig3.update_layout(height=300, yaxis_range=[0, 1.15], xaxis_title="Sol", yaxis_title="Utilización")
-        st.plotly_chart(fig3, use_container_width=True)
+    per_day_df = pd.DataFrame(per_day_rows)
+    total_row = {
+        "Sol": "Total",
+        "Kg": per_day_df["Kg"].sum(),
+        "kWh": per_day_df["kWh"].sum(),
+        "Agua (L)": per_day_df["Agua (L)"].sum(),
+        "Crew (min)": per_day_df["Crew (min)"].sum(),
+        "Utilización vs límites": per_day_df["Utilización vs límites"].mean(),
+        "Downtime aplicado": downtime_pct,
+    }
 
-    with b2:
-        st.markdown("**Downtime por sol**")
-        dt = daily[["sol","downtime"]].copy()
-        dt["valor"] = dt["downtime"].astype(int)
-        fig4 = px.bar(dt, x="sol", y="valor", color="downtime", color_discrete_map={True:"#f59e0b", False:"#93c5fd"})
-        fig4.update_layout(height=300, xaxis_title="Sol", yaxis_title="Downtime (0/1)", showlegend=False)
-        st.plotly_chart(fig4, use_container_width=True)
+    metric_summary = st.columns(4)
+    metric_summary[0].metric("Lotes totales", aggregate.get("batches", 0))
+    metric_summary[1].metric("Kg totales", f"{total_row['Kg']:.2f}")
+    metric_summary[2].metric("kWh totales", f"{total_row['kWh']:.2f}")
+    metric_summary[3].metric("Crew total (min)", f"{total_row['Crew (min)']:.0f}")
 
-    # 2.5: Tabla diaria y export
-    st.markdown("**Tabla diaria (post-límites y downtime)**")
-    st.dataframe(daily, use_container_width=True, hide_index=True)
-
-    csv = daily.to_csv(index=False).encode("utf-8")
-    st.download_button("⬇️ Descargar simulación (CSV)", data=csv, file_name="capacity_daily.csv", mime="text/csv")
-
-    # 2.6: Bloque de interpretación (criollo + técnico)
-    st.markdown("### 3) ¿Cómo leer esto? (criollo & técnico)")
-    cL, cR = st.columns(2)
-    with cL:
-        st.markdown("""
-**En criollo**
-- Pensá cada lote como una “hornada”. Si metés 3 lotes por turno y 2 turnos por sol, son 6 hornadas/sol.
-- La línea no es perfecta: podés perder tiempo por ajustes/mantenimiento (**downtime**).
-- Además, hay límites duros (kWh/sol, agua/sol, minutos de crew). Si te pasás, el simulador recorta la producción de ese día.
-- Buscá que la curva **Kg acumulados** cruce la **meta** antes de tu deadline.
-""")
-    with cR:
-        st.markdown("""
-**Técnico (rápido)**
-- **kg_día** = `kg_lote × lotes_turno × turnos_sol × eficiencia × (1 - downtime)`  
-  Luego se aplica un factor de recorte por el recurso **cuello de botella** del día.
-- **Cuello de botella** = argmin { `límite_recurso / consumo_día_recurso` }  
-  Ese recurso define la **utilización** (si =1, estás al límite).
-- Si tu **utilización** está cerca de 1 en muchos días → aumentar límites o bajar consumo por lote.
-""")
-
-    # 2.7: Sugerencias automáticas (pequeño optimizador heurístico)
-    st.markdown("### 4) Sugerencias automáticas (heurística)")
-    tips = []
-    if daily["utilización vs. límites"].mean() > 0.95:
-        tips.append("Estás pegando contra límites casi todos los días. Considerá subir kWh/sol, Agua/sol o Crew/sol, o bajar recursos por lote.")
-    if not hit_goal_day:
-        tips.append("No alcanzás la meta: incrementá `lotes por turno` o `turnos por sol`, o subí `kg por lote` (si la calidad lo permite).")
-    if (downtime_pct > 10):
-        tips.append("Downtime alto. Evalúa mantenimiento preventivo o buffers de WIP para desacoplar equipos.")
-    if efficiency < 0.9:
-        tips.append("La eficiencia es baja. Revisa setup, temperatura/tiempos del proceso y entrenamiento de operadores.")
-    if not tips:
-        tips.append("Setup sólido. Probá un pequeño DoE: ±5% en kg por lote y lotes por turno para hallar un ‘sweet spot’.")
-    st.markdown("<div class='callout'>" + "<br>• ".join(["**Recomendaciones:**"] + tips) + "</div>", unsafe_allow_html=True)
-
+    st.subheader("Producción por sol")
+    result_table = pd.concat([per_day_df, pd.DataFrame([total_row])], ignore_index=True)
+    st.dataframe(result_table, use_container_width=True, hide_index=True)
 else:
-    # Estado inicial con guía
-    st.info("Configura los parámetros arriba y pulsa **▶️ Ejecutar simulación**. "
-            "Si ya elegiste un candidato en Generador/Pareto, pre-cargamos los recursos por lote para que simules sobre datos reales.")
-
-# ============== Apoyo didáctico para aprendices ==============
-st.markdown("---")
-st.markdown("### 5) Lectura rápida para aprendices")
-g1, g2 = st.columns(2)
-with g1:
-    st.markdown("""
-- **¿Para qué sirve?** Para saber cuántos kg podés producir en X soles sin romper tus límites (kWh, agua, crew).
-- **¿Qué toco primero?** Probá subir `lotes por turno` y `turnos por sol`. Luego ajustá `kg por lote`.
-- **¿Por qué hay ‘downtime’?** Porque en la vida real se hacen ajustes, hay esperas y pequeñas fallas.
-""")
-with g2:
-    st.markdown("""
-- **¿Qué miro para decidir?**  
-  1) que la curva **Kg acumulados** cruce tu meta,  
-  2) que la **utilización** no sea 1 todos los días,  
-  3) que no te pases de los límites de recursos.
-- **¿Qué exporto?** La tabla diaria (CSV) para presentar al equipo y justificar recursos o turnos.
-""")
+    st.caption("Configurá los parámetros y presioná **Simular** para ver la proyección por sol.")

--- a/tests/pages/test_export.py
+++ b/tests/pages/test_export.py
@@ -1,0 +1,82 @@
+import json
+from types import SimpleNamespace
+
+import pandas as pd
+import pytest
+
+from app.modules.exporters import candidate_to_csv, candidate_to_json
+from app.modules.page_data import (
+    build_candidate_export_table,
+    build_material_summary_table,
+)
+
+
+def _sample_candidate():
+    return {
+        "process_id": "P01",
+        "process_name": "Laminar",
+        "materials": ["Regolith", "PET flakes"],
+        "weights": [0.6, 0.4],
+        "score": 0.87,
+        "props": SimpleNamespace(
+            energy_kwh=1.2,
+            water_l=0.35,
+            crew_min=32.0,
+            mass_final_kg=1.05,
+            rigidity=0.78,
+            tightness=0.65,
+        ),
+        "source_ids": ["A-1"],
+    }
+
+
+def test_build_candidate_export_table_includes_reference_metrics():
+    inventory = pd.DataFrame(
+        {
+            "id": ["A-1"],
+            "pc_density_density_g_per_cm3": [1.12],
+            "pc_mechanics_tensile_strength_mpa": [48.0],
+            "pc_mechanics_modulus_gpa": [3.5],
+            "pc_thermal_glass_transition_c": [145.0],
+            "pc_ignition_ignition_temperature_c": [280.0],
+            "pc_ignition_burn_time_min": [2.5],
+        }
+    )
+
+    df = build_candidate_export_table([_sample_candidate()], inventory)
+
+    assert "ρ ref (g/cm³)" in df.columns
+    assert "σₜ ref (MPa)" in df.columns
+    assert df.iloc[0]["ρ ref (g/cm³)"] == pytest.approx(1.12)
+    assert df.iloc[0]["Score"] == pytest.approx(0.87)
+
+
+def test_material_summary_table_aggregates_weights():
+    candidates = [
+        _sample_candidate(),
+        {
+            "materials": ["Regolith", "Glass"],
+            "weights": [0.4, 0.6],
+            "props": SimpleNamespace(),
+        },
+    ]
+
+    summary = build_material_summary_table(candidates)
+    assert "Regolith" in summary["Material"].values
+    regolith_row = summary[summary["Material"] == "Regolith"].iloc[0]
+    assert regolith_row["Peso total"] == pytest.approx(1.0)
+    assert regolith_row["Participaciones"] == 2
+
+
+def test_candidate_export_serialization_roundtrip():
+    candidate = _sample_candidate()
+    target = {"name": "Mission", "max_energy_kwh": 2.0}
+    safety = {"level": "OK", "detail": "Sin hallazgos."}
+
+    json_payload = json.loads(candidate_to_json(candidate, target, safety).decode("utf-8"))
+    csv_payload = candidate_to_csv(candidate).decode("utf-8")
+
+    assert json_payload["candidate"]["process"]["id"] == "P01"
+    assert json_payload["candidate"]["predictions"]["energy_kwh"] == pytest.approx(1.2)
+    assert "process_id" in csv_payload
+    assert "Laminar" in csv_payload


### PR DESCRIPTION
## Summary
- replace the Pareto & Export page with a simplified layout that reuses shared data helpers and focuses on interactive tables and export buttons
- streamline the scenario playbooks, feedback, and capacity simulator pages to rely on lightweight components and decision-oriented metrics
- extend page data helpers and add material/feedback summaries plus new unit tests covering export data and serializers

## Testing
- `pytest tests/pages/test_export.py`
- `pytest` *(fails: upstream polars module in data_sources lacks read_csv attribute in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ddcb54d2f88331acdc62b92c2ae8a2