### PR TITLE
Refine NASA minimal theme tokens

### DIFF
--- a/app/modules/ui_blocks.py
+++ b/app/modules/ui_blocks.py
@@ -10,6 +10,58 @@ import streamlit as st
 from streamlit.delta_generator import DeltaGenerator
 
 from app.modules.visual_theme import apply_global_visual_theme
+
+_SPACE_TOKEN_MAP: dict[str, str] = {
+    "xs": "var(--lab-space-1)",
+    "sm": "var(--lab-space-2)",
+    "md": "var(--lab-space-3)",
+    "lg": "var(--lab-space-4)",
+    "xl": "var(--lab-space-5)",
+    "xxl": "var(--lab-space-6)",
+}
+
+_SURFACE_BACKGROUNDS: dict[str, str] = {
+    "base": "var(--lab-color-surface)",
+    "sunken": "var(--lab-color-layer-soft)",
+    "raised": "var(--lab-color-surface)",
+}
+
+_SURFACE_BORDERS: dict[str, str] = {
+    "base": "var(--lab-color-border)",
+    "sunken": "var(--lab-color-border)",
+    "raised": "var(--lab-color-border-strong)",
+}
+
+_LAYOUT_STYLE_MAP: dict[str, str] = {
+    "layout-stack": "display:flex; flex-direction:column; gap: var(--lab-space-4);",
+    "layout-grid": (
+        "display:grid; gap: var(--lab-space-4); align-items:start; "
+        "width:min(100%, var(--lab-layout-max-width)); margin-inline:auto;"
+    ),
+    "layout-grid--dual": "grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));",
+    "layout-grid--flow": "grid-auto-flow: row;",
+    "depth-stack": "display:flex; flex-direction:column; gap: var(--lab-space-3);",
+    "side-panel": (
+        "display:flex; flex-direction:column; gap: var(--lab-space-3); "
+        "background-color: var(--lab-color-surface); "
+        "border: var(--lab-line-weight) solid var(--lab-color-border); "
+        "border-radius: var(--lab-radius-2); padding: var(--lab-space-5); "
+        "color: var(--lab-color-text);"
+    ),
+    "pane": (
+        "display:flex; flex-direction:column; gap: var(--lab-space-3); "
+        "background-color: var(--lab-color-surface); "
+        "border: var(--lab-line-weight) solid var(--lab-color-border); "
+        "border-radius: var(--lab-radius-2); padding: var(--lab-space-5); "
+        "color: var(--lab-color-text);"
+    ),
+    "layer-shadow": (
+        "background-color: var(--lab-color-layer-soft); "
+        "border-color: var(--lab-color-border-strong);"
+    ),
+    "fade-in": "",
+    "fade-in-delayed": "",
+}
 _THEME_HASH_KEY = "__rexai_theme_hash__"
 _REVEAL_FLAG_KEY = "__rexai_reveal_flag__"
 
@@ -94,36 +146,44 @@ def use_token(name: str, fallback: Optional[str] = None) -> str:
     return f"var({css_var})"
 
 
+def _space_value(token: str | None) -> str | None:
+    if token is None:
+        return None
+    sanitized = token.strip().lower()
+    return _SPACE_TOKEN_MAP.get(sanitized, token)
+
+
 def _surface_markup(
     *,
     tone: str,
     padding: Optional[str],
     shadow: Optional[str],
     radius: Optional[str],
-    extra_class: str = "",
+    background: str | None = None,
 ) -> str:
-    classes = ["rex-surface"]
-    if extra_class:
-        classes.append(extra_class)
-    attrs = []
-    if tone and tone != "base":
-        attrs.append(f'data-tone="{tone}"')
+    del shadow  # Shadows are intentionally omitted in the minimal lab theme.
 
-    style_bits = []
-    if padding:
-        style_bits.append(f"padding: var(--space-{padding});")
-    if shadow:
-        style_bits.append(f"box-shadow: var(--shadow-{shadow});")
-    if radius:
-        style_bits.append(f"border-radius: {radius};")
+    tone_key = tone if tone in _SURFACE_BACKGROUNDS else "base"
+    background_color = background or _SURFACE_BACKGROUNDS[tone_key]
+    border_color = _SURFACE_BORDERS.get(tone_key, "var(--lab-color-border)")
 
-    class_name = " ".join(classes)
-    style_attr = ""
-    if style_bits:
-        style_value = " ".join(style_bits)
-        style_attr = f' style="{style_value}"'
-    attr_segment = (" " + " ".join(attrs)) if attrs else ""
-    return f'<div class="{class_name}"{attr_segment}{style_attr}>'
+    padding_value = _space_value(padding)
+    radius_value = radius or "var(--lab-radius-2)"
+
+    style_bits = [
+        f"background-color: {background_color};",
+        f"border: var(--lab-line-weight) solid {border_color};",
+        "color: var(--lab-color-text);",
+        f"border-radius: {radius_value};",
+    ]
+
+    if padding_value:
+        style_bits.append(f"padding: {padding_value};")
+    else:
+        style_bits.append("padding: var(--lab-space-5);")
+
+    style_attr = " ".join(style_bits)
+    return f'<div data-surface-tone="{tone_key}" style="{style_attr}">'  # noqa: S702
 
 
 @contextmanager
@@ -160,7 +220,11 @@ def glass_card(
     load_theme(show_hud=False)
     container = st.container()
     opener = _surface_markup(
-        tone="base", padding=padding, shadow=shadow, radius=radius, extra_class="rex-glass"
+        tone="sunken",
+        padding=padding,
+        shadow=shadow,
+        radius=radius,
+        background="var(--lab-color-layer-strong)",
     )
     container.markdown(opener, unsafe_allow_html=True)
     inner = container.container()
@@ -175,13 +239,18 @@ def card(title: str, body: str = "", *, render: bool = True) -> str:
     """Render a simple Rex-AI card block."""
 
     load_theme(show_hud=False)
-    title_html = f"<h3 class='rex-card__title'>{escape(title)}</h3>" if title else ""
-    body_html = f"<p class='rex-card__body'>{escape(body)}</p>" if body else ""
-    markup = (
-        "<article class='rex-card'>"
-        f"{title_html}{body_html}"
-        "</article>"
+    base_style = (
+        "display:flex; flex-direction:column; gap: var(--lab-space-2); "
+        "background-color: var(--lab-color-surface); "
+        "border: var(--lab-line-weight) solid var(--lab-color-border); "
+        "border-radius: var(--lab-radius-2); "
+        "padding: var(--lab-space-5);"
     )
+    title_style = "margin:0; font-size:1.1rem; color: var(--lab-color-text); letter-spacing:0.01em;"
+    body_style = "margin:0; color: var(--lab-color-muted); font-size:0.95rem;"
+    title_html = f"<h3 style=\"{title_style}\">{escape(title)}</h3>" if title else ""
+    body_html = f"<p style=\"{body_style}\">{escape(body)}</p>" if body else ""
+    markup = f"<article data-lab-card style=\"{base_style}\">{title_html}{body_html}</article>"
     if render:
         st.markdown(markup, unsafe_allow_html=True)
     return markup
@@ -191,6 +260,23 @@ _PILL_KINDS = {
     "ok": "Rango nominal",
     "warn": "Monitoreo",
     "risk": "Riesgo",
+}
+
+_PILL_COLORS: dict[str, tuple[str, str]] = {
+    "ok": ("var(--lab-color-positive-soft)", "var(--lab-color-positive)"),
+    "warn": ("var(--lab-color-warning-soft)", "var(--lab-color-warning)"),
+    "risk": ("var(--lab-color-critical-soft)", "var(--lab-color-critical)"),
+}
+
+_CHIP_TONES: dict[str, tuple[str, str]] = {
+    "positive": ("var(--lab-color-positive-soft)", "var(--lab-color-positive)"),
+    "ok": ("var(--lab-color-positive-soft)", "var(--lab-color-positive)"),
+    "warning": ("var(--lab-color-warning-soft)", "var(--lab-color-warning)"),
+    "warn": ("var(--lab-color-warning-soft)", "var(--lab-color-warning)"),
+    "danger": ("var(--lab-color-critical-soft)", "var(--lab-color-critical)"),
+    "risk": ("var(--lab-color-critical-soft)", "var(--lab-color-critical)"),
+    "info": ("var(--lab-color-layer-soft)", "var(--lab-color-accent)"),
+    "accent": ("var(--lab-color-accent-soft)", "var(--lab-color-accent)"),
 }
 
 
@@ -204,10 +290,20 @@ def pill(
 
     load_theme(show_hud=False)
     tone = kind if kind in _PILL_KINDS else "ok"
+    bg_color, fg_color = _PILL_COLORS.get(tone, _PILL_COLORS["ok"])
+    base_style = (
+        "display:inline-flex; align-items:center; justify-content:center; "
+        "gap: var(--lab-space-1); padding: 0.35rem 0.9rem; border-radius: 999px; "
+        "font-weight: 600; letter-spacing: 0.04em; text-transform: uppercase; "
+        "font-size: 0.78rem;"
+    )
+    style = (
+        f"{base_style} background-color: {bg_color}; color: {fg_color}; "
+        f"border: var(--lab-line-weight) solid {fg_color};"
+    )
+    title_attr = escape(_PILL_KINDS[tone])
     markup = (
-        "<span class='rex-pill' "
-        f"data-kind='{tone}' "
-        f"title='{escape(_PILL_KINDS[tone])}'>"
+        f"<span data-lab-pill='{tone}' style=\"{style}\" title=\"{title_attr}\">"
         f"{escape(label)}"
         "</span>"
     )
@@ -391,8 +487,24 @@ def layout_block(
 ) -> Generator[DeltaGenerator, None, None]:
     """Yield a Streamlit container wrapped in custom layout classes."""
 
+    tokens = [token for token in classes.split() if token.strip()]
+    style_bits: list[str] = []
+    for token in tokens:
+        mapped = _LAYOUT_STYLE_MAP.get(token)
+        if mapped:
+            style_bits.append(mapped)
+
+    if not style_bits:
+        style_bits.append("display:flex; flex-direction:column; gap: var(--lab-space-3);")
+
+    style_attr = " ".join(style_bits)
+    data_attr = f' data-lab-classes="{escape(" ".join(tokens))}"' if tokens else ""
+
     target = parent if parent is not None else st.container()
-    target.markdown(f"<div class=\"{classes}\">", unsafe_allow_html=True)
+    target.markdown(
+        f"<div style=\"{style_attr}\"{data_attr}>",
+        unsafe_allow_html=True,
+    )
     inner = target.container()
     try:
         yield inner
@@ -430,7 +542,20 @@ def chipline(
 
     load_theme(show_hud=False)
 
-    html: list[str] = ["<div class=\"chipline\">"]
+    row_style = (
+        "display:flex; flex-wrap:wrap; align-items:center; gap: var(--lab-space-2); "
+        "margin-block: var(--lab-space-2);"
+    )
+    chip_base = (
+        "display:inline-flex; align-items:center; gap: var(--lab-space-1); "
+        "padding: 0.3rem 0.75rem; border-radius: 999px; font-size: 0.9rem; "
+        "border: var(--lab-line-weight) solid var(--lab-color-border); "
+        "background-color: var(--lab-color-layer-soft); color: var(--lab-color-text);"
+    )
+    icon_style = "font-size:1rem; line-height:1;"
+    label_style = "display:inline-flex; align-items:center; gap: var(--lab-space-1);"
+
+    html: list[str] = [f"<div style=\"{row_style}\">"]
     for item in items:
         if isinstance(item, Mapping):
             label_text = str(item.get("label", ""))
@@ -441,16 +566,25 @@ def chipline(
             icon_text = None
             tone = ""
 
-        tone_attr = f" data-tone='{escape(tone)}'" if tone else ""
+        tone_key = tone.lower()
+        bg_color, fg_color = _CHIP_TONES.get(
+            tone_key, ("var(--lab-color-layer-soft)", "var(--lab-color-text)")
+        )
+        chip_style = (
+            f"{chip_base} background-color: {bg_color}; color: {fg_color}; "
+            f"border-color: {fg_color};"
+            if tone_key in _CHIP_TONES
+            else chip_base
+        )
         icon_html = (
-            f"<span class='chipline__icon'>{escape(str(icon_text))}</span>"
+            f"<span style=\"{icon_style}\">{escape(str(icon_text))}</span>"
             if icon_text
             else ""
         )
+        tone_attr = f" data-lab-chip-tone='{escape(tone_key)}'" if tone_key else ""
         html.append(
-            "<span class='chipline__chip'"
-            f"{tone_attr}>"
-            f"{icon_html}<span class='chipline__label'>{escape(label_text)}</span>"
+            f"<span{tone_attr} style=\"{chip_style}\">"
+            f"{icon_html}<span style=\"{label_style}\">{escape(label_text)}</span>"
             "</span>"
         )
     html.append("</div>")
@@ -465,11 +599,37 @@ def chipline(
 def badge_group(labels: Iterable[str], *, parent: DeltaGenerator | None = None) -> None:
     """Render pill badges inside the shared badge group wrapper."""
 
-    items = [f'<span class="badge">{escape(label)}</span>' for label in labels]
+    palette_cycle = [
+        ("var(--lab-color-positive-soft)", "var(--lab-color-positive)"),
+        ("var(--lab-color-warning-soft)", "var(--lab-color-warning)"),
+        ("var(--lab-color-critical-soft)", "var(--lab-color-critical)"),
+    ]
+    row_style = (
+        "display:flex; flex-wrap:wrap; gap: var(--lab-space-2); margin-block: var(--lab-space-2);"
+    )
+    badge_style = (
+        "display:inline-flex; align-items:center; justify-content:center; "
+        "padding: 0.35rem 0.75rem; border-radius: 999px; font-weight:600; "
+        "letter-spacing:0.03em; text-transform:uppercase; font-size:0.75rem;"
+    )
+
+    items = list(labels)
     if not items:
         return
 
-    html = f"<div class=\"badge-group\">{''.join(items)}</div>"
+    badge_markup: list[str] = [f"<div style=\"{row_style}\">"]
+    for index, label in enumerate(items):
+        bg_color, fg_color = palette_cycle[index % len(palette_cycle)]
+        style = (
+            f"{badge_style} background-color: {bg_color}; color: {fg_color}; "
+            f"border: var(--lab-line-weight) solid {fg_color};"
+        )
+        badge_markup.append(
+            f"<span data-lab-badge-index='{index}' style=\"{style}\">{escape(label)}</span>"
+        )
+    badge_markup.append("</div>")
+
+    html = "".join(badge_markup)
     target = parent if parent is not None else st
     target.markdown(html, unsafe_allow_html=True)
 
@@ -478,4 +638,8 @@ def micro_divider(*, parent: DeltaGenerator | None = None) -> None:
     """Insert a subtle divider matching the Rex-AI style guide."""
 
     target = parent if parent is not None else st
-    target.markdown('<div class="hr-micro"></div>', unsafe_allow_html=True)
+    divider_style = (
+        "height:1px; width:100%; background-color: var(--lab-color-divider); "
+        "margin-block: var(--lab-space-4);"
+    )
+    target.markdown(f"<div style=\"{divider_style}\"></div>", unsafe_allow_html=True)

--- a/app/modules/visual_theme.py
+++ b/app/modules/visual_theme.py
@@ -1,8 +1,10 @@
-"""Shared data-visualization themes for Altair and Plotly.
+"""NASA minimal visualization themes for Altair and Plotly.
 
-The theme is inspired by premium automotive dashboards: deep, satin-finished
-surfaces contrasted with electric neon highlights.  A dedicated helper keeps
-the Streamlit pages consistent by wiring both the CSS and chart themes.
+The palette favours clean laboratory whites, aerospace blues, and sharply
+defined contrast so that charts feel like instrumentation readouts rather than
+entertainment dashboards.  Both Altair and Plotly share the same minimalist
+tokens so that Streamlit pages inherit a restrained NASA mission-control
+aesthetic regardless of the rendering backend.
 """
 from __future__ import annotations
 
@@ -35,41 +37,41 @@ class Palette:
 
 _PALETTES: Dict[ThemeMode, Palette] = {
     "light": Palette(
-        background="#F8FAFC",
+        background="#F4F7FB",
         surface="#FFFFFF",
-        panel="#E2E8F0",
-        grid="rgba(30,64,175,0.14)",
-        text="#0F172A",
-        muted="#475569",
-        accent="#1D4ED8",
-        accent_soft="#60A5FA",
-        electric_gradient=("#7CF4FF", "#33B9FF", "#3730FF"),
+        panel="#E4EBF7",
+        grid="rgba(23,63,134,0.18)",
+        text="#0E2140",
+        muted="#4B607D",
+        accent="#234A91",
+        accent_soft="#6E8FD6",
+        electric_gradient=("#D7E3FF", "#7FA7FF", "#1F3E7A"),
         categorical=(
-            "#0F76FF",
-            "#1DD3F8",
-            "#F59E0B",
-            "#14B8A6",
-            "#7C3AED",
-            "#F97316",
+            "#234A91",
+            "#2A7F9E",
+            "#BF6C00",
+            "#146B4E",
+            "#5A3BA6",
+            "#9C2F3F",
         ),
     ),
     "dark": Palette(
-        background="#070B12",
-        surface="#0E141F",
-        panel="#192132",
-        grid="rgba(148,163,184,0.22)",
-        text="#F8FAFC",
-        muted="#94A3B8",
-        accent="#38BDF8",
-        accent_soft="#7DD3FC",
-        electric_gradient=("#7CF4FF", "#2AA8FF", "#4C4CFF"),
+        background="#0B1526",
+        surface="#141F32",
+        panel="#1F2B41",
+        grid="rgba(165,179,201,0.24)",
+        text="#F4F7FB",
+        muted="#9AA9C2",
+        accent="#6F9BFF",
+        accent_soft="#A8C1FF",
+        electric_gradient=("#4469B8", "#5E87E3", "#B1C7FF"),
         categorical=(
-            "#7DD3FC",
-            "#34D399",
-            "#FBBF24",
-            "#F472B6",
-            "#A855F7",
-            "#F97316",
+            "#6F9BFF",
+            "#49B0C9",
+            "#D4973C",
+            "#49B188",
+            "#9082D5",
+            "#CF5E73",
         ),
     ),
 }
@@ -92,45 +94,46 @@ def _altair_config(mode: ThemeMode) -> Dict[str, Dict[str, object]]:
             "background": background,
             "view": {
                 "stroke": palette.panel,
-                "strokeOpacity": 0.0,
+                "strokeOpacity": 0.35,
             },
             "padding": 16,
             "title": {
-                "font": "Rajdhani, 'Segoe UI', sans-serif",
-                "fontSize": 22,
+                "font": "'Source Sans 3', 'Segoe UI', sans-serif",
+                "fontSize": 20,
                 "fontWeight": 600,
                 "color": palette.text,
             },
             "axis": {
-                "labelFont": "Inter, 'Segoe UI', sans-serif",
+                "labelFont": "'Source Sans 3', 'Segoe UI', sans-serif",
                 "labelFontSize": 12,
-                "labelColor": palette.text,
-                "titleFont": "Rajdhani, 'Segoe UI', sans-serif",
-                "titleFontWeight": 500,
-                "titleColor": palette.muted,
+                "labelColor": palette.muted,
+                "titleFont": "'Source Sans 3', 'Segoe UI', sans-serif",
+                "titleFontWeight": 600,
+                "titleColor": palette.text,
                 "grid": True,
                 "gridColor": palette.grid,
                 "domainColor": palette.grid,
                 "tickColor": palette.grid,
+                "tickSize": 4,
             },
             "legend": {
-                "labelFont": "Inter, 'Segoe UI', sans-serif",
-                "labelColor": palette.text,
-                "titleColor": palette.muted,
+                "labelFont": "'Source Sans 3', 'Segoe UI', sans-serif",
+                "labelColor": palette.muted,
+                "titleColor": palette.text,
                 "symbolType": "circle",
-                "gradientLength": 180,
+                "gradientLength": 140,
             },
             "header": {
-                "labelFont": "Inter, 'Segoe UI', sans-serif",
-                "titleFont": "Rajdhani, 'Segoe UI', sans-serif",
-                "labelColor": palette.text,
+                "labelFont": "'Source Sans 3', 'Segoe UI', sans-serif",
+                "titleFont": "'Source Sans 3', 'Segoe UI', sans-serif",
+                "labelColor": palette.muted,
                 "titleColor": palette.text,
             },
             "mark": {
                 "color": palette.accent,
                 "fill": palette.accent_soft,
                 "stroke": palette.accent,
-                "strokeWidth": 1.4,
+                "strokeWidth": 1.2,
             },
             "range": {
                 "category": list(palette.categorical),
@@ -140,19 +143,19 @@ def _altair_config(mode: ThemeMode) -> Dict[str, Dict[str, object]]:
             },
             "area": {
                 "line": True,
-                "opacity": 0.85,
+                "opacity": 0.8,
             },
             "rect": {
                 "stroke": surface,
                 "strokeWidth": 0,
             },
             "point": {
-                "size": 90,
+                "size": 80,
                 "filled": True,
             },
             "bar": {
-                "cornerRadiusTopLeft": 4,
-                "cornerRadiusTopRight": 4,
+                "cornerRadiusTopLeft": 2,
+                "cornerRadiusTopRight": 2,
             },
         }
     }
@@ -165,36 +168,38 @@ def _plotly_template(mode: ThemeMode) -> Dict[str, object]:
         [0.5, palette.electric_gradient[1]],
         [1.0, palette.electric_gradient[2]],
     ]
-    font_family = "Inter, 'Segoe UI', sans-serif"
-    title_family = "Rajdhani, 'Segoe UI', sans-serif"
+    font_family = "'Source Sans 3', 'Segoe UI', sans-serif"
+    title_family = "'Source Sans 3', 'Segoe UI', sans-serif"
 
     return {
         "layout": {
             "paper_bgcolor": palette.background,
             "plot_bgcolor": palette.surface,
             "font": {"family": font_family, "color": palette.text, "size": 14},
-            "title": {"font": {"family": title_family, "size": 22, "color": palette.text}},
+            "title": {"font": {"family": title_family, "size": 20, "color": palette.text}},
             "colorway": list(palette.categorical),
             "hoverlabel": {
                 "font": {"family": font_family, "color": palette.text},
-                "bgcolor": palette.panel,
-                "bordercolor": palette.accent,
+                "bgcolor": palette.surface,
+                "bordercolor": palette.panel,
             },
             "xaxis": {
                 "gridcolor": palette.grid,
-                "zerolinecolor": palette.accent_soft,
+                "zerolinecolor": palette.grid,
                 "linecolor": palette.grid,
                 "ticks": "outside",
                 "tickcolor": palette.grid,
                 "titlefont": {"family": title_family, "color": palette.muted},
+                "tickfont": {"family": font_family, "color": palette.muted},
             },
             "yaxis": {
                 "gridcolor": palette.grid,
-                "zerolinecolor": palette.accent_soft,
+                "zerolinecolor": palette.grid,
                 "linecolor": palette.grid,
                 "ticks": "outside",
                 "tickcolor": palette.grid,
                 "titlefont": {"family": title_family, "color": palette.muted},
+                "tickfont": {"family": font_family, "color": palette.muted},
             },
             "legend": {
                 "bgcolor": "rgba(0,0,0,0)",
@@ -211,7 +216,7 @@ def _plotly_template(mode: ThemeMode) -> Dict[str, object]:
             "bar": [
                 {
                     "marker": {
-                        "line": {"color": palette.panel, "width": 0.8},
+                        "line": {"color": palette.panel, "width": 0.6},
                         "colorscale": gradient,
                     }
                 }
@@ -219,9 +224,9 @@ def _plotly_template(mode: ThemeMode) -> Dict[str, object]:
             "scatter": [
                 {
                     "marker": {
-                        "line": {"color": palette.panel, "width": 0.8},
+                        "line": {"color": palette.panel, "width": 0.6},
                         "colorscale": gradient,
-                        "size": 12,
+                        "size": 10,
                     }
                 }
             ],

--- a/app/static/styles/base.css
+++ b/app/static/styles/base.css
@@ -1,64 +1,59 @@
 /*
- * NASA-inspired Streamlit theme focused on readability and contrast.
- * The palette favors deep blues, soft neutrals, and generous spacing.
+ * NASA laboratory minimal theme tokens for Streamlit pages.
+ * The variables favour clear contrast, high legibility, and restrained chrome
+ * so that analytical surfaces feel like mission-control workspaces.
  */
 
 :root {
-  --color-background: #09192f;
-  --color-background-alt: #0f2340;
-  --color-surface: #112a45;
-  --color-surface-sunken: #0c1e32;
-  --color-surface-raised: #1c3554;
-  --color-surface-neutral: #142d4c;
-  --color-border: rgba(123, 155, 204, 0.35);
-  --color-border-strong: rgba(123, 155, 204, 0.55);
-  --color-text: #f5f7fb;
-  --color-text-muted: #b6c4d8;
-  --color-accent: #63b3ff;
-  --color-accent-soft: #a0cffb;
-  --color-success: #4cd6c0;
-  --color-warn: #ffb347;
-  --color-risk: #ff6f91;
+  --lab-color-canvas: #f4f7fb;
+  --lab-color-surface: #ffffff;
+  --lab-color-layer-soft: #ecf1f9;
+  --lab-color-layer-strong: #dbe5f3;
+  --lab-color-border: #c3ccdd;
+  --lab-color-border-strong: #9da9bf;
+  --lab-color-divider: #d9e1ee;
+  --lab-color-text: #0b2142;
+  --lab-color-muted: #51607a;
+  --lab-color-accent: #224a91;
+  --lab-color-accent-soft: #5578c6;
+  --lab-color-positive: #1b6f5b;
+  --lab-color-positive-soft: #d5ede6;
+  --lab-color-warning: #b75e10;
+  --lab-color-warning-soft: #f4dfc8;
+  --lab-color-critical: #8e2430;
+  --lab-color-critical-soft: #f4d8dd;
 
-  --font-body: "IBM Plex Sans", "Source Sans Pro", system-ui, -apple-system, sans-serif;
-  --font-mono: "IBM Plex Mono", "SFMono-Regular", ui-monospace, monospace;
+  --lab-font-sans: "Source Sans 3", "Segoe UI", system-ui, sans-serif;
+  --lab-font-mono: "IBM Plex Mono", ui-monospace, SFMono-Regular, monospace;
 
-  --space-xs: 0.25rem;
-  --space-sm: 0.5rem;
-  --space-md: 0.875rem;
-  --space-lg: 1.5rem;
-  --space-xl: 2.25rem;
-  --space-xxl: 3.25rem;
+  --lab-space-1: 0.25rem;
+  --lab-space-2: 0.5rem;
+  --lab-space-3: 0.75rem;
+  --lab-space-4: 1rem;
+  --lab-space-5: 1.5rem;
+  --lab-space-6: 2.25rem;
 
-  --radius-sm: 0.4rem;
-  --radius-md: 0.75rem;
-  --radius-lg: 1.1rem;
+  --lab-radius-1: 0.25rem;
+  --lab-radius-2: 0.5rem;
 
-  --shadow-soft: 0 6px 18px rgba(3, 13, 31, 0.35);
-  --shadow-lift: 0 12px 28px rgba(9, 27, 54, 0.4);
-  --shadow-float: 0 18px 44px rgba(10, 32, 60, 0.45);
-
-  --grid-max-width: 1180px;
+  --lab-line-weight: 1px;
+  --lab-layout-max-width: 1120px;
 }
 
 body,
 .stApp {
   margin: 0;
   min-height: 100vh;
-  background-color: var(--color-background);
-  color: var(--color-text);
-  font-family: var(--font-body);
-  line-height: 1.55;
-}
-
-.stApp {
-  padding-bottom: var(--space-xxl);
+  background-color: var(--lab-color-canvas);
+  color: var(--lab-color-text);
+  font-family: var(--lab-font-sans);
+  line-height: 1.5;
 }
 
 main .block-container {
-  max-width: var(--grid-max-width);
-  padding-top: var(--space-xl);
-  padding-bottom: var(--space-xl);
+  max-width: var(--lab-layout-max-width);
+  padding-top: var(--lab-space-6);
+  padding-bottom: var(--lab-space-6);
 }
 
 h1,
@@ -67,10 +62,10 @@ h3,
 h4,
 h5,
 h6 {
+  color: var(--lab-color-text);
   font-weight: 600;
   letter-spacing: 0.01em;
-  color: var(--color-text);
-  margin-block: var(--space-md) var(--space-sm);
+  margin-block: var(--lab-space-4) var(--lab-space-2);
 }
 
 p,
@@ -91,341 +86,40 @@ small,
 caption,
 .stMarkdown small {
   font-size: 0.85rem;
-  color: var(--color-text-muted);
+  color: var(--lab-color-muted);
 }
 
 a {
-  color: var(--color-accent);
+  color: var(--lab-color-accent);
   text-decoration-thickness: 2px;
   text-underline-offset: 4px;
 }
 
 a:hover,
 a:focus {
-  color: var(--color-accent-soft);
+  color: var(--lab-color-accent-soft);
 }
 
 code,
 pre,
 .stCode {
-  font-family: var(--font-mono);
-  color: var(--color-accent-soft);
+  font-family: var(--lab-font-mono);
+  color: var(--lab-color-accent);
 }
 
 button,
 .stButton > button,
 button[kind="secondary"] {
-  border-radius: var(--radius-md);
+  border-radius: var(--lab-radius-2);
 }
 
-/* Layout primitives */
-.layout-stack {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-lg);
+table {
+  border-color: var(--lab-color-divider);
 }
 
-.layout-grid {
-  display: grid;
-  gap: var(--space-lg);
-  align-items: start;
-  width: min(100%, var(--grid-max-width));
-  margin-inline: auto;
-}
-
-.layout-grid--dual {
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-}
-
-.layout-grid--flow {
-  grid-auto-flow: row;
-}
-
-.depth-stack {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-md);
-}
-
-.pane,
-.pane-block,
-.side-panel {
-  background-color: var(--color-surface);
-  border-radius: var(--radius-lg);
-  border: 1px solid var(--color-border);
-  padding: var(--space-xl);
-  box-shadow: var(--shadow-soft);
-}
-
-.layer-shadow {
-  box-shadow: var(--shadow-soft);
-}
-
-.fade-in,
-.fade-in-delayed {
-  opacity: 1 !important;
-  transform: none !important;
-}
-
-/* Surface system */
-.rex-surface {
-  position: relative;
-  border-radius: var(--radius-lg);
-  border: 1px solid var(--color-border);
-  background-color: var(--color-surface);
-  padding: var(--space-lg);
-  color: var(--color-text);
-}
-
-.rex-surface[data-tone="sunken"] {
-  background-color: var(--color-surface-sunken);
-}
-
-.rex-surface[data-tone="raised"] {
-  background-color: var(--color-surface-raised);
-  box-shadow: var(--shadow-lift);
-}
-
-.rex-surface.rex-glass,
-.rex-glass {
-  background-color: var(--color-surface-neutral);
-  border: 1px solid var(--color-border-strong);
-  box-shadow: var(--shadow-soft);
-}
-
-/* Chip + badge helpers */
-.chipline {
-  display: flex;
-  flex-wrap: wrap;
-  gap: var(--space-sm);
-  margin-bottom: var(--space-sm);
-}
-
-.chipline__chip {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--space-xs);
-  padding: 0.35rem 0.75rem;
-  border-radius: 999px;
-  font-size: 0.9rem;
-  background-color: rgba(123, 155, 204, 0.18);
-  border: 1px solid var(--color-border);
-  color: var(--color-text);
-}
-
-.chipline__chip[data-tone="positive"] {
-  background-color: rgba(76, 214, 192, 0.15);
-  border-color: rgba(76, 214, 192, 0.45);
-  color: var(--color-success);
-}
-
-.chipline__chip[data-tone="warning"] {
-  background-color: rgba(255, 179, 71, 0.16);
-  border-color: rgba(255, 179, 71, 0.4);
-  color: var(--color-warn);
-}
-
-.chipline__chip[data-tone="danger"],
-.chipline__chip[data-tone="risk"] {
-  background-color: rgba(255, 111, 145, 0.16);
-  border-color: rgba(255, 111, 145, 0.4);
-  color: var(--color-risk);
-}
-
-.chipline__chip[data-tone="info"] {
-  background-color: rgba(99, 179, 255, 0.16);
-  border-color: rgba(99, 179, 255, 0.45);
-  color: var(--color-accent);
-}
-
-.chipline__chip[data-tone="accent"] {
-  background-color: rgba(94, 234, 212, 0.15);
-  border-color: rgba(94, 234, 212, 0.45);
-  color: rgba(94, 234, 212, 0.95);
-}
-
-.chipline__icon {
-  font-size: 1.1rem;
-  line-height: 1;
-}
-
-.chipline__label {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--space-xs);
-}
-
-.badge-group {
-  display: flex;
-  flex-wrap: wrap;
-  gap: var(--space-sm);
-  margin-block: var(--space-sm);
-}
-
-.badge {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0.35rem 0.75rem;
-  border-radius: 999px;
-  font-weight: 600;
-  letter-spacing: 0.03em;
-  text-transform: uppercase;
-  font-size: 0.75rem;
-  border: 1px solid transparent;
-}
-
-.badge:nth-of-type(3n + 1) {
-  background-color: rgba(76, 214, 192, 0.15);
-  color: var(--color-success);
-  border-color: rgba(76, 214, 192, 0.45);
-}
-
-.badge:nth-of-type(3n + 2) {
-  background-color: rgba(255, 179, 71, 0.15);
-  color: var(--color-warn);
-  border-color: rgba(255, 179, 71, 0.4);
-}
-
-.badge:nth-of-type(3n + 3) {
-  background-color: rgba(255, 111, 145, 0.15);
-  color: var(--color-risk);
-  border-color: rgba(255, 111, 145, 0.4);
-}
-
-.rex-pill {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 0.35rem;
-  padding: 0.35rem 0.85rem;
-  border-radius: 999px;
-  font-weight: 600;
-  letter-spacing: 0.03em;
-  text-transform: uppercase;
-  font-size: 0.78rem;
-  border: 1px solid transparent;
-  background-color: rgba(17, 46, 78, 0.85);
-  color: var(--color-text);
-}
-
-.rex-pill[data-kind="ok"] {
-  border-color: rgba(76, 214, 192, 0.5);
-  color: var(--color-success);
-  background-color: rgba(76, 214, 192, 0.12);
-}
-
-.rex-pill[data-kind="warn"] {
-  border-color: rgba(255, 179, 71, 0.5);
-  color: var(--color-warn);
-  background-color: rgba(255, 179, 71, 0.12);
-}
-
-.rex-pill[data-kind="risk"] {
-  border-color: rgba(255, 111, 145, 0.5);
-  color: var(--color-risk);
-  background-color: rgba(255, 111, 145, 0.12);
-}
-
-.rex-card {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-sm);
-  padding: var(--space-lg);
-  border-radius: var(--radius-lg);
-  border: 1px solid var(--color-border);
-  background-color: var(--color-surface-neutral);
-  box-shadow: var(--shadow-soft);
-}
-
-.rex-card__title {
-  margin: 0;
-  font-size: 1.15rem;
-  letter-spacing: 0.02em;
-}
-
-.rex-card__body {
-  margin: 0;
-  color: var(--color-text-muted);
-  font-size: 0.95rem;
-}
-
-.hr-micro {
+hr {
+  border: 0;
   height: 1px;
-  width: 100%;
-  background-color: rgba(123, 155, 204, 0.35);
-  margin-block: var(--space-lg);
-}
-
-/* Minimal CTA */
-.rexai-minimal-wrapper {
-  display: inline-flex;
-  flex-direction: column;
-  gap: var(--space-sm);
-  width: 100%;
-}
-
-.rexai-minimal-wrapper[data-width="auto"] {
-  width: auto;
-}
-
-.rexai-minimal-button {
-  width: 100%;
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-lg);
-  padding: 0.95rem 1.4rem;
-  font-weight: 600;
-  font-size: 1rem;
-  background-color: var(--color-surface);
-  color: var(--color-text);
-  transition: transform 0.18s ease, box-shadow 0.18s ease, background 0.18s ease;
-}
-
-.rexai-minimal-button:hover,
-.rexai-minimal-button:focus {
-  background-color: var(--color-surface-raised);
-  box-shadow: var(--shadow-soft);
-}
-
-.rexai-minimal-button:disabled {
-  opacity: 0.7;
-  cursor: not-allowed;
-  box-shadow: none;
-}
-
-.rexai-minimal-text {
-  display: inline-flex;
-  flex-direction: column;
-  align-items: center;
-  gap: var(--space-xs);
-  text-align: center;
-}
-
-.rexai-minimal-text[data-layout="inline"] {
-  flex-direction: row;
-  gap: var(--space-sm);
-}
-
-.rexai-minimal-status {
-  font-size: 0.78rem;
-  color: var(--color-text-muted);
-  text-transform: uppercase;
-  letter-spacing: 0.03em;
-  transition: opacity 0.18s ease;
-}
-
-.rexai-minimal-status[data-active="false"] {
-  opacity: 0;
-  height: 0;
-  overflow: hidden;
-}
-
-.rexai-minimal-status[data-active="true"] {
-  opacity: 1;
-  height: auto;
-}
-
-.rexai-minimal-help {
-  font-size: 0.82rem;
-  color: var(--color-text-muted);
+  background-color: var(--lab-color-divider);
+  margin-block: var(--lab-space-5);
 }

--- a/tests/ui/test_theme_css.py
+++ b/tests/ui/test_theme_css.py
@@ -4,8 +4,8 @@ from pathlib import Path
 def test_base_css_defines_new_primitives() -> None:
     css = Path("app/static/styles/base.css").read_text(encoding="utf-8")
 
-    for selector in (".rex-pill", ".chipline__chip", ".rex-card"):
-        assert selector in css, f"Expected {selector} styles in base theme"
+    for token in ("--lab-color-canvas", "--lab-color-surface", "--lab-space-4"):
+        assert token in css, f"Expected {token} token in base theme"
 
-    for legacy in (".luxe-", "tesla-hero", "parallax"):
+    for legacy in (".rex-pill", ".chipline__chip", ".rex-card", "linear-gradient"):
         assert legacy not in css

--- a/tests/ui/test_ui_blocks_markup.py
+++ b/tests/ui/test_ui_blocks_markup.py
@@ -15,8 +15,8 @@ def test_pill_returns_markup_without_render():
 
     html = ui_blocks.pill("Seguridad", kind="ok", render=False)
 
-    assert "rex-pill" in html
-    assert "data-kind='ok'" in html
+    assert "data-lab-pill='ok'" in html
+    assert "var(--lab-color-positive)" in html
 
 
 def test_chipline_accepts_mappings(monkeypatch):
@@ -33,6 +33,6 @@ def test_chipline_accepts_mappings(monkeypatch):
         render=False,
     )
 
-    assert "chipline__chip" in html
+    assert "data-lab-chip-tone='positive'" in html
     assert "🧪" in html
-    assert "data-tone='positive'" in html
+    assert "var(--lab-color-positive-soft)" in html


### PR DESCRIPTION
## Summary
- restyle the shared Altair/Plotly palettes around a NASA minimal aesthetic
- replace the heavy HUD CSS with lightweight NASA lab design tokens
- refactor UI helpers to use inline token styles and update coverage tests

## Testing
- pytest tests/ui/test_ui_blocks_markup.py tests/ui/test_theme_css.py tests/modules/test_mission_overview.py

------
https://chatgpt.com/codex/tasks/task_e_68ded61bf5d48331b4d5f4d0d8b13828