### PR TITLE
Refactor home page timestamp handling

### DIFF
--- a/app/Home.py
+++ b/app/Home.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import sys
-from datetime import datetime
 from pathlib import Path
 from typing import Iterable
 
@@ -22,7 +21,12 @@ from app.modules import mission_overview
 from app.modules.ml_models import get_model_registry
 from app.modules.navigation import render_breadcrumbs, render_stepper, set_active_step
 from app.modules.ui_blocks import initialise_frontend, load_theme
-from app.modules.io import MissingDatasetError, format_missing_dataset_message
+from app.modules.io import (
+    MissingDatasetError,
+    format_missing_dataset_message,
+    get_last_modified,
+)
+from app.modules.paths import DATA_ROOT
 
 
 def render_page() -> None:
@@ -78,10 +82,8 @@ def render_page() -> None:
         st.caption(f"Categorías: {categories_label}")
     st.caption(f"Problemáticos detectados: {problematic}")
 
-    last_modified: datetime | None = None
-    data_path = Path("data/waste_inventory_sample.csv")
-    if data_path.exists():
-        last_modified = datetime.fromtimestamp(data_path.stat().st_mtime)
+    data_path = DATA_ROOT / "waste_inventory_sample.csv"
+    last_modified = get_last_modified(data_path)
     if last_modified:
         st.caption(last_modified.strftime("Actualizado: %Y-%m-%d %H:%M"))
 

--- a/app/modules/io.py
+++ b/app/modules/io.py
@@ -9,6 +9,7 @@ import os
 from functools import lru_cache
 from pathlib import Path
 from typing import Mapping, Sequence
+from datetime import datetime
 
 import pandas as pd
 import polars as pl
@@ -35,6 +36,17 @@ INSTALL_DATA_HINT = "Instalá los datasets ejecutando `python scripts/download_d
 
 def format_missing_dataset_message(error: MissingDatasetError) -> str:
     return f"{error} {INSTALL_DATA_HINT}"
+
+
+def get_last_modified(path: Path | str) -> datetime | None:
+    """Return the last modification timestamp for ``path`` if it exists."""
+
+    candidate = Path(path)
+    try:
+        stat_result = candidate.stat()
+    except FileNotFoundError:
+        return None
+    return datetime.fromtimestamp(stat_result.st_mtime)
 
 # Archivos que proporcionó NASA (ustedes)
 WASTE_CSV   = DATA_DIR / "waste_inventory_sample.csv"

--- a/tests/modules/test_io.py
+++ b/tests/modules/test_io.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from datetime import datetime
 
 import pandas as pd
 import pytest
@@ -11,6 +12,7 @@ import app.modules.io as io_module
 from app.modules.io import (
     MissingDatasetError,
     format_missing_dataset_message,
+    get_last_modified,
     load_process_df,
     load_targets,
     load_waste_df,
@@ -64,3 +66,20 @@ def test_load_targets_raises_missing_dataset(monkeypatch: pytest.MonkeyPatch, tm
         load_targets()
 
     assert excinfo.value.path == missing_path
+
+
+def test_get_last_modified_returns_timestamp(tmp_path: Path) -> None:
+    file_path = tmp_path / "timestamp.txt"
+    file_path.write_text("sample")
+
+    timestamp = get_last_modified(file_path)
+
+    assert isinstance(timestamp, datetime)
+    assert timestamp is not None
+    assert pytest.approx(file_path.stat().st_mtime, rel=1e-3) == timestamp.timestamp()
+
+
+def test_get_last_modified_missing_path(tmp_path: Path) -> None:
+    missing_path = tmp_path / "missing.txt"
+
+    assert get_last_modified(missing_path) is None

--- a/tests/ui/test_home_timestamp.py
+++ b/tests/ui/test_home_timestamp.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+from pathlib import Path
+
+import pytest
+from pytest_streamlit import StreamlitRunner
+
+from app.modules.paths import DATA_ROOT
+
+
+def _home_timestamp_app() -> None:
+    import os
+    import importlib
+    import streamlit as st
+    from pathlib import Path
+    import sys
+
+    root_env = os.environ.get("REXAI_PROJECT_ROOT")
+    root = Path(root_env) if root_env else Path.cwd()
+    app_dir = root / "app"
+    for candidate in (root, app_dir):
+        if str(candidate) not in sys.path:
+            sys.path.insert(0, str(candidate))
+
+    original_page_config = st.set_page_config
+    st.set_page_config = lambda *args, **kwargs: None
+
+    import app.modules.ml_models as ml_models
+    import app.modules.mission_overview as mission_overview
+    import app.modules.ui_blocks as ui_blocks
+
+    class _RegistryStub:
+        metadata = {
+            "trained_at": "2024-01-01T00:00:00+00:00",
+            "n_samples": 256,
+            "ready": True,
+        }
+        ready = True
+
+    original_registry = ml_models.get_model_registry
+    original_load_theme = ui_blocks.load_theme
+    original_inventory_loader = mission_overview.load_inventory_overview
+
+    try:
+        ml_models.get_model_registry = lambda: _RegistryStub()  # type: ignore[assignment]
+        ui_blocks.load_theme = lambda **_: None  # type: ignore[assignment]
+        mission_overview.load_inventory_overview = mission_overview.load_waste_df  # type: ignore[assignment]
+
+        sys.modules.pop("app.Home", None)
+        home_module = importlib.import_module("app.Home")
+        home_module.render_page()
+    finally:
+        ml_models.get_model_registry = original_registry  # type: ignore[assignment]
+        ui_blocks.load_theme = original_load_theme  # type: ignore[assignment]
+        mission_overview.load_inventory_overview = original_inventory_loader  # type: ignore[assignment]
+        st.set_page_config = original_page_config
+
+
+@pytest.fixture
+def home_timestamp_runner() -> StreamlitRunner:
+    os.environ.setdefault("REXAI_PROJECT_ROOT", str(Path(__file__).resolve().parents[2]))
+    return StreamlitRunner(_home_timestamp_app)
+
+
+def test_home_page_shows_last_modified_caption(
+    home_timestamp_runner: StreamlitRunner,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    csv_path = DATA_ROOT / "waste_inventory_sample.csv"
+    assert csv_path.exists(), "El dataset de inventario debe existir bajo DATA_ROOT para la prueba"
+
+    monkeypatch.chdir(tmp_path)
+
+    app = home_timestamp_runner.run()
+
+    caption_texts = [caption.body for caption in app.caption]
+    assert any("Actualizado:" in text for text in caption_texts)


### PR DESCRIPTION
## Summary
- use the shared DATA_ROOT constant on the Home page and rely on a helper to load the CSV timestamp
- add a reusable `get_last_modified` helper in `app.modules.io` with unit coverage
- add a Streamlit regression test that ensures the timestamp caption renders when running outside the repo root

## Testing
- pytest tests/modules/test_io.py
- pytest tests/ui/test_home_timestamp.py

------
https://chatgpt.com/codex/tasks/task_e_68df3f47ddf883319126e5669ad820d1