### PR TITLE
Ensure Streamlit pages bootstrap project root

### DIFF
--- a/app/pages/0_Mission_Overview.py
+++ b/app/pages/0_Mission_Overview.py
@@ -1,5 +1,9 @@
 """Mission overview entrypoint consolidating mission status panels."""
 
+from app.bootstrap import ensure_project_root
+
+ensure_project_root()
+
 from app.Home import render_page
 
 render_page()

--- a/app/pages/2_Target_Designer.py
+++ b/app/pages/2_Target_Designer.py
@@ -1,3 +1,7 @@
+from app.bootstrap import ensure_project_root
+
+ensure_project_root()
+
 import streamlit as st
 
 from app.modules.io import load_targets

--- a/app/pages/3_Generator.py
+++ b/app/pages/3_Generator.py
@@ -1,3 +1,7 @@
+from app.bootstrap import ensure_project_root
+
+ensure_project_root()
+
 from typing import Any, Mapping
 
 import math

--- a/app/pages/4_Results_and_Tradeoffs.py
+++ b/app/pages/4_Results_and_Tradeoffs.py
@@ -1,3 +1,7 @@
+from app.bootstrap import ensure_project_root
+
+ensure_project_root()
+
 import altair as alt
 import pandas as pd
 import plotly.graph_objects as go

--- a/app/pages/5_Compare_and_Explain.py
+++ b/app/pages/5_Compare_and_Explain.py
@@ -1,3 +1,7 @@
+from app.bootstrap import ensure_project_root
+
+ensure_project_root()
+
 import numpy as np
 import streamlit as st
 import pandas as pd

--- a/app/pages/6_Pareto_and_Export.py
+++ b/app/pages/6_Pareto_and_Export.py
@@ -1,5 +1,9 @@
 """Streamlined Pareto exploration and export centre."""
 
+from app.bootstrap import ensure_project_root
+
+ensure_project_root()
+
 import math
 from typing import Iterable
 

--- a/app/pages/7_Scenario_Playbooks.py
+++ b/app/pages/7_Scenario_Playbooks.py
@@ -1,5 +1,9 @@
 """Simplified scenario playbooks with actionable summaries."""
 
+from app.bootstrap import ensure_project_root
+
+ensure_project_root()
+
 from typing import Iterable
 
 import pandas as pd

--- a/app/pages/8_Feedback_and_Impact.py
+++ b/app/pages/8_Feedback_and_Impact.py
@@ -1,5 +1,9 @@
 """Consolidated feedback capture and mission impact tracking."""
 
+from app.bootstrap import ensure_project_root
+
+ensure_project_root()
+
 from datetime import datetime
 
 import pandas as pd

--- a/app/pages/9_Capacity_Simulator.py
+++ b/app/pages/9_Capacity_Simulator.py
@@ -1,5 +1,9 @@
 """Lightweight capacity simulator driven by shared helpers."""
 
+from app.bootstrap import ensure_project_root
+
+ensure_project_root()
+
 import pandas as pd
 import streamlit as st
 

--- a/tests/ui/test_action_button_usage.py
+++ b/tests/ui/test_action_button_usage.py
@@ -9,9 +9,19 @@ from typing import Any
 import pytest
 
 
-for _missing in ("joblib", "plotly"):
-    sys.modules.setdefault(_missing, types.ModuleType(_missing))
-sys.modules.setdefault("plotly.graph_objects", types.ModuleType("plotly.graph_objects"))
+sys.modules.setdefault("joblib", types.ModuleType("joblib"))
+
+try:  # prefer the real dependency when available
+    import plotly  # type: ignore[import]
+
+    # Ensure the submodules used in the UI helpers are importable during the test
+    import plotly.graph_objects  # noqa: F401  # type: ignore[import]
+    import plotly.io  # noqa: F401  # type: ignore[import]
+except ModuleNotFoundError:  # pragma: no cover - fallback for minimal environments
+    stub = types.ModuleType("plotly")
+    sys.modules.setdefault("plotly", stub)
+    sys.modules.setdefault("plotly.graph_objects", types.ModuleType("plotly.graph_objects"))
+    sys.modules.setdefault("plotly.io", types.ModuleType("plotly.io"))
 
 _polars = types.ModuleType("polars")
 


### PR DESCRIPTION
## Summary
- call `ensure_project_root()` from all Streamlit pages before any other imports to guarantee module resolution
- reuse the shared bootstrap helper and adjust UI action button test to prefer real Plotly or provide a lightweight stub fallback

## Testing
- `pytest -k streamlit`


------
https://chatgpt.com/codex/tasks/task_e_68decdd74de48331942e9899f41cf169