### PR TITLE
Ensure Streamlit entrypoints bootstrap project root consistently

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,25 @@ streamlit run app/Home.py
 
 No se requieren variables de entorno adicionales para el arranque interactivo.
 
-> ⚙️ **Bootstrap obligatorio:** antes de importar desde `app.modules`, cada
-> script de Streamlit debe ejecutar `from app.bootstrap import
-> ensure_project_root; ensure_project_root()`. Esto garantiza que la carpeta
-> raíz del repositorio esté en `sys.path` cuando se ejecutan archivos sueltos
-> con `streamlit run` o `python app/...`.
+> ⚙️ **Bootstrap obligatorio:** antes de cualquier `import app.*`, cada entrypoint
+> de Streamlit debe añadir el proyecto al `sys.path` y luego ejecutar `ensure_project_root()`:
+>
+> ```python
+> import sys
+> from pathlib import Path
+>
+> project_root = Path(__file__).resolve().parents[1]
+> project_root_str = str(project_root)
+> if project_root_str not in sys.path:
+>     sys.path.insert(0, project_root_str)
+>
+> from app.bootstrap import ensure_project_root
+>
+> ensure_project_root()
+> ```
+>
+> Esto garantiza que la carpeta raíz del repositorio esté en `sys.path` cuando se
+> ejecutan archivos sueltos con `streamlit run` o `python app/...`.
 
 El script `app/Home.py` renderiza la misma vista de *Mission Overview* que la
 entrada multipágina `app/pages/0_Mission_Overview.py`, de modo que la pantalla

--- a/app/Home.py
+++ b/app/Home.py
@@ -2,13 +2,19 @@
 
 from __future__ import annotations
 
-from app.bootstrap import ensure_project_root
-
-ensure_project_root()
-
+import sys
 from datetime import datetime
 from pathlib import Path
 from typing import Iterable
+
+project_root = Path(__file__).resolve().parents[1]
+project_root_str = str(project_root)
+if project_root_str not in sys.path:
+    sys.path.insert(0, project_root_str)
+
+from app.bootstrap import ensure_project_root
+
+ensure_project_root()
 
 import streamlit as st
 

--- a/app/pages/0_Mission_Overview.py
+++ b/app/pages/0_Mission_Overview.py
@@ -1,5 +1,13 @@
 """Mission overview entrypoint consolidating mission status panels."""
 
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[1]
+project_root_str = str(project_root)
+if project_root_str not in sys.path:
+    sys.path.insert(0, project_root_str)
+
 from app.bootstrap import ensure_project_root
 
 ensure_project_root()

--- a/app/pages/2_Target_Designer.py
+++ b/app/pages/2_Target_Designer.py
@@ -1,3 +1,11 @@
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[1]
+project_root_str = str(project_root)
+if project_root_str not in sys.path:
+    sys.path.insert(0, project_root_str)
+
 from app.bootstrap import ensure_project_root
 
 ensure_project_root()

--- a/app/pages/3_Generator.py
+++ b/app/pages/3_Generator.py
@@ -1,8 +1,15 @@
+import sys
+from pathlib import Path
+from typing import Any, Mapping
+
+project_root = Path(__file__).resolve().parents[1]
+project_root_str = str(project_root)
+if project_root_str not in sys.path:
+    sys.path.insert(0, project_root_str)
+
 from app.bootstrap import ensure_project_root
 
 ensure_project_root()
-
-from typing import Any, Mapping
 
 import math
 

--- a/app/pages/4_Results_and_Tradeoffs.py
+++ b/app/pages/4_Results_and_Tradeoffs.py
@@ -1,3 +1,11 @@
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[1]
+project_root_str = str(project_root)
+if project_root_str not in sys.path:
+    sys.path.insert(0, project_root_str)
+
 from app.bootstrap import ensure_project_root
 
 ensure_project_root()

--- a/app/pages/5_Compare_and_Explain.py
+++ b/app/pages/5_Compare_and_Explain.py
@@ -1,3 +1,11 @@
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[1]
+project_root_str = str(project_root)
+if project_root_str not in sys.path:
+    sys.path.insert(0, project_root_str)
+
 from app.bootstrap import ensure_project_root
 
 ensure_project_root()

--- a/app/pages/6_Pareto_and_Export.py
+++ b/app/pages/6_Pareto_and_Export.py
@@ -1,11 +1,19 @@
 """Streamlined Pareto exploration and export centre."""
 
+import sys
+from pathlib import Path
+from typing import Iterable
+
+project_root = Path(__file__).resolve().parents[1]
+project_root_str = str(project_root)
+if project_root_str not in sys.path:
+    sys.path.insert(0, project_root_str)
+
 from app.bootstrap import ensure_project_root
 
 ensure_project_root()
 
 import math
-from typing import Iterable
 
 import streamlit as st
 

--- a/app/pages/7_Scenario_Playbooks.py
+++ b/app/pages/7_Scenario_Playbooks.py
@@ -1,10 +1,17 @@
 """Simplified scenario playbooks with actionable summaries."""
 
+import sys
+from pathlib import Path
+from typing import Iterable
+
+project_root = Path(__file__).resolve().parents[1]
+project_root_str = str(project_root)
+if project_root_str not in sys.path:
+    sys.path.insert(0, project_root_str)
+
 from app.bootstrap import ensure_project_root
 
 ensure_project_root()
-
-from typing import Iterable
 
 import pandas as pd
 import streamlit as st

--- a/app/pages/8_Feedback_and_Impact.py
+++ b/app/pages/8_Feedback_and_Impact.py
@@ -1,10 +1,17 @@
 """Consolidated feedback capture and mission impact tracking."""
 
+import sys
+from pathlib import Path
+from datetime import datetime
+
+project_root = Path(__file__).resolve().parents[1]
+project_root_str = str(project_root)
+if project_root_str not in sys.path:
+    sys.path.insert(0, project_root_str)
+
 from app.bootstrap import ensure_project_root
 
 ensure_project_root()
-
-from datetime import datetime
 
 import pandas as pd
 import streamlit as st

--- a/app/pages/9_Capacity_Simulator.py
+++ b/app/pages/9_Capacity_Simulator.py
@@ -1,5 +1,13 @@
 """Lightweight capacity simulator driven by shared helpers."""
 
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[1]
+project_root_str = str(project_root)
+if project_root_str not in sys.path:
+    sys.path.insert(0, project_root_str)
+
 from app.bootstrap import ensure_project_root
 
 ensure_project_root()


### PR DESCRIPTION
## Summary
- insert project root on `sys.path` before importing any `app.*` modules in `app/Home.py` and each multipage entrypoint
- execute `ensure_project_root()` after the manual path injection and update the README bootstrap snippet accordingly

## Testing
- streamlit run app/Home.py --server.headless true --server.port 8501
- streamlit run app/pages/0_Mission_Overview.py --server.headless true --server.port 8502
- streamlit run app/pages/2_Target_Designer.py --server.headless true --server.port 8503
- streamlit run app/pages/3_Generator.py --server.headless true --server.port 8504
- streamlit run app/pages/4_Results_and_Tradeoffs.py --server.headless true --server.port 8505
- streamlit run app/pages/5_Compare_and_Explain.py --server.headless true --server.port 8506
- streamlit run app/pages/6_Pareto_and_Export.py --server.headless true --server.port 8507
- streamlit run app/pages/7_Scenario_Playbooks.py --server.headless true --server.port 8508
- streamlit run app/pages/8_Feedback_and_Impact.py --server.headless true --server.port 8509
- streamlit run app/pages/9_Capacity_Simulator.py --server.headless true --server.port 8510

------
https://chatgpt.com/codex/tasks/task_e_68ded4b083e08331af3f6052b0ff5b18