### PR TITLE
chore: refresh mission control visual theme

### DIFF
--- a/app/modules/ui_blocks.py
+++ b/app/modules/ui_blocks.py
@@ -4,7 +4,7 @@ import hashlib
 from contextlib import contextmanager
 from html import escape
 from pathlib import Path
-from typing import Any, Generator, Iterable, Iterator, Literal, Mapping, Optional
+from typing import Any, Generator, Iterable, Literal, Mapping, Optional
 
 import streamlit as st
 from streamlit.delta_generator import DeltaGenerator
@@ -12,31 +12,31 @@ from streamlit.delta_generator import DeltaGenerator
 from app.modules.visual_theme import apply_global_visual_theme
 
 _LAYOUT_STYLE_MAP: dict[str, str] = {
-    "layout-stack": "display:flex; flex-direction:column; gap: var(--lab-space-4);",
+    "layout-stack": "display:flex; flex-direction:column; gap: var(--mission-space-md);",
     "layout-grid": (
-        "display:grid; gap: var(--lab-space-4); align-items:start; "
-        "width:min(100%, var(--lab-layout-max-width)); margin-inline:auto;"
+        "display:grid; gap: var(--mission-space-md); align-items:start; "
+        "width:min(100%, var(--mission-layout-max-width)); margin-inline:auto;"
     ),
     "layout-grid--dual": "grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));",
     "layout-grid--flow": "grid-auto-flow: row;",
-    "depth-stack": "display:flex; flex-direction:column; gap: var(--lab-space-3);",
+    "depth-stack": "display:flex; flex-direction:column; gap: var(--mission-space-sm);",
     "side-panel": (
-        "display:flex; flex-direction:column; gap: var(--lab-space-3); "
-        "background-color: var(--lab-color-surface); "
-        "border: var(--lab-line-weight) solid var(--lab-color-border); "
-        "border-radius: var(--lab-radius-2); padding: var(--lab-space-5); "
-        "color: var(--lab-color-text);"
+        "display:flex; flex-direction:column; gap: var(--mission-space-sm); "
+        "background-color: var(--mission-color-surface); "
+        "border: var(--mission-line-weight) solid var(--mission-color-border); "
+        "border-radius: var(--mission-radius-md); padding: var(--mission-space-lg); "
+        "color: var(--mission-color-text);"
     ),
     "pane": (
-        "display:flex; flex-direction:column; gap: var(--lab-space-3); "
-        "background-color: var(--lab-color-surface); "
-        "border: var(--lab-line-weight) solid var(--lab-color-border); "
-        "border-radius: var(--lab-radius-2); padding: var(--lab-space-5); "
-        "color: var(--lab-color-text);"
+        "display:flex; flex-direction:column; gap: var(--mission-space-sm); "
+        "background-color: var(--mission-color-surface); "
+        "border: var(--mission-line-weight) solid var(--mission-color-border); "
+        "border-radius: var(--mission-radius-md); padding: var(--mission-space-lg); "
+        "color: var(--mission-color-text);"
     ),
     "layer-shadow": (
-        "background-color: var(--lab-color-layer-soft); "
-        "border-color: var(--lab-color-border-strong);"
+        "background-color: var(--mission-color-panel); "
+        "border-color: var(--mission-color-border-strong);"
     ),
     "fade-in": "",
     "fade-in-delayed": "",
@@ -108,21 +108,27 @@ def use_token(name: str, fallback: Optional[str] = None) -> str:
 
 
 def card(title: str, body: str = "", *, render: bool = True) -> str:
-    """Render a simple Rex-AI card block."""
+    """Render a minimalist mission panel."""
 
     load_theme(show_hud=False)
     base_style = (
-        "display:flex; flex-direction:column; gap: var(--lab-space-2); "
-        "background-color: var(--lab-color-surface); "
-        "border: var(--lab-line-weight) solid var(--lab-color-border); "
-        "border-radius: var(--lab-radius-2); "
-        "padding: var(--lab-space-5);"
+        "display:flex; flex-direction:column; gap: var(--mission-space-xs); "
+        "background-color: var(--mission-color-surface); "
+        "border: var(--mission-line-weight) solid var(--mission-color-border); "
+        "border-radius: var(--mission-radius-md); "
+        "padding: var(--mission-space-lg);"
     )
-    title_style = "margin:0; font-size:1.1rem; color: var(--lab-color-text); letter-spacing:0.01em;"
-    body_style = "margin:0; color: var(--lab-color-muted); font-size:0.95rem;"
+    title_style = (
+        "margin:0; font-size:1.1rem; color: var(--mission-color-text); "
+        "letter-spacing:0.01em;"
+    )
+    body_style = "margin:0; color: var(--mission-color-muted); font-size:0.95rem;"
     title_html = f"<h3 style=\"{title_style}\">{escape(title)}</h3>" if title else ""
     body_html = f"<p style=\"{body_style}\">{escape(body)}</p>" if body else ""
-    markup = f"<article data-lab-card style=\"{base_style}\">{title_html}{body_html}</article>"
+    markup = (
+        f"<article data-mission-card data-lab-card style=\"{base_style}\">"
+        f"{title_html}{body_html}</article>"
+    )
     if render:
         st.markdown(markup, unsafe_allow_html=True)
     return markup
@@ -137,22 +143,22 @@ _PILL_KINDS = {
 }
 
 _PILL_COLORS: dict[str, tuple[str, str]] = {
-    "ok": ("var(--lab-color-positive-soft)", "var(--lab-color-positive)"),
-    "warn": ("var(--lab-color-warning-soft)", "var(--lab-color-warning)"),
-    "risk": ("var(--lab-color-critical-soft)", "var(--lab-color-critical)"),
-    "info": ("var(--lab-color-layer-soft)", "var(--lab-color-accent)"),
-    "accent": ("var(--lab-color-accent-soft)", "var(--lab-color-accent)"),
+    "ok": ("var(--mission-color-positive-soft)", "var(--mission-color-positive)"),
+    "warn": ("var(--mission-color-warning-soft)", "var(--mission-color-warning)"),
+    "risk": ("var(--mission-color-critical-soft)", "var(--mission-color-critical)"),
+    "info": ("var(--mission-color-panel)", "var(--mission-color-accent)"),
+    "accent": ("var(--mission-color-accent-soft)", "var(--mission-color-accent)"),
 }
 
 _CHIP_TONES: dict[str, tuple[str, str]] = {
-    "positive": ("var(--lab-color-positive-soft)", "var(--lab-color-positive)"),
-    "ok": ("var(--lab-color-positive-soft)", "var(--lab-color-positive)"),
-    "warning": ("var(--lab-color-warning-soft)", "var(--lab-color-warning)"),
-    "warn": ("var(--lab-color-warning-soft)", "var(--lab-color-warning)"),
-    "danger": ("var(--lab-color-critical-soft)", "var(--lab-color-critical)"),
-    "risk": ("var(--lab-color-critical-soft)", "var(--lab-color-critical)"),
-    "info": ("var(--lab-color-layer-soft)", "var(--lab-color-accent)"),
-    "accent": ("var(--lab-color-accent-soft)", "var(--lab-color-accent)"),
+    "positive": ("var(--mission-color-positive-soft)", "var(--mission-color-positive)"),
+    "ok": ("var(--mission-color-positive-soft)", "var(--mission-color-positive)"),
+    "warning": ("var(--mission-color-warning-soft)", "var(--mission-color-warning)"),
+    "warn": ("var(--mission-color-warning-soft)", "var(--mission-color-warning)"),
+    "danger": ("var(--mission-color-critical-soft)", "var(--mission-color-critical)"),
+    "risk": ("var(--mission-color-critical-soft)", "var(--mission-color-critical)"),
+    "info": ("var(--mission-color-panel)", "var(--mission-color-accent)"),
+    "accent": ("var(--mission-color-accent-soft)", "var(--mission-color-accent)"),
 }
 
 
@@ -162,26 +168,26 @@ def pill(
     *,
     render: bool = True,
 ) -> str:
-    """Render a lab-status pill using the base mission palette."""
+    """Render a mission-status pill using the base palette."""
 
     load_theme(show_hud=False)
     tone = kind if kind in _PILL_KINDS else "ok"
     bg_color, fg_color = _PILL_COLORS.get(tone, _PILL_COLORS["ok"])
     base_style = (
         "display:inline-flex; align-items:center; justify-content:center; "
-        "gap: var(--lab-space-1); padding: 0.35rem 0.9rem; border-radius: 999px; "
+        "gap: var(--mission-space-2xs); padding: 0.35rem 0.9rem; border-radius: 999px; "
         "font-weight: 600; letter-spacing: 0.04em; text-transform: uppercase; "
         "font-size: 0.78rem;"
     )
     style = (
-        f"{base_style} background-color: var(--lab-pill-bg, {bg_color}); "
-        f"color: var(--lab-pill-fg, {fg_color}); "
-        f"border: var(--lab-line-weight) solid var(--lab-pill-fg, {fg_color});"
+        f"{base_style} background-color: var(--mission-pill-bg, {bg_color}); "
+        f"color: var(--mission-pill-fg, {fg_color}); "
+        f"border: var(--mission-line-weight) solid var(--mission-pill-fg, {fg_color});"
     )
     title_attr = escape(_PILL_KINDS[tone])
     tone_attr = escape(tone)
     markup = (
-        f"<span data-lab-pill='{tone}' data-kind='{tone_attr}' "
+        f"<span data-mission-pill='{tone}' data-lab-pill='{tone}' data-kind='{tone_attr}' "
         f"style=\"{style}\" title=\"{title_attr}\">"
         f"{escape(label)}"
         "</span>"
@@ -346,10 +352,15 @@ def layout_block(
             style_bits.append(mapped)
 
     if not style_bits:
-        style_bits.append("display:flex; flex-direction:column; gap: var(--lab-space-3);")
+        style_bits.append("display:flex; flex-direction:column; gap: var(--mission-space-sm);")
 
     style_attr = " ".join(style_bits)
-    data_attr = f' data-lab-classes="{escape(" ".join(tokens))}"' if tokens else ""
+    data_attr = ""
+    if tokens:
+        token_attr = escape(" ".join(tokens))
+        data_attr = (
+            f' data-mission-classes="{token_attr}" data-lab-classes="{token_attr}"'
+        )
 
     target = parent if parent is not None else st.container()
     target.markdown(
@@ -394,17 +405,17 @@ def chipline(
     load_theme(show_hud=False)
 
     row_style = (
-        "display:flex; flex-wrap:wrap; align-items:center; gap: var(--lab-space-2); "
-        "margin-block: var(--lab-space-2);"
+        "display:flex; flex-wrap:wrap; align-items:center; gap: var(--mission-space-xs); "
+        "margin-block: var(--mission-space-xs);"
     )
     chip_base = (
-        "display:inline-flex; align-items:center; gap: var(--lab-space-1); "
+        "display:inline-flex; align-items:center; gap: var(--mission-space-2xs); "
         "padding: 0.3rem 0.75rem; border-radius: 999px; font-size: 0.9rem; "
-        "border: var(--lab-line-weight) solid var(--lab-color-border); "
-        "background-color: var(--lab-color-layer-soft); color: var(--lab-color-text);"
+        "border: var(--mission-line-weight) solid var(--mission-color-border); "
+        "background-color: var(--mission-color-panel); color: var(--mission-color-text);"
     )
     icon_style = "font-size:1rem; line-height:1;"
-    label_style = "display:inline-flex; align-items:center; gap: var(--lab-space-1);"
+    label_style = "display:inline-flex; align-items:center; gap: var(--mission-space-2xs);"
 
     html: list[str] = [f"<div style=\"{row_style}\">"]
     for item in items:
@@ -419,7 +430,7 @@ def chipline(
 
         tone_key = tone.lower()
         bg_color, fg_color = _CHIP_TONES.get(
-            tone_key, ("var(--lab-color-layer-soft)", "var(--lab-color-text)")
+            tone_key, ("var(--mission-color-panel)", "var(--mission-color-text)")
         )
         chip_style = (
             f"{chip_base} background-color: {bg_color}; color: {fg_color}; "
@@ -432,7 +443,10 @@ def chipline(
             if icon_text
             else ""
         )
-        tone_attr = f" data-lab-chip-tone='{escape(tone_key)}'" if tone_key else ""
+        tone_attr = (
+            f" data-mission-chip-tone='{escape(tone_key)}'"
+            f" data-lab-chip-tone='{escape(tone_key)}'"
+        ) if tone_key else ""
         html.append(
             f"<span{tone_attr} style=\"{chip_style}\">"
             f"{icon_html}<span style=\"{label_style}\">{escape(label_text)}</span>"
@@ -451,12 +465,12 @@ def badge_group(labels: Iterable[str], *, parent: DeltaGenerator | None = None) 
     """Render pill badges inside the shared badge group wrapper."""
 
     palette_cycle = [
-        ("var(--lab-color-positive-soft)", "var(--lab-color-positive)"),
-        ("var(--lab-color-warning-soft)", "var(--lab-color-warning)"),
-        ("var(--lab-color-critical-soft)", "var(--lab-color-critical)"),
+        ("var(--mission-color-positive-soft)", "var(--mission-color-positive)"),
+        ("var(--mission-color-warning-soft)", "var(--mission-color-warning)"),
+        ("var(--mission-color-critical-soft)", "var(--mission-color-critical)"),
     ]
     row_style = (
-        "display:flex; flex-wrap:wrap; gap: var(--lab-space-2); margin-block: var(--lab-space-2);"
+        "display:flex; flex-wrap:wrap; gap: var(--mission-space-xs); margin-block: var(--mission-space-xs);"
     )
     badge_style = (
         "display:inline-flex; align-items:center; justify-content:center; "
@@ -473,10 +487,11 @@ def badge_group(labels: Iterable[str], *, parent: DeltaGenerator | None = None) 
         bg_color, fg_color = palette_cycle[index % len(palette_cycle)]
         style = (
             f"{badge_style} background-color: {bg_color}; color: {fg_color}; "
-            f"border: var(--lab-line-weight) solid {fg_color};"
+            f"border: var(--mission-line-weight) solid {fg_color};"
         )
         badge_markup.append(
-            f"<span data-lab-badge-index='{index}' style=\"{style}\">{escape(label)}</span>"
+            f"<span data-mission-badge-index='{index}' data-lab-badge-index='{index}' "
+            f"style=\"{style}\">{escape(label)}</span>"
         )
     badge_markup.append("</div>")
 
@@ -486,11 +501,11 @@ def badge_group(labels: Iterable[str], *, parent: DeltaGenerator | None = None) 
 
 
 def micro_divider(*, parent: DeltaGenerator | None = None) -> None:
-    """Insert a subtle divider matching the Rex-AI style guide."""
+    """Insert a subtle divider matching the mission style guide."""
 
     target = parent if parent is not None else st
     divider_style = (
-        "height:1px; width:100%; background-color: var(--lab-color-divider); "
-        "margin-block: var(--lab-space-4);"
+        "height:1px; width:100%; background-color: var(--mission-color-divider); "
+        "margin-block: var(--mission-space-md);"
     )
     target.markdown(f"<div style=\"{divider_style}\"></div>", unsafe_allow_html=True)

--- a/app/modules/visual_theme.py
+++ b/app/modules/visual_theme.py
@@ -1,10 +1,12 @@
 """NASA minimal visualization themes for Altair and Plotly.
 
-The palette favours clean laboratory whites, aerospace blues, and sharply
-defined contrast so that charts feel like instrumentation readouts rather than
-entertainment dashboards.  Both Altair and Plotly share the same minimalist
-tokens so that Streamlit pages inherit a restrained NASA mission-control
-aesthetic regardless of the rendering backend.
+The module codifies a compact palette derived from the NASA "meatball"
+guidelines: desaturated instrumentation neutrals, clean whites, and the
+mission-operations blue used as the primary accent.  The aim is to give charts
+and dashboards the feeling of a console readout—high legibility, zero
+ornamentation, and consistent contrast across libraries.  The same design
+tokens are exported to Altair, Plotly, and the CSS layer so that whichever
+backend renders a chart it stays aligned with the mission-control aesthetic.
 """
 from __future__ import annotations
 
@@ -19,9 +21,12 @@ ThemeMode = Literal["light", "dark"]
 
 _THEME_ENV_VAR = "REXAI_THEME_MODE"
 _DEFAULT_MODE: ThemeMode = "dark"
+FONT_STACK = "'Source Sans 3', 'Segoe UI', sans-serif"
+
+
 @dataclass(frozen=True)
 class Palette:
-    """Palette tokens exposed for downstream documentation or widgets."""
+    """Minimal high-contrast palette shared between backends."""
 
     background: str
     surface: str
@@ -37,41 +42,41 @@ class Palette:
 
 _PALETTES: Dict[ThemeMode, Palette] = {
     "light": Palette(
-        background="#F4F7FB",
+        background="#F5F7FA",
         surface="#FFFFFF",
-        panel="#E4EBF7",
-        grid="rgba(23,63,134,0.18)",
-        text="#0E2140",
-        muted="#4B607D",
-        accent="#234A91",
-        accent_soft="#6E8FD6",
-        electric_gradient=("#D7E3FF", "#7FA7FF", "#1F3E7A"),
+        panel="#E1E6EF",
+        grid="rgba(18,36,66,0.24)",
+        text="#0B1526",
+        muted="#465164",
+        accent="#0B3D91",
+        accent_soft="#4D6FB8",
+        electric_gradient=("#C9D4E8", "#7B93C9", "#1F3D7A"),
         categorical=(
-            "#234A91",
-            "#2A7F9E",
-            "#BF6C00",
-            "#146B4E",
-            "#5A3BA6",
-            "#9C2F3F",
+            "#0B3D91",
+            "#345D9C",
+            "#B65E15",
+            "#1D5F48",
+            "#5A4FBF",
+            "#A13A4A",
         ),
     ),
     "dark": Palette(
-        background="#0B1526",
-        surface="#141F32",
-        panel="#1F2B41",
-        grid="rgba(165,179,201,0.24)",
-        text="#F4F7FB",
-        muted="#9AA9C2",
-        accent="#6F9BFF",
-        accent_soft="#A8C1FF",
-        electric_gradient=("#4469B8", "#5E87E3", "#B1C7FF"),
+        background="#050A14",
+        surface="#0F172A",
+        panel="#1C2840",
+        grid="rgba(148,163,184,0.35)",
+        text="#F8FAFC",
+        muted="#9AA5BF",
+        accent="#5A8DEE",
+        accent_soft="#90AAEF",
+        electric_gradient=("#1D3B6F", "#325EA3", "#8FB8FF"),
         categorical=(
-            "#6F9BFF",
-            "#49B0C9",
-            "#D4973C",
-            "#49B188",
-            "#9082D5",
-            "#CF5E73",
+            "#5A8DEE",
+            "#3F9BB8",
+            "#D0812A",
+            "#4FA079",
+            "#8579D6",
+            "#C65B6C",
         ),
     ),
 }
@@ -94,20 +99,20 @@ def _altair_config(mode: ThemeMode) -> Dict[str, Dict[str, object]]:
             "background": background,
             "view": {
                 "stroke": palette.panel,
-                "strokeOpacity": 0.35,
+                "strokeOpacity": 0.4,
             },
             "padding": 16,
             "title": {
-                "font": "'Source Sans 3', 'Segoe UI', sans-serif",
+                "font": FONT_STACK,
                 "fontSize": 20,
                 "fontWeight": 600,
                 "color": palette.text,
             },
             "axis": {
-                "labelFont": "'Source Sans 3', 'Segoe UI', sans-serif",
+                "labelFont": FONT_STACK,
                 "labelFontSize": 12,
                 "labelColor": palette.muted,
-                "titleFont": "'Source Sans 3', 'Segoe UI', sans-serif",
+                "titleFont": FONT_STACK,
                 "titleFontWeight": 600,
                 "titleColor": palette.text,
                 "grid": True,
@@ -117,15 +122,15 @@ def _altair_config(mode: ThemeMode) -> Dict[str, Dict[str, object]]:
                 "tickSize": 4,
             },
             "legend": {
-                "labelFont": "'Source Sans 3', 'Segoe UI', sans-serif",
+                "labelFont": FONT_STACK,
                 "labelColor": palette.muted,
                 "titleColor": palette.text,
-                "symbolType": "circle",
+                "symbolType": "square",
                 "gradientLength": 140,
             },
             "header": {
-                "labelFont": "'Source Sans 3', 'Segoe UI', sans-serif",
-                "titleFont": "'Source Sans 3', 'Segoe UI', sans-serif",
+                "labelFont": FONT_STACK,
+                "titleFont": FONT_STACK,
                 "labelColor": palette.muted,
                 "titleColor": palette.text,
             },
@@ -133,7 +138,7 @@ def _altair_config(mode: ThemeMode) -> Dict[str, Dict[str, object]]:
                 "color": palette.accent,
                 "fill": palette.accent_soft,
                 "stroke": palette.accent,
-                "strokeWidth": 1.2,
+                "strokeWidth": 1.1,
             },
             "range": {
                 "category": list(palette.categorical),
@@ -143,7 +148,7 @@ def _altair_config(mode: ThemeMode) -> Dict[str, Dict[str, object]]:
             },
             "area": {
                 "line": True,
-                "opacity": 0.8,
+                "opacity": 0.85,
             },
             "rect": {
                 "stroke": surface,
@@ -168,8 +173,8 @@ def _plotly_template(mode: ThemeMode) -> Dict[str, object]:
         [0.5, palette.electric_gradient[1]],
         [1.0, palette.electric_gradient[2]],
     ]
-    font_family = "'Source Sans 3', 'Segoe UI', sans-serif"
-    title_family = "'Source Sans 3', 'Segoe UI', sans-serif"
+    font_family = FONT_STACK
+    title_family = FONT_STACK
 
     return {
         "layout": {

--- a/app/static/styles/base.css
+++ b/app/static/styles/base.css
@@ -1,59 +1,57 @@
 /*
- * NASA laboratory minimal theme tokens for Streamlit pages.
- * The variables favour clear contrast, high legibility, and restrained chrome
- * so that analytical surfaces feel like mission-control workspaces.
+ * NASA instrumentation-inspired base tokens and minimal resets.
+ * The palette emphasises neutral control-room surfaces with a single
+ * operations blue accent so analytical views stay focused and legible.
  */
 
 :root {
-  --lab-color-canvas: #f4f7fb;
-  --lab-color-surface: #ffffff;
-  --lab-color-layer-soft: #ecf1f9;
-  --lab-color-layer-strong: #dbe5f3;
-  --lab-color-border: #c3ccdd;
-  --lab-color-border-strong: #9da9bf;
-  --lab-color-divider: #d9e1ee;
-  --lab-color-text: #0b2142;
-  --lab-color-muted: #51607a;
-  --lab-color-accent: #224a91;
-  --lab-color-accent-soft: #5578c6;
-  --lab-color-positive: #1b6f5b;
-  --lab-color-positive-soft: #d5ede6;
-  --lab-color-warning: #b75e10;
-  --lab-color-warning-soft: #f4dfc8;
-  --lab-color-critical: #8e2430;
-  --lab-color-critical-soft: #f4d8dd;
+  --mission-color-canvas: #f5f7fa;
+  --mission-color-surface: #ffffff;
+  --mission-color-panel: #e1e6ef;
+  --mission-color-border: #b7c2d3;
+  --mission-color-border-strong: #7f8ba0;
+  --mission-color-divider: #cbd5e1;
+  --mission-color-text: #0b1526;
+  --mission-color-muted: #465164;
+  --mission-color-accent: #0b3d91;
+  --mission-color-accent-soft: #4d6fb8;
+  --mission-color-positive: #19624d;
+  --mission-color-positive-soft: #c7e5d9;
+  --mission-color-warning: #b35c1a;
+  --mission-color-warning-soft: #f2dfcd;
+  --mission-color-critical: #8c2f3a;
+  --mission-color-critical-soft: #f2d3da;
 
-  --lab-font-sans: "Source Sans 3", "Segoe UI", system-ui, sans-serif;
-  --lab-font-mono: "IBM Plex Mono", ui-monospace, SFMono-Regular, monospace;
+  --mission-font-sans: "Source Sans 3", "Segoe UI", system-ui, sans-serif;
+  --mission-font-mono: "IBM Plex Mono", ui-monospace, SFMono-Regular, monospace;
 
-  --lab-space-1: 0.25rem;
-  --lab-space-2: 0.5rem;
-  --lab-space-3: 0.75rem;
-  --lab-space-4: 1rem;
-  --lab-space-5: 1.5rem;
-  --lab-space-6: 2.25rem;
+  --mission-space-2xs: 0.25rem;
+  --mission-space-xs: 0.5rem;
+  --mission-space-sm: 0.75rem;
+  --mission-space-md: 1rem;
+  --mission-space-lg: 1.5rem;
+  --mission-space-xl: 2.25rem;
 
-  --lab-radius-1: 0.25rem;
-  --lab-radius-2: 0.5rem;
+  --mission-radius-sm: 0.25rem;
+  --mission-radius-md: 0.5rem;
 
-  --lab-line-weight: 1px;
-  --lab-layout-max-width: 1120px;
+  --mission-line-weight: 1px;
+  --mission-layout-max-width: 1120px;
 }
 
 body,
 .stApp {
   margin: 0;
   min-height: 100vh;
-  background-color: var(--lab-color-canvas);
-  color: var(--lab-color-text);
-  font-family: var(--lab-font-sans);
-  line-height: 1.5;
+  background-color: var(--mission-color-canvas);
+  color: var(--mission-color-text);
+  font-family: var(--mission-font-sans);
+  line-height: 1.55;
 }
 
 main .block-container {
-  max-width: var(--lab-layout-max-width);
-  padding-top: var(--lab-space-6);
-  padding-bottom: var(--lab-space-6);
+  max-width: var(--mission-layout-max-width);
+  padding-block: var(--mission-space-xl);
 }
 
 h1,
@@ -62,10 +60,10 @@ h3,
 h4,
 h5,
 h6 {
-  color: var(--lab-color-text);
+  color: var(--mission-color-text);
   font-weight: 600;
   letter-spacing: 0.01em;
-  margin-block: var(--lab-space-4) var(--lab-space-2);
+  margin-block: var(--mission-space-md) var(--mission-space-xs);
 }
 
 p,
@@ -86,70 +84,61 @@ small,
 caption,
 .stMarkdown small {
   font-size: 0.85rem;
-  color: var(--lab-color-muted);
+  color: var(--mission-color-muted);
 }
 
 a {
-  color: var(--lab-color-accent);
+  color: var(--mission-color-accent);
   text-decoration-thickness: 2px;
   text-underline-offset: 4px;
 }
 
 a:hover,
 a:focus {
-  color: var(--lab-color-accent-soft);
+  color: var(--mission-color-accent-soft);
 }
 
 code,
 pre,
 .stCode {
-  font-family: var(--lab-font-mono);
-  color: var(--lab-color-accent);
+  font-family: var(--mission-font-mono);
+  color: var(--mission-color-accent);
 }
 
 button,
 .stButton > button,
 button[kind="secondary"] {
-  border-radius: var(--lab-radius-2);
-}
-
-table {
-  border-color: var(--lab-color-divider);
+  border-radius: var(--mission-radius-md);
 }
 
 hr {
   border: 0;
   height: 1px;
-  background-color: var(--lab-color-divider);
-  margin-block: var(--lab-space-5);
+  background-color: var(--mission-color-divider);
+  margin-block: var(--mission-space-lg);
 }
 
-[data-lab-pill] {
-  --lab-pill-bg: var(--lab-color-positive-soft);
-  --lab-pill-fg: var(--lab-color-positive);
+table {
+  border-color: var(--mission-color-divider);
 }
 
-[data-lab-pill][data-kind="ok"] {
-  --lab-pill-bg: var(--lab-color-positive-soft);
-  --lab-pill-fg: var(--lab-color-positive);
+[data-testid="stMetricValue"] {
+  color: var(--mission-color-text);
+  font-weight: 600;
 }
 
-[data-lab-pill][data-kind="warn"] {
-  --lab-pill-bg: var(--lab-color-warning-soft);
-  --lab-pill-fg: var(--lab-color-warning);
+[data-testid="stMetricLabel"] {
+  color: var(--mission-color-muted);
+  font-size: 0.78rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
 }
 
-[data-lab-pill][data-kind="risk"] {
-  --lab-pill-bg: var(--lab-color-critical-soft);
-  --lab-pill-fg: var(--lab-color-critical);
+[data-testid="stMetricDelta"] {
+  font-weight: 600;
 }
 
-[data-lab-pill][data-kind="info"] {
-  --lab-pill-bg: var(--lab-color-layer-soft);
-  --lab-pill-fg: var(--lab-color-accent);
-}
-
-[data-lab-pill][data-kind="accent"] {
-  --lab-pill-bg: var(--lab-color-accent-soft);
-  --lab-pill-fg: var(--lab-color-accent);
+:focus-visible {
+  outline: 2px solid var(--mission-color-accent);
+  outline-offset: 2px;
 }

--- a/tests/ui/test_theme_css.py
+++ b/tests/ui/test_theme_css.py
@@ -4,7 +4,11 @@ from pathlib import Path
 def test_base_css_defines_new_primitives() -> None:
     css = Path("app/static/styles/base.css").read_text(encoding="utf-8")
 
-    for token in ("--lab-color-canvas", "--lab-color-surface", "--lab-space-4"):
+    for token in (
+        "--mission-color-canvas",
+        "--mission-color-surface",
+        "--mission-space-md",
+    ):
         assert token in css, f"Expected {token} token in base theme"
 
     for legacy in (".rex-pill", ".chipline__chip", ".rex-card", "linear-gradient"):

--- a/tests/ui/test_ui_blocks_markup.py
+++ b/tests/ui/test_ui_blocks_markup.py
@@ -15,9 +15,10 @@ def test_pill_returns_markup_without_render():
 
     html = ui_blocks.pill("Seguridad", kind="ok", render=False)
 
+    assert "data-mission-pill='ok'" in html
     assert "data-lab-pill='ok'" in html
     assert "data-kind='ok'" in html
-    assert "var(--lab-color-positive)" in html
+    assert "var(--mission-color-positive)" in html
 
 
 def test_pill_supports_info_and_accent_kinds():
@@ -27,9 +28,9 @@ def test_pill_supports_info_and_accent_kinds():
     accent_html = ui_blocks.pill("Aleación", kind="accent", render=False)
 
     assert "data-kind='info'" in info_html
-    assert "var(--lab-color-accent)" in info_html
+    assert "var(--mission-color-accent)" in info_html
     assert "data-kind='accent'" in accent_html
-    assert "var(--lab-color-accent-soft)" in accent_html
+    assert "var(--mission-color-accent-soft)" in accent_html
 
 
 def test_chipline_accepts_mappings(monkeypatch):
@@ -46,9 +47,9 @@ def test_chipline_accepts_mappings(monkeypatch):
         render=False,
     )
 
-    assert "data-lab-chip-tone='positive'" in html
+    assert "data-mission-chip-tone='positive'" in html
     assert "🧪" in html
-    assert "var(--lab-color-positive-soft)" in html
+    assert "var(--mission-color-positive-soft)" in html
 
 
 def test_chipline_uses_defined_tone_palette(monkeypatch):
@@ -65,7 +66,7 @@ def test_chipline_uses_defined_tone_palette(monkeypatch):
         render=False,
     )
 
-    assert "data-lab-chip-tone='danger'" in html
-    assert "data-lab-chip-tone='warning'" in html
-    assert "var(--lab-color-critical-soft)" in html
-    assert "var(--lab-color-warning-soft)" in html
+    assert "data-mission-chip-tone='danger'" in html
+    assert "data-mission-chip-tone='warning'" in html
+    assert "var(--mission-color-critical-soft)" in html
+    assert "var(--mission-color-warning-soft)" in html


### PR DESCRIPTION
## Summary
- document the NASA-inspired neutral palette and update Altair/Plotly templates to match the mission-control aesthetic
- replace the legacy glassmorphism base stylesheet with lightweight mission tokens and refreshed metric styling
- retune mission UI helpers (panels, chips, badges) and accompanying tests to use the new token family

## Testing
- pytest tests/ui *(fails: streamlit.testing import missing in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68df2ee75db48331afcf9a183bccb847