### PR TITLE
Modernize compare and explain page styling

### DIFF
--- a/app/modules/ui_blocks.py
+++ b/app/modules/ui_blocks.py
@@ -125,20 +125,13 @@ def card(title: str, body: str = "", *, render: bool = True) -> str:
     return markup
 
 
+
 _PILL_KINDS = {
     "ok": "Rango nominal",
     "warn": "Monitoreo",
     "risk": "Riesgo",
     "info": "Referencia informativa",
     "accent": "Etiqueta destacada",
-}
-
-_PILL_COLORS: dict[str, tuple[str, str]] = {
-    "ok": ("var(--mission-color-positive-soft)", "var(--mission-color-positive)"),
-    "warn": ("var(--mission-color-warning-soft)", "var(--mission-color-warning)"),
-    "risk": ("var(--mission-color-critical-soft)", "var(--mission-color-critical)"),
-    "info": ("var(--mission-color-panel)", "var(--mission-color-accent)"),
-    "accent": ("var(--mission-color-accent-soft)", "var(--mission-color-accent)"),
 }
 
 _CHIP_TONES: dict[str, tuple[str, str]] = {
@@ -155,7 +148,7 @@ _CHIP_TONES: dict[str, tuple[str, str]] = {
 
 def pill(
     label: str,
-    kind: Literal["ok", "warn", "risk"] = "ok",
+    kind: Literal["ok", "warn", "risk", "info", "accent"] = "ok",
     *,
     render: bool = True,
 ) -> str:
@@ -163,25 +156,14 @@ def pill(
 
     load_theme(show_hud=False)
     tone = kind if kind in _PILL_KINDS else "ok"
-    bg_color, fg_color = _PILL_COLORS.get(tone, _PILL_COLORS["ok"])
-    base_style = (
-        "display:inline-flex; align-items:center; justify-content:center; "
-        "gap: var(--mission-space-2xs); padding: 0.35rem 0.9rem; border-radius: 999px; "
-        "font-weight: 600; letter-spacing: 0.04em; text-transform: uppercase; "
-        "font-size: 0.78rem;"
-    )
-    style = (
-        f"{base_style} background-color: var(--mission-pill-bg, {bg_color}); "
-        f"color: var(--mission-pill-fg, {fg_color}); "
-        f"border: var(--mission-line-weight) solid var(--mission-pill-fg, {fg_color});"
-    )
     title_attr = escape(_PILL_KINDS[tone])
     tone_attr = escape(tone)
+    label_html = escape(label)
     markup = (
-        f"<span data-mission-pill='{tone}' data-lab-pill='{tone}' data-kind='{tone_attr}' "
-        f"style=\"{style}\" title=\"{title_attr}\">"
-        f"{escape(label)}"
-        "</span>"
+        f"<span class='mission-pill mission-pill--{tone_attr}' "
+        f"data-mission-pill='{tone_attr}' data-lab-pill='{tone_attr}' "
+        f"data-kind='{tone_attr}' title='{title_attr}'>"
+        f"{label_html}</span>"
     )
     if render:
         st.markdown(markup, unsafe_allow_html=True)

--- a/app/pages/5_Compare_and_Explain.py
+++ b/app/pages/5_Compare_and_Explain.py
@@ -523,13 +523,36 @@ with tab1:
     # Resumen del candidato
     cL, cR = st.columns([1.2, 1.0])
     with cL:
-        st.markdown(f"**Proceso:** {c['process_id']} — {c['process_name']}")
-        st.markdown(f"**Materiales:** {', '.join(c['materials'])}")
-        st.markdown(f"**Pesos:** {c['weights']}")
-        st.markdown(f"**Score:** {c['score']:.2f}")
+        st.markdown(f"#### Candidato #{int(pick)} — {c['process_name']}")
+        st.caption(f"Proceso {c['process_id']} · Materiales: {', '.join(c['materials'])}")
+
         p = c["props"]
-        st.markdown(f"**Predicción** → Rigidez {p.rigidity:.2f} | Estanqueidad {p.tightness:.2f} | Masa {p.mass_final_kg:.2f} kg")
-        st.markdown(f"**Recursos** → Energía {p.energy_kwh:.2f} kWh | Agua {p.water_l:.2f} L | Crew {p.crew_min:.0f} min")
+        primary_metrics = st.columns(3)
+        with primary_metrics[0]:
+            st.metric("Score", f"{c['score']:.2f}")
+        with primary_metrics[1]:
+            st.metric("Rigidez", f"{p.rigidity:.2f}")
+        with primary_metrics[2]:
+            st.metric("Estanqueidad", f"{p.tightness:.2f}")
+
+        resource_metrics = st.columns(3)
+        with resource_metrics[0]:
+            st.metric("Energía (kWh)", f"{p.energy_kwh:.2f}")
+        with resource_metrics[1]:
+            st.metric("Agua (L)", f"{p.water_l:.2f}")
+        with resource_metrics[2]:
+            st.metric("Crew (min)", f"{p.crew_min:.0f}")
+
+        st.metric("Masa final (kg)", f"{p.mass_final_kg:.2f}")
+
+        weights_series = pd.Series(c["weights"], name="Peso")
+        weights_df = (
+            weights_series.rename_axis("Factor").reset_index()
+            if not weights_series.empty
+            else pd.DataFrame({"Factor": [], "Peso": []})
+        )
+        st.dataframe(weights_df, use_container_width=True, hide_index=True)
+
         # Pills de ajuste a límites
         pill_markup: list[str] = []
         limits = [

--- a/app/static/styles/base.css
+++ b/app/static/styles/base.css
@@ -138,6 +138,55 @@ table {
   font-weight: 600;
 }
 
+[data-mission-pill] {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--mission-space-2xs);
+  padding: 0.35rem 0.9rem;
+  border-radius: 999px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  font-size: 0.78rem;
+  border: var(--mission-line-weight) solid transparent;
+}
+
+[data-mission-pill="ok"],
+.mission-pill--ok {
+  background-color: var(--mission-color-positive-soft);
+  color: var(--mission-color-positive);
+  border-color: var(--mission-color-positive);
+}
+
+[data-mission-pill="warn"],
+.mission-pill--warn {
+  background-color: var(--mission-color-warning-soft);
+  color: var(--mission-color-warning);
+  border-color: var(--mission-color-warning);
+}
+
+[data-mission-pill="risk"],
+.mission-pill--risk {
+  background-color: var(--mission-color-critical-soft);
+  color: var(--mission-color-critical);
+  border-color: var(--mission-color-critical);
+}
+
+[data-mission-pill="info"],
+.mission-pill--info {
+  background-color: var(--mission-color-panel);
+  color: var(--mission-color-accent);
+  border-color: var(--mission-color-accent);
+}
+
+[data-mission-pill="accent"],
+.mission-pill--accent {
+  background-color: var(--mission-color-accent-soft);
+  color: var(--mission-color-surface);
+  border-color: var(--mission-color-accent-soft);
+}
+
 :focus-visible {
   outline: 2px solid var(--mission-color-accent);
   outline-offset: 2px;

--- a/tests/pages/test_compare_and_explain_page.py
+++ b/tests/pages/test_compare_and_explain_page.py
@@ -141,6 +141,17 @@ def test_compare_page_renders_table_and_storytelling(compare_page_runner: Stream
     expected_columns = {"Score", "Energía (kWh)", "Agua (L)", "Crew (min)"}
     assert expected_columns.issubset(set(comparison_table.columns))
 
+    metric_labels = {metric.label for metric in app.metric}
+    assert {"Opciones generadas", "Mejor Score"}.issubset(metric_labels)
+
     storytelling_section = " ".join(block.body for block in app.markdown)
     assert "Storytelling asistido por IA" in storytelling_section
     assert "- " in storytelling_section  # bullet list con los insights
+
+
+def test_compare_page_pills_do_not_use_inline_styles(compare_page_runner: StreamlitRunner) -> None:
+    app = compare_page_runner.run()
+
+    pill_sections = [block.body for block in app.markdown if "data-mission-pill" in block.body]
+    assert pill_sections, "Se espera al menos un pill renderizado"
+    assert all("style=" not in section.lower() for section in pill_sections)


### PR DESCRIPTION
## Summary
- replace the compare page’s inline-styled blocks with Streamlit metrics, columns, dataframes, and pills for the candidate inspector
- refactor the pill helper to emit class-based markup and extend the base stylesheet with mission pill rules
- tighten the page regression tests to assert the comparative table, metrics, and pill markup render without inline styles

## Testing
- pytest tests/pages/test_compare_and_explain_page.py

------
https://chatgpt.com/codex/tasks/task_e_68df357211008331918b7b8611d79462