### PR TITLE
Handle missing datasets gracefully across pages

### DIFF
--- a/app/Home.py
+++ b/app/Home.py
@@ -22,6 +22,7 @@ from app.modules import mission_overview
 from app.modules.ml_models import get_model_registry
 from app.modules.navigation import render_breadcrumbs, render_stepper, set_active_step
 from app.modules.ui_blocks import initialise_frontend, load_theme
+from app.modules.io import MissingDatasetError, format_missing_dataset_message
 
 
 def render_page() -> None:
@@ -40,7 +41,11 @@ def render_page() -> None:
 
     st.title("0) Mission Overview")
 
-    inventory_df = mission_overview.load_inventory_overview()
+    try:
+        inventory_df = mission_overview.load_inventory_overview()
+    except MissingDatasetError as error:
+        st.error(format_missing_dataset_message(error))
+        st.stop()
     mission_metrics = mission_overview.compute_mission_summary(inventory_df)
     mission_overview.render_mission_objective(mission_metrics)
 

--- a/app/modules/mission_overview.py
+++ b/app/modules/mission_overview.py
@@ -21,7 +21,11 @@ from typing import Any, Iterable, Mapping
 import pandas as pd
 import streamlit as st
 
-from app.modules.io import load_waste_df
+from app.modules.io import (
+    MissingDatasetError,
+    format_missing_dataset_message,
+    load_waste_df,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -31,7 +35,12 @@ from app.modules.io import load_waste_df
 def load_inventory_overview() -> pd.DataFrame:
     """Return a defensive copy of the enriched inventory dataframe."""
 
-    df = load_waste_df()
+    try:
+        df = load_waste_df()
+    except MissingDatasetError as error:
+        st.error(format_missing_dataset_message(error))
+        st.stop()
+        raise  # pragma: no cover - st.stop halts execution
     result = df.copy(deep=True)
     if "_problematic" in result.columns:
         result["_problematic"] = result["_problematic"].astype(bool)

--- a/app/pages/3_Generator.py
+++ b/app/pages/3_Generator.py
@@ -20,7 +20,12 @@ import streamlit as st
 
 from app.modules.candidate_showroom import render_candidate_showroom
 from app.modules.generator import generate_candidates
-from app.modules.io import load_waste_df, load_process_df  # si tu IO usa load_process_catalog, cámbialo aquí
+from app.modules.io import (
+    MissingDatasetError,
+    format_missing_dataset_message,
+    load_process_df,
+    load_waste_df,
+)  # si tu IO usa load_process_catalog, cámbialo aquí
 from app.modules.ml_models import get_model_registry
 from app.modules.navigation import render_breadcrumbs, set_active_step
 from app.modules.process_planner import choose_process
@@ -961,8 +966,12 @@ if not target:
     st.stop()
 
 # ----------------------------- Datos base -----------------------------
-waste_df = load_waste_df()
-proc_df = load_process_df()
+try:
+    waste_df = load_waste_df()
+    proc_df = load_process_df()
+except MissingDatasetError as error:
+    st.error(format_missing_dataset_message(error))
+    st.stop()
 polymer_density_distribution = _numeric_series(
     waste_df, "pc_density_density_g_per_cm3"
 )

--- a/app/pages/4_Results_and_Tradeoffs.py
+++ b/app/pages/4_Results_and_Tradeoffs.py
@@ -24,7 +24,11 @@ from app.modules.data_sources import (
     load_regolith_thermal_profiles,
 )
 from app.modules.explain import score_breakdown
-from app.modules.io import load_waste_df
+from app.modules.io import (
+    MissingDatasetError,
+    format_missing_dataset_message,
+    load_waste_df,
+)
 from app.modules.schema import (
     ALUMINIUM_LABEL_COLUMNS,
     ALUMINIUM_NUMERIC_COLUMNS,
@@ -63,7 +67,11 @@ score = cand.get("score", 0.0)
 safety = selected.get("safety", {"level": "—", "detail": ""})
 process_id = cand.get("process_id", "—")
 process_name = cand.get("process_name", "Proceso")
-inventory_df = load_waste_df()
+try:
+    inventory_df = load_waste_df()
+except MissingDatasetError as error:
+    st.error(format_missing_dataset_message(error))
+    st.stop()
 polymer_density_distribution = pd.to_numeric(
     inventory_df.get("pc_density_density_g_per_cm3"), errors="coerce"
 ).dropna()

--- a/app/pages/5_Compare_and_Explain.py
+++ b/app/pages/5_Compare_and_Explain.py
@@ -20,7 +20,11 @@ from streamlit_sortables import sort_items
 from app.modules.explain import compare_table, score_breakdown
 from app.modules.navigation import render_breadcrumbs, set_active_step
 from app.modules.ui_blocks import initialise_frontend, load_theme, pill
-from app.modules.io import load_waste_df
+from app.modules.io import (
+    MissingDatasetError,
+    format_missing_dataset_message,
+    load_waste_df,
+)
 
 
 def _generate_storytelling(
@@ -198,7 +202,11 @@ if not cands or not target:
     st.warning("Generá opciones en **3) Generador** primero.")
     st.stop()
 
-inventory_df = load_waste_df()
+try:
+    inventory_df = load_waste_df()
+except MissingDatasetError as error:
+    st.error(format_missing_dataset_message(error))
+    st.stop()
 
 st.title("🧪 Compare & Explain")
 st.caption(

--- a/app/pages/6_Pareto_and_Export.py
+++ b/app/pages/6_Pareto_and_Export.py
@@ -19,7 +19,11 @@ import streamlit as st
 
 from app.modules.analytics import pareto_front
 from app.modules.exporters import candidate_to_csv, candidate_to_json
-from app.modules.io import load_waste_df
+from app.modules.io import (
+    MissingDatasetError,
+    format_missing_dataset_message,
+    load_waste_df,
+)
 from app.modules.navigation import render_breadcrumbs, set_active_step
 from app.modules.page_data import (
     build_candidate_export_table,
@@ -62,7 +66,11 @@ selected_candidate = selected_state["data"] if isinstance(selected_state, dict) 
 selected_badge = selected_state.get("safety") if isinstance(selected_state, dict) else None
 selected_option_number = st.session_state.get("selected_option_number")
 
-inventory_df = load_waste_df()
+try:
+    inventory_df = load_waste_df()
+except MissingDatasetError as error:
+    st.error(format_missing_dataset_message(error))
+    st.stop()
 export_df = build_candidate_export_table(candidates, inventory_df)
 
 with layout_stack():

--- a/tests/modules/test_io.py
+++ b/tests/modules/test_io.py
@@ -2,9 +2,19 @@
 
 from __future__ import annotations
 
-import pandas as pd
+from pathlib import Path
 
-from app.modules.io import load_waste_df
+import pandas as pd
+import pytest
+
+import app.modules.io as io_module
+from app.modules.io import (
+    MissingDatasetError,
+    format_missing_dataset_message,
+    load_process_df,
+    load_targets,
+    load_waste_df,
+)
 from app.modules.problematic import problematic_mask
 
 
@@ -20,3 +30,37 @@ def test_problematic_column_matches_helper() -> None:
         helper_mask,
         check_names=False,
     )
+
+
+def test_load_waste_df_raises_missing_dataset(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    missing_path = tmp_path / "missing_waste.csv"
+    monkeypatch.setattr(io_module, "WASTE_CSV", missing_path)
+    io_module.invalidate_waste_cache()
+
+    with pytest.raises(MissingDatasetError) as excinfo:
+        load_waste_df()
+
+    assert excinfo.value.path == missing_path
+    assert str(missing_path) in format_missing_dataset_message(excinfo.value)
+
+
+def test_load_process_df_raises_missing_dataset(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    missing_path = tmp_path / "missing_process.csv"
+    monkeypatch.setattr(io_module, "PROC_CSV", missing_path)
+    io_module.invalidate_process_cache()
+
+    with pytest.raises(MissingDatasetError) as excinfo:
+        load_process_df()
+
+    assert excinfo.value.path == missing_path
+
+
+def test_load_targets_raises_missing_dataset(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    missing_path = tmp_path / "missing_targets.json"
+    monkeypatch.setattr(io_module, "TARGETS_JSON", missing_path)
+    io_module.invalidate_targets_cache()
+
+    with pytest.raises(MissingDatasetError) as excinfo:
+        load_targets()
+
+    assert excinfo.value.path == missing_path

--- a/tests/pages/test_results_and_export_pages.py
+++ b/tests/pages/test_results_and_export_pages.py
@@ -1,0 +1,210 @@
+from __future__ import annotations
+
+import os
+import runpy
+import sys
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+pytest.importorskip("streamlit")
+
+from pytest_streamlit import StreamlitRunner
+
+from app.modules.io import format_missing_dataset_message, MissingDatasetError
+
+
+def _results_page_app(*, missing_dataset: bool = False) -> None:
+    import os
+    import pandas as pd
+    import runpy
+    import sys
+    import streamlit as st
+    from pathlib import Path
+
+    root_env = os.environ.get("REXAI_PROJECT_ROOT")
+    root = Path(root_env) if root_env else Path.cwd()
+    app_dir = root / "app"
+    for candidate in (root, app_dir):
+        if str(candidate) not in sys.path:
+            sys.path.insert(0, str(candidate))
+
+    st.session_state.clear()
+
+    base_props = {
+        "rigidity": 0.0,
+        "tightness": 0.0,
+        "energy_kwh": 0.0,
+        "water_l": 0.0,
+        "crew_min": 0.0,
+        "mass_final_kg": 0.0,
+    }
+    st.session_state["selected"] = {
+        "data": {
+            "props": base_props,
+            "heuristic_props": base_props,
+            "confidence_interval": {},
+            "uncertainty": {},
+            "model_variants": [],
+            "feature_importance": [],
+            "ml_prediction": {"metadata": {}},
+            "latent_vector": [],
+            "regolith_pct": 0.0,
+            "materials": [],
+            "score": 0.0,
+            "process_id": "P01",
+            "process_name": "Proceso demo",
+            "source_ids": [],
+        },
+        "safety": {"level": "OK", "detail": ""},
+    }
+    st.session_state["target"] = {"max_energy_kwh": 2.0, "max_water_l": 1.0, "max_crew_min": 60.0}
+
+    import app.modules.ui_blocks as ui_blocks
+    import app.modules.navigation as navigation
+    import app.modules.io as io_module
+
+    original_page_config = st.set_page_config
+    original_load_theme = ui_blocks.load_theme
+    original_initialise = ui_blocks.initialise_frontend
+    original_breadcrumbs = navigation.render_breadcrumbs
+    original_loader = io_module.load_waste_df
+
+    st.set_page_config = lambda *args, **kwargs: None  # type: ignore[assignment]
+    ui_blocks.load_theme = lambda **_: None  # type: ignore[assignment]
+    ui_blocks.initialise_frontend = lambda **_: None  # type: ignore[assignment]
+    navigation.render_breadcrumbs = lambda *args, **kwargs: None  # type: ignore[assignment]
+
+    if missing_dataset:
+        missing_path = Path("missing_results.csv")
+
+        def _raise_missing() -> pd.DataFrame:
+            raise io_module.MissingDatasetError(missing_path)
+
+        io_module.load_waste_df = _raise_missing  # type: ignore[assignment]
+    else:
+        io_module.load_waste_df = lambda: pd.DataFrame()  # type: ignore[assignment]
+
+    results_page = app_dir / "pages" / "4_Results_and_Tradeoffs.py"
+
+    try:
+        runpy.run_path(str(results_page), run_name="__main__")
+    finally:
+        st.set_page_config = original_page_config  # type: ignore[assignment]
+        ui_blocks.load_theme = original_load_theme  # type: ignore[assignment]
+        ui_blocks.initialise_frontend = original_initialise  # type: ignore[assignment]
+        navigation.render_breadcrumbs = original_breadcrumbs  # type: ignore[assignment]
+        io_module.load_waste_df = original_loader  # type: ignore[assignment]
+
+
+def _pareto_page_app(*, missing_dataset: bool = False) -> None:
+    import os
+    import pandas as pd
+    import runpy
+    import sys
+    import streamlit as st
+    from pathlib import Path
+
+    root_env = os.environ.get("REXAI_PROJECT_ROOT")
+    root = Path(root_env) if root_env else Path.cwd()
+    app_dir = root / "app"
+    for candidate in (root, app_dir):
+        if str(candidate) not in sys.path:
+            sys.path.insert(0, str(candidate))
+
+    st.session_state.clear()
+
+    base_props = {
+        "energy_kwh": 0.0,
+        "water_l": 0.0,
+        "crew_min": 0.0,
+        "mass_final_kg": 0.0,
+        "rigidity": 0.0,
+        "tightness": 0.0,
+    }
+    st.session_state["candidates"] = [
+        {
+            "materials": [],
+            "weights": [],
+            "score": 0.0,
+            "props": base_props,
+            "process_id": "P01",
+            "process_name": "Proceso demo",
+        }
+    ]
+    st.session_state["target"] = {"max_energy_kwh": 2.0, "max_water_l": 1.0, "max_crew_min": 60.0}
+    st.session_state["selected"] = {
+        "data": {
+            "materials": [],
+            "weights": [],
+            "props": base_props,
+            "process_id": "P01",
+            "process_name": "Proceso demo",
+        },
+        "safety": {"level": "OK", "detail": ""},
+    }
+
+    import app.modules.ui_blocks as ui_blocks
+    import app.modules.navigation as navigation
+    import app.modules.io as io_module
+
+    original_page_config = st.set_page_config
+    original_load_theme = ui_blocks.load_theme
+    original_initialise = ui_blocks.initialise_frontend
+    original_breadcrumbs = navigation.render_breadcrumbs
+    original_loader = io_module.load_waste_df
+
+    st.set_page_config = lambda *args, **kwargs: None  # type: ignore[assignment]
+    ui_blocks.load_theme = lambda **_: None  # type: ignore[assignment]
+    ui_blocks.initialise_frontend = lambda **_: None  # type: ignore[assignment]
+    navigation.render_breadcrumbs = lambda *args, **kwargs: None  # type: ignore[assignment]
+
+    if missing_dataset:
+        missing_path = Path("missing_pareto.csv")
+
+        def _raise_missing() -> pd.DataFrame:
+            raise io_module.MissingDatasetError(missing_path)
+
+        io_module.load_waste_df = _raise_missing  # type: ignore[assignment]
+    else:
+        io_module.load_waste_df = lambda: pd.DataFrame()  # type: ignore[assignment]
+
+    pareto_page = app_dir / "pages" / "6_Pareto_and_Export.py"
+
+    try:
+        runpy.run_path(str(pareto_page), run_name="__main__")
+    finally:
+        st.set_page_config = original_page_config  # type: ignore[assignment]
+        ui_blocks.load_theme = original_load_theme  # type: ignore[assignment]
+        ui_blocks.initialise_frontend = original_initialise  # type: ignore[assignment]
+        navigation.render_breadcrumbs = original_breadcrumbs  # type: ignore[assignment]
+        io_module.load_waste_df = original_loader  # type: ignore[assignment]
+
+
+def test_results_page_shows_error_for_missing_dataset() -> None:
+    runner = StreamlitRunner(_results_page_app, kwargs={"missing_dataset": True})
+    app = runner.run()
+
+    error_messages = " ".join(block.body for block in app.error)
+    assert "missing_results.csv" in error_messages
+    assert "python scripts/download_datasets.py" in error_messages
+    expected_message = format_missing_dataset_message(
+        MissingDatasetError(Path("missing_results.csv"))
+    )
+    assert expected_message in error_messages
+    assert not app.exception
+
+
+def test_pareto_page_shows_error_for_missing_dataset() -> None:
+    runner = StreamlitRunner(_pareto_page_app, kwargs={"missing_dataset": True})
+    app = runner.run()
+
+    error_messages = " ".join(block.body for block in app.error)
+    assert "missing_pareto.csv" in error_messages
+    assert "python scripts/download_datasets.py" in error_messages
+    expected_message = format_missing_dataset_message(
+        MissingDatasetError(Path("missing_pareto.csv"))
+    )
+    assert expected_message in error_messages
+    assert not app.exception


### PR DESCRIPTION
## Summary
- add a dedicated `MissingDatasetError` in the IO module, include user-facing install hints, and wrap cached loaders so missing files raise the new error without polluting caches
- guard Mission Overview, Home, Generator, Results, Compare, and Pareto/Export pages to show a helpful Streamlit error and halt rendering when datasets are missing
- extend IO and page tests to simulate absent datasets, asserting the new error messaging and stop behaviour across the affected views

## Testing
- pytest tests/modules/test_io.py
- pytest tests/pages/test_generator_page.py
- pytest tests/pages/test_compare_and_explain_page.py
- pytest tests/ui/test_mission_overview_page.py
- pytest tests/pages/test_results_and_export_pages.py


------
https://chatgpt.com/codex/tasks/task_e_68df3cc80804833196dbafe7785219b7