### PR TITLE
Ensure Streamlit entrypoints bootstrap repository path

### DIFF
--- a/app/Home.py
+++ b/app/Home.py
@@ -4,6 +4,10 @@ from __future__ import annotations
 
 from typing import Iterable
 
+from app.bootstrap import ensure_streamlit_imports
+
+ensure_streamlit_imports(__file__)
+
 from app.bootstrap import ensure_streamlit_path
 
 ensure_streamlit_path(__file__)

--- a/app/bootstrap.py
+++ b/app/bootstrap.py
@@ -7,6 +7,22 @@ from pathlib import Path
 from typing import Iterable
 
 
+def ensure_streamlit_imports(module_file: str | Path | None = None) -> Path:
+    """Ensure entrypoints can import the project without circular hacks."""
+
+    resolved = Path(module_file) if module_file is not None else Path(__file__)
+    resolved = resolved.resolve()
+    parents = resolved.parents
+    try:
+        root = parents[2]
+    except IndexError:  # pragma: no cover - defensive fallback
+        root = parents[-1]
+    root_str = str(root)
+    if root_str not in sys.path:
+        sys.path.insert(0, root_str)
+    return root
+
+
 def _candidate_roots(start: Path) -> Iterable[Path]:
     """Yield candidate roots from ``start`` up to the filesystem root."""
 
@@ -49,4 +65,8 @@ def ensure_project_root(start: str | Path | None = None) -> Path:
     return ensure_streamlit_path(start)
 
 
-__all__ = ["ensure_project_root", "ensure_streamlit_path"]
+__all__ = [
+    "ensure_project_root",
+    "ensure_streamlit_imports",
+    "ensure_streamlit_path",
+]

--- a/app/pages/0_Mission_Overview.py
+++ b/app/pages/0_Mission_Overview.py
@@ -1,5 +1,9 @@
 """Mission overview entrypoint consolidating mission status panels."""
 
+from app.bootstrap import ensure_streamlit_imports
+
+ensure_streamlit_imports(__file__)
+
 from app.bootstrap import ensure_streamlit_path
 
 ensure_streamlit_path(__file__)

--- a/app/pages/2_Target_Designer.py
+++ b/app/pages/2_Target_Designer.py
@@ -1,3 +1,7 @@
+from app.bootstrap import ensure_streamlit_imports
+
+ensure_streamlit_imports(__file__)
+
 from app.bootstrap import ensure_streamlit_path
 
 ensure_streamlit_path(__file__)

--- a/app/pages/3_Generator.py
+++ b/app/pages/3_Generator.py
@@ -1,6 +1,10 @@
 from contextlib import contextmanager
 from typing import Any, Generator, Mapping
 
+from app.bootstrap import ensure_streamlit_imports
+
+ensure_streamlit_imports(__file__)
+
 from app.bootstrap import ensure_streamlit_path
 
 ensure_streamlit_path(__file__)

--- a/app/pages/4_Results_and_Tradeoffs.py
+++ b/app/pages/4_Results_and_Tradeoffs.py
@@ -1,5 +1,9 @@
 from collections.abc import Mapping
 
+from app.bootstrap import ensure_streamlit_imports
+
+ensure_streamlit_imports(__file__)
+
 from app.bootstrap import ensure_streamlit_path
 
 ensure_streamlit_path(__file__)

--- a/app/pages/5_Compare_and_Explain.py
+++ b/app/pages/5_Compare_and_Explain.py
@@ -1,3 +1,7 @@
+from app.bootstrap import ensure_streamlit_imports
+
+ensure_streamlit_imports(__file__)
+
 from app.bootstrap import ensure_streamlit_path
 
 ensure_streamlit_path(__file__)

--- a/app/pages/6_Pareto_and_Export.py
+++ b/app/pages/6_Pareto_and_Export.py
@@ -2,6 +2,10 @@
 
 from typing import Iterable
 
+from app.bootstrap import ensure_streamlit_imports
+
+ensure_streamlit_imports(__file__)
+
 from app.bootstrap import ensure_streamlit_path
 
 ensure_streamlit_path(__file__)

--- a/app/pages/7_Scenario_Playbooks.py
+++ b/app/pages/7_Scenario_Playbooks.py
@@ -2,6 +2,10 @@
 
 from typing import Iterable
 
+from app.bootstrap import ensure_streamlit_imports
+
+ensure_streamlit_imports(__file__)
+
 from app.bootstrap import ensure_streamlit_path
 
 ensure_streamlit_path(__file__)

--- a/app/pages/8_Feedback_and_Impact.py
+++ b/app/pages/8_Feedback_and_Impact.py
@@ -2,6 +2,10 @@
 
 from datetime import datetime
 
+from app.bootstrap import ensure_streamlit_imports
+
+ensure_streamlit_imports(__file__)
+
 from app.bootstrap import ensure_streamlit_path
 
 ensure_streamlit_path(__file__)

--- a/app/pages/9_Capacity_Simulator.py
+++ b/app/pages/9_Capacity_Simulator.py
@@ -1,5 +1,9 @@
 """Lightweight capacity simulator driven by shared helpers."""
 
+from app.bootstrap import ensure_streamlit_imports
+
+ensure_streamlit_imports(__file__)
+
 from app.bootstrap import ensure_streamlit_path
 
 ensure_streamlit_path(__file__)

--- a/tests/ui/test_page_entrypoints_import.py
+++ b/tests/ui/test_page_entrypoints_import.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import importlib
 import importlib.util
+import sys
 
 import pytest
 
@@ -28,3 +30,11 @@ def test_page_module_importable(module_name: str) -> None:
     spec = importlib.util.find_spec(module_name)
     assert spec is not None, f"Expected to discover module '{module_name}'"
     assert spec.loader is not None, f"Expected loader for module '{module_name}'"
+    try:
+        module = importlib.import_module(module_name)
+    except ModuleNotFoundError as error:  # pragma: no cover - explicit failure path
+        pytest.fail(f"Unexpected ModuleNotFoundError importing '{module_name}': {error}")
+    except Exception:
+        module = sys.modules.get(module_name)
+    if module is not None:
+        assert module.__name__ == module_name


### PR DESCRIPTION
## Summary
- add a reusable `ensure_streamlit_imports` helper to guarantee the repository root is on `sys.path`
- call the new helper at the top of `app/Home.py` and every module under `app/pages/` before importing `ensure_streamlit_path`
- extend the UI import test to attempt importing each entrypoint and explicitly fail on `ModuleNotFoundError`

## Testing
- pytest tests/ui/test_page_entrypoints_import.py

------
https://chatgpt.com/codex/tasks/task_e_68df4a3d30148331983cb1ed7b3df616