### PR TITLE
Refactor Streamlit path bootstrap and add import checks

### DIFF
--- a/app/Home.py
+++ b/app/Home.py
@@ -2,18 +2,11 @@
 
 from __future__ import annotations
 
-import sys
-from pathlib import Path
 from typing import Iterable
 
-project_root = Path(__file__).resolve().parents[1]
-project_root_str = str(project_root)
-if project_root_str not in sys.path:
-    sys.path.insert(0, project_root_str)
+from app.bootstrap import ensure_streamlit_path
 
-from app.bootstrap import ensure_project_root
-
-ensure_project_root()
+ensure_streamlit_path(__file__)
 
 import streamlit as st
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from .bootstrap import ensure_project_root
+from .bootstrap import ensure_project_root, ensure_streamlit_path
 
-ROOT = ensure_project_root()
+ROOT = ensure_streamlit_path()
 
-__all__ = ["ROOT", "ensure_project_root"]
+__all__ = ["ROOT", "ensure_project_root", "ensure_streamlit_path"]

--- a/app/pages/0_Mission_Overview.py
+++ b/app/pages/0_Mission_Overview.py
@@ -1,16 +1,8 @@
 """Mission overview entrypoint consolidating mission status panels."""
 
-import sys
-from pathlib import Path
+from app.bootstrap import ensure_streamlit_path
 
-project_root = Path(__file__).resolve().parents[1]
-project_root_str = str(project_root)
-if project_root_str not in sys.path:
-    sys.path.insert(0, project_root_str)
-
-from app.bootstrap import ensure_project_root
-
-ensure_project_root()
+ensure_streamlit_path(__file__)
 
 from app.Home import render_page
 

--- a/app/pages/2_Target_Designer.py
+++ b/app/pages/2_Target_Designer.py
@@ -1,14 +1,6 @@
-import sys
-from pathlib import Path
+from app.bootstrap import ensure_streamlit_path
 
-project_root = Path(__file__).resolve().parents[1]
-project_root_str = str(project_root)
-if project_root_str not in sys.path:
-    sys.path.insert(0, project_root_str)
-
-from app.bootstrap import ensure_project_root
-
-ensure_project_root()
+ensure_streamlit_path(__file__)
 
 import streamlit as st
 

--- a/app/pages/3_Generator.py
+++ b/app/pages/3_Generator.py
@@ -1,16 +1,9 @@
-import sys
 from contextlib import contextmanager
-from pathlib import Path
 from typing import Any, Generator, Mapping
 
-project_root = Path(__file__).resolve().parents[1]
-project_root_str = str(project_root)
-if project_root_str not in sys.path:
-    sys.path.insert(0, project_root_str)
+from app.bootstrap import ensure_streamlit_path
 
-from app.bootstrap import ensure_project_root
-
-ensure_project_root()
+ensure_streamlit_path(__file__)
 
 import math
 

--- a/app/pages/4_Results_and_Tradeoffs.py
+++ b/app/pages/4_Results_and_Tradeoffs.py
@@ -1,14 +1,6 @@
-import sys
-from pathlib import Path
+from app.bootstrap import ensure_streamlit_path
 
-project_root = Path(__file__).resolve().parents[1]
-project_root_str = str(project_root)
-if project_root_str not in sys.path:
-    sys.path.insert(0, project_root_str)
-
-from app.bootstrap import ensure_project_root
-
-ensure_project_root()
+ensure_streamlit_path(__file__)
 
 import altair as alt
 import pandas as pd

--- a/app/pages/5_Compare_and_Explain.py
+++ b/app/pages/5_Compare_and_Explain.py
@@ -1,14 +1,6 @@
-import sys
-from pathlib import Path
+from app.bootstrap import ensure_streamlit_path
 
-project_root = Path(__file__).resolve().parents[1]
-project_root_str = str(project_root)
-if project_root_str not in sys.path:
-    sys.path.insert(0, project_root_str)
-
-from app.bootstrap import ensure_project_root
-
-ensure_project_root()
+ensure_streamlit_path(__file__)
 
 import numpy as np
 import streamlit as st

--- a/app/pages/6_Pareto_and_Export.py
+++ b/app/pages/6_Pareto_and_Export.py
@@ -1,17 +1,10 @@
 """Streamlined Pareto exploration and export centre."""
 
-import sys
-from pathlib import Path
 from typing import Iterable
 
-project_root = Path(__file__).resolve().parents[1]
-project_root_str = str(project_root)
-if project_root_str not in sys.path:
-    sys.path.insert(0, project_root_str)
+from app.bootstrap import ensure_streamlit_path
 
-from app.bootstrap import ensure_project_root
-
-ensure_project_root()
+ensure_streamlit_path(__file__)
 
 import math
 

--- a/app/pages/7_Scenario_Playbooks.py
+++ b/app/pages/7_Scenario_Playbooks.py
@@ -1,17 +1,10 @@
 """Simplified scenario playbooks with actionable summaries."""
 
-import sys
-from pathlib import Path
 from typing import Iterable
 
-project_root = Path(__file__).resolve().parents[1]
-project_root_str = str(project_root)
-if project_root_str not in sys.path:
-    sys.path.insert(0, project_root_str)
+from app.bootstrap import ensure_streamlit_path
 
-from app.bootstrap import ensure_project_root
-
-ensure_project_root()
+ensure_streamlit_path(__file__)
 
 import pandas as pd
 import streamlit as st

--- a/app/pages/8_Feedback_and_Impact.py
+++ b/app/pages/8_Feedback_and_Impact.py
@@ -1,17 +1,10 @@
 """Consolidated feedback capture and mission impact tracking."""
 
-import sys
-from pathlib import Path
 from datetime import datetime
 
-project_root = Path(__file__).resolve().parents[1]
-project_root_str = str(project_root)
-if project_root_str not in sys.path:
-    sys.path.insert(0, project_root_str)
+from app.bootstrap import ensure_streamlit_path
 
-from app.bootstrap import ensure_project_root
-
-ensure_project_root()
+ensure_streamlit_path(__file__)
 
 import pandas as pd
 import streamlit as st

--- a/app/pages/9_Capacity_Simulator.py
+++ b/app/pages/9_Capacity_Simulator.py
@@ -1,16 +1,8 @@
 """Lightweight capacity simulator driven by shared helpers."""
 
-import sys
-from pathlib import Path
+from app.bootstrap import ensure_streamlit_path
 
-project_root = Path(__file__).resolve().parents[1]
-project_root_str = str(project_root)
-if project_root_str not in sys.path:
-    sys.path.insert(0, project_root_str)
-
-from app.bootstrap import ensure_project_root
-
-ensure_project_root()
+ensure_streamlit_path(__file__)
 
 import pandas as pd
 import streamlit as st

--- a/tests/ui/test_page_entrypoints_import.py
+++ b/tests/ui/test_page_entrypoints_import.py
@@ -1,0 +1,30 @@
+"""Ensure Streamlit entrypoints are discoverable without path hacks."""
+
+from __future__ import annotations
+
+import importlib.util
+
+import pytest
+
+
+PAGE_MODULES = [
+    "app.Home",
+    "app.pages.0_Mission_Overview",
+    "app.pages.2_Target_Designer",
+    "app.pages.3_Generator",
+    "app.pages.4_Results_and_Tradeoffs",
+    "app.pages.5_Compare_and_Explain",
+    "app.pages.6_Pareto_and_Export",
+    "app.pages.7_Scenario_Playbooks",
+    "app.pages.8_Feedback_and_Impact",
+    "app.pages.9_Capacity_Simulator",
+]
+
+
+@pytest.mark.parametrize("module_name", PAGE_MODULES)
+def test_page_module_importable(module_name: str) -> None:
+    """Import the module ensuring ``ModuleNotFoundError`` is not raised."""
+
+    spec = importlib.util.find_spec(module_name)
+    assert spec is not None, f"Expected to discover module '{module_name}'"
+    assert spec.loader is not None, f"Expected loader for module '{module_name}'"


### PR DESCRIPTION
## Summary
- add an `ensure_streamlit_path` helper that normalizes sys.path discovery for Streamlit entrypoints
- update `app/Home.py` and every page module to call the shared helper instead of inlining sys.path logic
- add a UI smoke test that verifies the home and page modules can be discovered without ModuleNotFoundError

## Testing
- pytest tests/ui/test_page_entrypoints_import.py

------
https://chatgpt.com/codex/tasks/task_e_68df42a90d308331bfcbf900a82a2cc3