### PR TITLE
Add info and accent pill tones styling and tests

### DIFF
--- a/app/modules/ui_blocks.py
+++ b/app/modules/ui_blocks.py
@@ -126,7 +126,10 @@ def card(title: str, body: str = "", *, render: bool = True) -> str:
 
 
 
-_PILL_KINDS = {
+PillKind = Literal["ok", "warn", "risk", "info", "accent"]
+
+
+_PILL_KINDS: dict[PillKind, str] = {
     "ok": "Rango nominal",
     "warn": "Monitoreo",
     "risk": "Riesgo",
@@ -148,7 +151,7 @@ _CHIP_TONES: dict[str, tuple[str, str]] = {
 
 def pill(
     label: str,
-    kind: Literal["ok", "warn", "risk", "info", "accent"] = "ok",
+    kind: PillKind = "ok",
     *,
     render: bool = True,
 ) -> str:

--- a/app/static/styles/base.css
+++ b/app/static/styles/base.css
@@ -173,6 +173,7 @@ table {
   border-color: var(--mission-color-critical);
 }
 
+/* Informational tone emphasises the analytical accent colour. */
 [data-mission-pill="info"],
 .mission-pill--info {
   background-color: var(--mission-color-panel);
@@ -180,11 +181,12 @@ table {
   border-color: var(--mission-color-accent);
 }
 
+/* Accent tone highlights key tags with stronger borders. */
 [data-mission-pill="accent"],
 .mission-pill--accent {
   background-color: var(--mission-color-accent-soft);
   color: var(--mission-color-surface);
-  border-color: var(--mission-color-accent-soft);
+  border-color: var(--mission-color-accent);
 }
 
 :focus-visible {

--- a/tests/modules/test_ui_blocks.py
+++ b/tests/modules/test_ui_blocks.py
@@ -1,0 +1,25 @@
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _stub_load_theme(monkeypatch):
+    from app.modules import ui_blocks
+
+    monkeypatch.setattr(ui_blocks, "load_theme", lambda show_hud=False: None)
+
+
+@pytest.mark.parametrize(
+    ("kind", "expected_title"),
+    (
+        ("info", "Referencia informativa"),
+        ("accent", "Etiqueta destacada"),
+    ),
+)
+def test_pill_serialises_extended_tones(kind, expected_title):
+    from app.modules import ui_blocks
+
+    html = ui_blocks.pill("Etiqueta", kind=kind, render=False)
+
+    assert f"data-mission-pill='{kind}'" in html
+    assert f"data-kind='{kind}'" in html
+    assert f"title='{expected_title}'" in html


### PR DESCRIPTION
## Summary
- formalize the pill tone map with explicit Literal coverage for the info and accent tags
- adjust the base stylesheet so the informational and accent pills have dedicated rules and stronger borders
- add module-level tests that exercise the serialization of the new pill tones

## Testing
- pytest tests/modules/test_ui_blocks.py

------
https://chatgpt.com/codex/tasks/task_e_68df387dc9748331b5257b4d5eae5b24