### PR TITLE
Refine candidate showroom UI styling and tests

### DIFF
--- a/app/modules/candidate_showroom.py
+++ b/app/modules/candidate_showroom.py
@@ -8,7 +8,7 @@ import pandas as pd
 import streamlit as st
 
 from app.modules.safety import check_safety, safety_badge
-from app.modules.ui_blocks import action_button
+from app.modules.ui_blocks import action_button, chipline, pill
 
 _SUCCESS_KEY = "__candidate_showroom_success__"
 _MODAL_KEY = "showroom_modal"
@@ -298,12 +298,14 @@ def _render_candidate_table(
     active_filters.extend(resource_labels)
 
     if only_safe or active_filters:
-        captions: list[str] = []
+        st.caption("Filtros activos")
+        chips: list[dict[str, str]] = []
         if only_safe:
-            captions.append("Filtro de seguridad activo")
-        if active_filters:
-            captions.append("; ".join(active_filters))
-        st.caption(" · ".join(captions))
+            chips.append({"label": "Sólo seguros", "icon": "🛡️", "tone": "positive"})
+        for label in active_filters:
+            icon = "🎯" if label.startswith("Score") else "⚙️"
+            chips.append({"label": label, "icon": icon, "tone": "info"})
+        chipline(chips)
 
     table_payload: list[dict[str, Any]] = []
     for rank, row in enumerate(rows, start=1):
@@ -365,16 +367,17 @@ def _render_candidate_actions(
         badge_cols[1].metric("Rigidez", f"{row['rigidity']:.2f}")
         badge_cols[2].metric("Consumo", f"{row['energy']:.2f} kWh")
 
-        detail_cols = st.columns(3)
+        detail_cols = st.columns(2)
         detail_cols[0].metric("Agua", f"{row['water']:.2f} L")
         detail_cols[1].metric("Crew", f"{row['crew']:.1f} min")
+
         safety_label = "Seguro" if row["is_safe"] else "Riesgo"
-        detail_cols[2].metric("Seguridad", safety_label)
+        pill(f"Seguridad: {safety_label}", kind="ok" if row["is_safe"] else "risk")
         st.caption(badge.get("detail", ""))
 
         badges = row.get("badges", [])
         if badges:
-            st.caption("Etiquetas: " + " · ".join(badges))
+            chipline(badges)
 
         candidate_key = row["key"]
         modal_key = st.session_state.get(_MODAL_KEY)

--- a/app/modules/ui_blocks.py
+++ b/app/modules/ui_blocks.py
@@ -58,7 +58,10 @@ def _read_css_bundle() -> str:
         return ""
 
 
-def _inject_css_once() -> None:
+def load_theme(*, show_hud: bool = True) -> None:
+    """Inject the lightweight NASA-inspired base stylesheet."""
+
+    del show_hud  # compatibility no-op
     css = _read_css_bundle()
     if not css:
         return
@@ -69,18 +72,6 @@ def _inject_css_once() -> None:
 
     st.markdown(f"<style>{css}</style>", unsafe_allow_html=True)
     st.session_state[_THEME_HASH_KEY] = css_hash
-
-
-
-
-
-
-
-def load_theme(*, show_hud: bool = True) -> None:
-    """Inject the lightweight NASA-inspired base stylesheet."""
-
-    del show_hud  # compatibility no-op
-    _inject_css_once()
 
 
 def initialise_frontend() -> None:

--- a/tests/modules/test_candidate_showroom.py
+++ b/tests/modules/test_candidate_showroom.py
@@ -1,9 +1,120 @@
 import pytest
 
+import sys
+import types
+
+sys.modules.setdefault("joblib", types.ModuleType("joblib"))
+class _FakeNumpy(types.ModuleType):
+    def isscalar(self, obj):  # pragma: no cover - simple heuristic
+        return not isinstance(obj, (list, tuple, dict, set))
+
+    bool_ = bool
+
+
+sys.modules.setdefault("numpy", _FakeNumpy("numpy"))
+sys.modules.setdefault("requests", types.ModuleType("requests"))
+sys.modules.setdefault("polars", types.ModuleType("polars"))
+
+
+class _FakePandas(types.ModuleType):
+    def DataFrame(self, data):  # pragma: no cover - simple stub
+        self.last_dataframe_input = data
+        return {"rows": data}
+
+
+sys.modules.setdefault("pandas", _FakePandas("pandas"))
+
+
+class _StreamlitStub(types.ModuleType):
+    def __init__(self):
+        super().__init__("streamlit")
+        self.session_state = {}
+        self.column_config = types.SimpleNamespace(
+            NumberColumn=lambda *args, **kwargs: {"label": args[0] if args else ""},
+            TextColumn=lambda *args, **kwargs: {"label": args[0] if args else ""},
+            ListColumn=lambda *args, **kwargs: {"label": args[0] if args else ""},
+        )
+        self.__path__ = []
+
+    def cache_resource(self, *args, **kwargs):  # pragma: no cover - simple identity decorator
+        def _decorator(func):
+            return func
+
+        return _decorator
+
+    def __getattr__(self, name):  # pragma: no cover - simple stub
+        def _noop(*args, **kwargs):
+            return None
+
+        return _noop
+
+
+sys.modules.setdefault("streamlit", _StreamlitStub())
+streamlit_delta = types.ModuleType("streamlit.delta_generator")
+
+
+class _DeltaGenerator:  # pragma: no cover - simple stub
+    pass
+
+
+streamlit_delta.DeltaGenerator = _DeltaGenerator
+sys.modules.setdefault("streamlit.delta_generator", streamlit_delta)
+
+ml_models_stub = types.ModuleType("app.modules.ml_models")
+ml_models_stub.MODEL_REGISTRY = object()
+
+
+class _DummyModelRegistry:  # pragma: no cover - simple stub
+    ready = False
+
+
+ml_models_stub.ModelRegistry = _DummyModelRegistry
+ml_models_stub.PredictionResult = type("PredictionResult", (), {})
+
+
+class _DummyRegistryCache:  # pragma: no cover - simple stub
+    def __call__(self):
+        return _DummyModelRegistry()
+
+    def clear(self):
+        return None
+
+
+ml_models_stub.get_model_registry = _DummyRegistryCache()
+sys.modules["app.modules.ml_models"] = ml_models_stub
+
+io_stub = types.ModuleType("app.modules.io")
+
+
+def _noop_io(*_args, **_kwargs):  # pragma: no cover - simple stub
+    return None
+
+
+for _name in [
+    "load_waste_df",
+    "save_waste_df",
+    "load_targets",
+    "load_process_catalog",
+    "invalidate_waste_cache",
+    "invalidate_process_cache",
+    "invalidate_targets_cache",
+    "invalidate_all_io_caches",
+]:
+    setattr(io_stub, _name, _noop_io)
+
+
+sys.modules["app.modules.io"] = io_stub
+sys.modules.setdefault("app.modules.mission_overview", types.ModuleType("app.modules.mission_overview"))
+visual_theme_stub = types.ModuleType("app.modules.visual_theme")
+visual_theme_stub.apply_global_visual_theme = lambda: None
+sys.modules["app.modules.visual_theme"] = visual_theme_stub
+
+from app.modules import candidate_showroom
 from app.modules.candidate_showroom import (
     _collect_badges,
     _normalize_success,
     _prepare_rows,
+    render_candidate_showroom,
 )
 
 
@@ -89,3 +200,196 @@ def test_collect_badges_sources_and_auxiliary():
     assert "⛰️ ISRU MGS-1" in badges
     assert "♻️ Valorización problemáticos" in badges
     assert "🛡️ Seal ready" in badges
+
+
+def test_render_candidate_actions_uses_pill_and_chipline(monkeypatch):
+    fake_st = _FakeStreamlit()
+    monkeypatch.setattr(candidate_showroom, "st", fake_st)
+    monkeypatch.setattr(candidate_showroom, "action_button", lambda *_, **__: False)
+
+    pill_calls: list[tuple[str, str]] = []
+
+    def _record_pill(label, *, kind="ok", render=True):
+        del render
+        pill_calls.append((label, kind))
+        return label
+
+    chip_calls: list[list[str]] = []
+
+    def _record_chipline(labels):
+        chip_calls.append(list(labels))
+        return ""
+
+    monkeypatch.setattr(candidate_showroom, "pill", _record_pill)
+    monkeypatch.setattr(candidate_showroom, "chipline", _record_chipline)
+
+    row = {
+        "process_name": "Proceso Seguro",
+        "process_id": "A1",
+        "score": 0.9,
+        "rigidity": 0.5,
+        "energy": 1.2,
+        "water": 0.8,
+        "crew": 3.0,
+        "is_safe": True,
+        "safety": {"detail": "Sin hallazgos", "level": "OK"},
+        "badges": ["🎯 Score ≥ 0.80"],
+        "key": "0",
+        "candidate": _base_candidate(),
+    }
+
+    candidate_showroom._render_candidate_actions(1, row, {"candidate_key": None}, scenario="Test")
+
+    assert pill_calls and pill_calls[0][0].startswith("Seguridad"), "La pastilla debe mostrar la seguridad"
+    assert chip_calls and chip_calls[0] == ["🎯 Score ≥ 0.80"], "Las etiquetas deben mostrarse como chips"
+
+class _NullContext:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+class _ColumnConfig:
+    class NumberColumn:  # pragma: no cover - simple data holder
+        def __init__(self, label: str, **kwargs):
+            self.label = label
+            self.options = kwargs
+
+    class TextColumn:  # pragma: no cover - simple data holder
+        def __init__(self, label: str, **kwargs):
+            self.label = label
+            self.options = kwargs
+
+    class ListColumn:  # pragma: no cover - simple data holder
+        def __init__(self, label: str, **kwargs):
+            self.label = label
+            self.options = kwargs
+
+
+class _FakeColumn:
+    def __init__(self, store):
+        self._store = store
+
+    def metric(self, label, value):
+        self._store.append({"label": label, "value": value})
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+class _FakeStreamlit:
+    def __init__(self):
+        self.session_state: dict[str, object] = {}
+        self.slider_values: list[object] = []
+        self.checkbox_values: list[object] = []
+        self.slider_calls: list[dict[str, object]] = []
+        self.checkbox_calls: list[dict[str, object]] = []
+        self.caption_texts: list[str] = []
+        self.subheaders: list[str] = []
+        self.dataframe_calls: list[tuple[object, dict]] = []
+        self.metric_calls: list[tuple[str, object]] = []
+        self.column_calls: list[tuple[int, str]] = []
+        self.warning_messages: list[str] = []
+        self.info_messages: list[str] = []
+        self.success_messages: list[str] = []
+        self.column_config = _ColumnConfig
+
+    def info(self, message):
+        self.info_messages.append(message)
+
+    def slider(self, label, *, min_value=None, max_value=None, value=None, step=None, key=None):
+        call = {
+            "label": label,
+            "min": min_value,
+            "max": max_value,
+            "value": value,
+            "step": step,
+            "key": key,
+        }
+        self.slider_calls.append(call)
+        if self.slider_values:
+            return self.slider_values.pop(0)
+        return value
+
+    def checkbox(self, label, *, value=False, key=None, help=None):
+        call = {"label": label, "value": value, "key": key, "help": help}
+        self.checkbox_calls.append(call)
+        if self.checkbox_values:
+            return self.checkbox_values.pop(0)
+        return value
+
+    def columns(self, n, gap="small"):
+        self.column_calls.append((n, gap))
+        return [_FakeColumn(self.metric_calls) for _ in range(n)]
+
+    def caption(self, text):
+        self.caption_texts.append(str(text))
+
+    def subheader(self, text):
+        self.subheaders.append(str(text))
+
+    def dataframe(self, data, **kwargs):
+        self.dataframe_calls.append((data, kwargs))
+
+    def warning(self, message):
+        self.warning_messages.append(str(message))
+
+    def success(self, message):
+        self.success_messages.append(str(message))
+
+    def metric(self, *args, **kwargs):
+        label = args[0] if args else kwargs.get("label", "")
+        value = args[1] if len(args) > 1 else kwargs.get("value")
+        self.metric_calls.append({"label": label, "value": value})
+
+    # Compatibility helpers for patched actions
+    def expander(self, *_, **__):
+        return _NullContext()
+
+    def modal(self, *_, **__):
+        return _NullContext()
+
+    def markdown(self, *_, **__):
+        return None
+
+
+def test_render_candidate_showroom_native_mode(monkeypatch):
+    fake_st = _FakeStreamlit()
+    fake_st.slider_values = [0.82, 2.3, 1.1, 5]
+    fake_st.checkbox_values = [True, True, True, True]
+
+    monkeypatch.setattr(candidate_showroom, "st", fake_st)
+    monkeypatch.setattr(candidate_showroom, "_render_candidate_actions", lambda *_, **__: None)
+
+    chip_calls: list[list[str]] = []
+
+    def _record_chipline(labels):
+        chip_calls.append(list(labels))
+        return ""
+
+    monkeypatch.setattr(candidate_showroom, "chipline", _record_chipline)
+
+    candidates = [_base_candidate(score=0.88)]
+    target = {
+        "max_energy_kwh": 2.5,
+        "max_water_l": 1.5,
+        "max_crew_min": 5,
+        "scenario": "Daring Discoveries",
+    }
+
+    visible = render_candidate_showroom(candidates, target)
+
+    assert visible == candidates
+    assert fake_st.subheaders and "Ranking" in fake_st.subheaders[0]
+    assert fake_st.dataframe_calls, "Should render native dataframe"
+    df_kwargs = fake_st.dataframe_calls[0][1]
+    assert df_kwargs.get("hide_index") is True
+    assert "column_config" in df_kwargs
+    assert any("Score mínimo" in item["label"] for item in fake_st.metric_calls)
+    assert "Filtros activos" in fake_st.caption_texts
+    assert chip_calls, "Chipline should be used for filtros activos"


### PR DESCRIPTION
## Summary
- replace the showroom filter summary with chipline badges and a safety pill while keeping the native dataframe view
- inline the CSS theme loader so the private `_inject_css` helper is no longer required
- expand the candidate showroom tests with streamlit stubs that cover native rendering plus the new pill and chip badges

## Testing
- pipx run pytest tests/modules/test_candidate_showroom.py

------
https://chatgpt.com/codex/tasks/task_e_68df3116017483319bdad61449fa5db3