### PR TITLE
Refactor action button wrapper to use native widgets

### DIFF
--- a/app/modules/candidate_showroom.py
+++ b/app/modules/candidate_showroom.py
@@ -395,11 +395,12 @@ def _render_candidate_actions(
             key=f"showroom_select_{candidate_key}",
             state=btn_state,
             width="full",
-            loading_label="Abriendo holograma…",
-            success_label="Receta seleccionada",
             help_text="Confirmá la receta desde la ventana emergente.",
-            status_hints={
-                "idle": "",
+            state_labels={
+                "loading": "Abriendo holograma…",
+                "success": "Receta seleccionada",
+            },
+            state_messages={
                 "loading": "Mostrando holograma",
                 "success": "Receta lista para confirmar",
                 "error": "Reintentá la selección",
@@ -421,10 +422,11 @@ def _render_candidate_actions(
                         key=f"confirm_{candidate_key}",
                         state="idle",
                         width="full",
-                        loading_label="Sincronizando…",
-                        success_label="Receta confirmada",
-                        status_hints={
-                            "idle": "",
+                        state_labels={
+                            "loading": "Sincronizando…",
+                            "success": "Receta confirmada",
+                        },
+                        state_messages={
                             "loading": "Sincronizando selección",
                             "success": "Receta confirmada",
                             "error": "No se pudo confirmar",

--- a/app/pages/3_Generator.py
+++ b/app/pages/3_Generator.py
@@ -1007,11 +1007,12 @@ with layout_block("layout-grid layout-grid--dual layout-grid--flow", parent=None
                     state=button_state,
                     width="full",
                     help_text="Ejecuta Ax + BoTorch con los parámetros seleccionados.",
-                    loading_label="Generando lote…",
-                    success_label="Lote listo",
-                    error_label="Reintentar",
-                    status_hints={
-                        "idle": "",
+                    state_labels={
+                        "loading": "Generando lote…",
+                        "success": "Lote listo",
+                        "error": "Reintentar",
+                    },
+                    state_messages={
                         "loading": "Ejecutando optimizador",
                         "success": "Resultados actualizados",
                         "error": "Revisá la configuración",


### PR DESCRIPTION
## Summary
- rework `action_button` to wrap Streamlit buttons and report state with spinner/status widgets
- update generator and candidate showroom flows to use the new state label/message options
- refresh the action button unit tests to assert native widget usage

## Testing
- `pytest tests/ui/test_action_button_usage.py`


------
https://chatgpt.com/codex/tasks/task_e_68df34869b34833183240631dd960cd3