### PR TITLE
Handle empty distributions and mapping-friendly numeric series

### DIFF
--- a/app/pages/3_Generator.py
+++ b/app/pages/3_Generator.py
@@ -158,9 +158,18 @@ def _safe_float(value: object) -> float | None:
     return number
 
 
-def _numeric_series(df: pd.DataFrame | None, column: str) -> pd.Series:
+def _numeric_series(
+    df: pd.DataFrame | Mapping[str, object] | None, column: str
+) -> pd.Series:
+    if isinstance(df, Mapping):
+        candidate = df.get(column)
+        if isinstance(candidate, pd.DataFrame):
+            df = candidate
+        else:
+            return pd.Series([], dtype=float)
+
     if not isinstance(df, pd.DataFrame) or column not in df.columns:
-        return pd.Series(dtype="float64")
+        return pd.Series([], dtype=float)
 
     series = pd.to_numeric(df[column], errors="coerce")
     return series.dropna()

--- a/app/pages/4_Results_and_Tradeoffs.py
+++ b/app/pages/4_Results_and_Tradeoffs.py
@@ -304,7 +304,12 @@ if external_profiles:
             density_value = polymer_metrics.get("density_g_cm3")
             tensile_value = polymer_metrics.get("tensile_mpa")
             chart_cols = st.columns(2)
-            if density_value and not polymer_density_distribution.empty:
+            density_area, tensile_area = chart_cols
+            if polymer_density_distribution.empty:
+                density_area.info(
+                    "No hay densidades de polímeros en el inventario actual para comparar."
+                )
+            elif density_value:
                 base = alt.Chart(
                     pd.DataFrame({"density": polymer_density_distribution})
                 ).mark_bar(color="#22d3ee", opacity=0.55).encode(
@@ -314,8 +319,13 @@ if external_profiles:
                 rule = alt.Chart(pd.DataFrame({"density": [density_value]})).mark_rule(
                     color="#f97316", size=3
                 ).encode(x="density:Q")
-                chart_cols[0].altair_chart(base + rule, use_container_width=True)
-            if tensile_value and not polymer_tensile_distribution.empty:
+                density_area.altair_chart(base + rule, use_container_width=True)
+
+            if polymer_tensile_distribution.empty:
+                tensile_area.info(
+                    "No hay datos de resistencia a tracción de polímeros en el inventario actual."
+                )
+            elif tensile_value:
                 base = alt.Chart(
                     pd.DataFrame({"tensile": polymer_tensile_distribution})
                 ).mark_bar(color="#f472b6", opacity=0.55).encode(
@@ -325,7 +335,7 @@ if external_profiles:
                 rule = alt.Chart(pd.DataFrame({"tensile": [tensile_value]})).mark_rule(
                     color="#f97316", size=3
                 ).encode(x="tensile:Q")
-                chart_cols[1].altair_chart(base + rule, use_container_width=True)
+                tensile_area.altair_chart(base + rule, use_container_width=True)
 
     aluminium_section = external_profiles.get("aluminium")
     if aluminium_section:
@@ -345,7 +355,12 @@ if external_profiles:
             tensile_value = aluminium_metrics.get("tensile_mpa")
             yield_value = aluminium_metrics.get("yield_mpa")
             chart_cols = st.columns(2)
-            if tensile_value and not aluminium_tensile_distribution.empty:
+            tensile_area, yield_area = chart_cols
+            if aluminium_tensile_distribution.empty:
+                tensile_area.info(
+                    "No hay datos de tracción de aluminio en el inventario actual para comparar."
+                )
+            elif tensile_value:
                 base = alt.Chart(
                     pd.DataFrame({"tensile": aluminium_tensile_distribution})
                 ).mark_bar(color="#f97316", opacity=0.55).encode(
@@ -355,8 +370,13 @@ if external_profiles:
                 rule = alt.Chart(pd.DataFrame({"tensile": [tensile_value]})).mark_rule(
                     color="#22d3ee", size=3
                 ).encode(x="tensile:Q")
-                chart_cols[0].altair_chart(base + rule, use_container_width=True)
-            if yield_value and not aluminium_yield_distribution.empty:
+                tensile_area.altair_chart(base + rule, use_container_width=True)
+
+            if aluminium_yield_distribution.empty:
+                yield_area.info(
+                    "No hay datos de límite de fluencia de aluminio en el inventario actual."
+                )
+            elif yield_value:
                 base = alt.Chart(
                     pd.DataFrame({"yield_strength": aluminium_yield_distribution})
                 ).mark_bar(color="#fb923c", opacity=0.55).encode(
@@ -366,7 +386,7 @@ if external_profiles:
                 rule = alt.Chart(pd.DataFrame({"yield_strength": [yield_value]})).mark_rule(
                     color="#22d3ee", size=3
                 ).encode(x="yield_strength:Q")
-                chart_cols[1].altair_chart(base + rule, use_container_width=True)
+                yield_area.altair_chart(base + rule, use_container_width=True)
 
     st.caption(
         "Comparativa con laboratorios/industria (`polymer_composite_*`, `aluminium_alloys.csv`)."

--- a/tests/pages/test_generator_page.py
+++ b/tests/pages/test_generator_page.py
@@ -295,6 +295,20 @@ def test_generator_page_warns_when_inventory_missing_columns(
     assert "No hay datos de tracción de aluminio en el inventario actual para comparar." in info_messages
 
 
+def test_generator_page_renders_without_external_columns(
+    run_generator_page: Callable[..., object]
+) -> None:
+    inventory = pd.DataFrame({"id": ["poly-1"], "other": [1.0]})
+
+    app = run_generator_page(inventory)
+
+    headers = " ".join(block.body for block in app.header)
+    assert "Generador" in headers
+
+    subheaders = " ".join(block.body for block in app.subheader)
+    assert "Resultados del generador" in subheaders
+
+
 def test_generator_page_falls_back_when_expander_missing(
     run_generator_page: Callable[..., object]
 ) -> None:


### PR DESCRIPTION
## Summary
- handle mapping inputs in `_numeric_series` and default to an empty float series when data is unavailable
- display informative messages before rendering distribution histograms if the backing series is empty
- add a generator page regression test that uses an inventory without external columns

## Testing
- pytest tests/pages/test_generator_page.py

------
https://chatgpt.com/codex/tasks/task_e_68df387e9fe88331bd9cdb8f7905f703