### PR TITLE
Handle convergence render without metrics

### DIFF
--- a/tests/modules/test_visualizations.py
+++ b/tests/modules/test_visualizations.py
@@ -1,0 +1,29 @@
+import pandas as pd
+
+from app.modules.visualizations import ConvergenceScene
+
+
+class DummyTarget:
+    def __init__(self) -> None:
+        self.infos: list[str] = []
+
+    def info(self, message: str) -> None:  # pragma: no cover - simple collector
+        self.infos.append(message)
+
+
+def test_convergence_scene_render_handles_missing_metrics():
+    history = pd.DataFrame(
+        {
+            "iteration": [0, 1, 2],
+            "score": [0.5, 0.6, 0.7],
+        }
+    )
+
+    scene = ConvergenceScene(history)
+    target = DummyTarget()
+
+    scene.render(container=target)
+
+    assert target.infos == [
+        "Sin datos de convergencia todavía. Ejecutá el optimizador para graficar su progreso."
+    ]


### PR DESCRIPTION
## Summary
- reuse filtered convergence history when rendering metrics and charts
- return early with info message when the filtered history is empty
- add a regression test covering histories missing hypervolume and dominance_ratio

## Testing
- pytest tests/modules/test_visualizations.py

------
https://chatgpt.com/codex/tasks/task_e_68df3f4458a4833199278558794841f5