### PR TITLE
Replace experimental Streamlit rerun API usages

### DIFF
--- a/app/pages/3_Generator.py
+++ b/app/pages/3_Generator.py
@@ -1078,7 +1078,7 @@ with layout_block("layout-grid layout-grid--dual layout-grid--flow", parent=None
                 st.session_state[generator_state_key] = "loading"
                 st.session_state[generator_trigger_key] = True
                 st.session_state.pop(generator_error_key, None)
-                st.experimental_rerun()
+                st.rerun()
 
             button_state_now = st.session_state.get(generator_state_key)
             if button_error and button_state_now == "error":

--- a/app/pages/8_Feedback_and_Impact.py
+++ b/app/pages/8_Feedback_and_Impact.py
@@ -134,7 +134,7 @@ with st.form("impact_form"):
         )
         append_impact(entry)
         st.success("Impacto registrado.")
-        st.experimental_rerun()
+        st.rerun()
 
 with st.form("feedback_form"):
     st.subheader("Registrar feedback operativo")
@@ -164,4 +164,4 @@ with st.form("feedback_form"):
         )
         append_feedback(entry)
         st.success("Feedback registrado.")
-        st.experimental_rerun()
+        st.rerun()


### PR DESCRIPTION
## Summary
- update the generator and feedback pages to use `st.rerun()` instead of the deprecated experimental helper
- ensure session state reset paths still trigger Streamlit reruns via the stable API

## Testing
- pytest *(fails: missing streamlit.testing module in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68df44396a68833199cff7f4af569851