### PR TITLE
Add info and accent pill tones with CSS support

### DIFF
--- a/app/modules/ui_blocks.py
+++ b/app/modules/ui_blocks.py
@@ -260,12 +260,16 @@ _PILL_KINDS = {
     "ok": "Rango nominal",
     "warn": "Monitoreo",
     "risk": "Riesgo",
+    "info": "Referencia informativa",
+    "accent": "Etiqueta destacada",
 }
 
 _PILL_COLORS: dict[str, tuple[str, str]] = {
     "ok": ("var(--lab-color-positive-soft)", "var(--lab-color-positive)"),
     "warn": ("var(--lab-color-warning-soft)", "var(--lab-color-warning)"),
     "risk": ("var(--lab-color-critical-soft)", "var(--lab-color-critical)"),
+    "info": ("var(--lab-color-layer-soft)", "var(--lab-color-accent)"),
+    "accent": ("var(--lab-color-accent-soft)", "var(--lab-color-accent)"),
 }
 
 _CHIP_TONES: dict[str, tuple[str, str]] = {
@@ -298,12 +302,15 @@ def pill(
         "font-size: 0.78rem;"
     )
     style = (
-        f"{base_style} background-color: {bg_color}; color: {fg_color}; "
-        f"border: var(--lab-line-weight) solid {fg_color};"
+        f"{base_style} background-color: var(--lab-pill-bg, {bg_color}); "
+        f"color: var(--lab-pill-fg, {fg_color}); "
+        f"border: var(--lab-line-weight) solid var(--lab-pill-fg, {fg_color});"
     )
     title_attr = escape(_PILL_KINDS[tone])
+    tone_attr = escape(tone)
     markup = (
-        f"<span data-lab-pill='{tone}' style=\"{style}\" title=\"{title_attr}\">"
+        f"<span data-lab-pill='{tone}' data-kind='{tone_attr}' "
+        f"style=\"{style}\" title=\"{title_attr}\">"
         f"{escape(label)}"
         "</span>"
     )

--- a/app/static/styles/base.css
+++ b/app/static/styles/base.css
@@ -123,3 +123,33 @@ hr {
   background-color: var(--lab-color-divider);
   margin-block: var(--lab-space-5);
 }
+
+[data-lab-pill] {
+  --lab-pill-bg: var(--lab-color-positive-soft);
+  --lab-pill-fg: var(--lab-color-positive);
+}
+
+[data-lab-pill][data-kind="ok"] {
+  --lab-pill-bg: var(--lab-color-positive-soft);
+  --lab-pill-fg: var(--lab-color-positive);
+}
+
+[data-lab-pill][data-kind="warn"] {
+  --lab-pill-bg: var(--lab-color-warning-soft);
+  --lab-pill-fg: var(--lab-color-warning);
+}
+
+[data-lab-pill][data-kind="risk"] {
+  --lab-pill-bg: var(--lab-color-critical-soft);
+  --lab-pill-fg: var(--lab-color-critical);
+}
+
+[data-lab-pill][data-kind="info"] {
+  --lab-pill-bg: var(--lab-color-layer-soft);
+  --lab-pill-fg: var(--lab-color-accent);
+}
+
+[data-lab-pill][data-kind="accent"] {
+  --lab-pill-bg: var(--lab-color-accent-soft);
+  --lab-pill-fg: var(--lab-color-accent);
+}

--- a/tests/ui/test_ui_blocks_markup.py
+++ b/tests/ui/test_ui_blocks_markup.py
@@ -16,7 +16,20 @@ def test_pill_returns_markup_without_render():
     html = ui_blocks.pill("Seguridad", kind="ok", render=False)
 
     assert "data-lab-pill='ok'" in html
+    assert "data-kind='ok'" in html
     assert "var(--lab-color-positive)" in html
+
+
+def test_pill_supports_info_and_accent_kinds():
+    from app.modules import ui_blocks
+
+    info_html = ui_blocks.pill("Polímero", kind="info", render=False)
+    accent_html = ui_blocks.pill("Aleación", kind="accent", render=False)
+
+    assert "data-kind='info'" in info_html
+    assert "var(--lab-color-accent)" in info_html
+    assert "data-kind='accent'" in accent_html
+    assert "var(--lab-color-accent-soft)" in accent_html
 
 
 def test_chipline_accepts_mappings(monkeypatch):
@@ -36,3 +49,23 @@ def test_chipline_accepts_mappings(monkeypatch):
     assert "data-lab-chip-tone='positive'" in html
     assert "🧪" in html
     assert "var(--lab-color-positive-soft)" in html
+
+
+def test_chipline_uses_defined_tone_palette(monkeypatch):
+    from app.modules import ui_blocks
+
+    fake_streamlit = types.SimpleNamespace(markdown=lambda *args, **kwargs: None)
+    monkeypatch.setattr(ui_blocks, "st", fake_streamlit)
+
+    html = ui_blocks.chipline(
+        [
+            {"label": "PFAS en riesgo", "tone": "danger"},
+            {"label": "Microplásticos monitoreo", "tone": "warning"},
+        ],
+        render=False,
+    )
+
+    assert "data-lab-chip-tone='danger'" in html
+    assert "data-lab-chip-tone='warning'" in html
+    assert "var(--lab-color-critical-soft)" in html
+    assert "var(--lab-color-warning-soft)" in html


### PR DESCRIPTION
## Summary
- extend the pill tone registry with info and accent variants used in Generator chips
- expose shared CSS custom properties for pill colors in the minimal base stylesheet
- expand UI block tests to cover new pill tones and chip tone rendering

## Testing
- pytest tests/ui/test_ui_blocks_markup.py

------
https://chatgpt.com/codex/tasks/task_e_68dee413474c8331857ac63149aacfe1