### PR TITLE
Ensure Streamlit entrypoints bootstrap project root

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ streamlit run app/Home.py
 
 No se requieren variables de entorno adicionales para el arranque interactivo.
 
+> ⚙️ **Bootstrap obligatorio:** antes de importar desde `app.modules`, cada
+> script de Streamlit debe ejecutar `from app.bootstrap import
+> ensure_project_root; ensure_project_root()`. Esto garantiza que la carpeta
+> raíz del repositorio esté en `sys.path` cuando se ejecutan archivos sueltos
+> con `streamlit run` o `python app/...`.
+
 El script `app/Home.py` renderiza la misma vista de *Mission Overview* que la
 entrada multipágina `app/pages/0_Mission_Overview.py`, de modo que la pantalla
 principal y el paso "Overview" permanecen sincronizados.

--- a/app/Home.py
+++ b/app/Home.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+from app.bootstrap import ensure_project_root
+
+ensure_project_root()
+
 from datetime import datetime
 from pathlib import Path
 from typing import Iterable

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -2,11 +2,8 @@
 
 from __future__ import annotations
 
-import sys
-from pathlib import Path
+from .bootstrap import ensure_project_root
 
-ROOT = Path(__file__).resolve().parents[1]
-if str(ROOT) not in sys.path:
-    sys.path.insert(0, str(ROOT))
+ROOT = ensure_project_root()
 
-__all__ = ["ROOT"]
+__all__ = ["ROOT", "ensure_project_root"]

--- a/app/bootstrap.py
+++ b/app/bootstrap.py
@@ -1,0 +1,25 @@
+"""Bootstrap helpers for Streamlit entrypoints."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+def ensure_project_root() -> Path:
+    """Ensure the repository root is present on ``sys.path``.
+
+    Streamlit executes scripts as modules, and when running standalone files
+    the repository root might be missing from ``sys.path``. This helper makes
+    sure the absolute path two levels above this file (the project root) is
+    inserted so imports like ``app.modules`` succeed reliably.
+    """
+
+    root = Path(__file__).resolve().parents[1]
+    root_str = str(root)
+    if root_str not in sys.path:
+        sys.path.insert(0, root_str)
+    return root
+
+
+__all__ = ["ensure_project_root"]

--- a/tests/ui/test_home_bootstrap_import.py
+++ b/tests/ui/test_home_bootstrap_import.py
@@ -1,0 +1,12 @@
+"""Smoke test to ensure the Streamlit home entrypoint can be imported."""
+
+from __future__ import annotations
+
+import importlib
+
+
+def test_home_module_importable() -> None:
+    """Import ``app.Home`` ensuring bootstrap wiring prevents path issues."""
+
+    module = importlib.import_module("app.Home")
+    assert module is not None


### PR DESCRIPTION
## Summary
- add a reusable `ensure_project_root()` helper for Streamlit scripts
- invoke the bootstrap helper in `app/Home.py` and expose it via `app.__init__`
- document the requirement to call the bootstrap helper and cover it with a smoke test

## Testing
- `pytest tests/ui/test_home_bootstrap_import.py`


------
https://chatgpt.com/codex/tasks/task_e_68decd1772d08331b17cfe24049b09a5