### PR TITLE
Add ensure_streamlit_entrypoint bootstrap helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,27 +17,18 @@ streamlit run app/Home.py
 No se requieren variables de entorno adicionales para el arranque interactivo.
 
 > ⚙️ **Bootstrap obligatorio:** antes de cualquier `import app.*`, cada entrypoint
-> de Streamlit (incluyendo los módulos dentro de `app/pages/`) debe añadir el
-> proyecto al `sys.path` y luego ejecutar `ensure_project_root()`:
+> de Streamlit (incluyendo los módulos dentro de `app/pages/`) debe llamar a
+> `ensure_streamlit_entrypoint(__file__)`:
 >
 > ```python
-> import sys
-> from pathlib import Path
+> from app.bootstrap import ensure_streamlit_entrypoint
 >
-> project_root = Path(__file__).resolve().parents[1]
-> project_root_str = str(project_root)
-> if project_root_str not in sys.path:
->     sys.path.insert(0, project_root_str)
->
-> from app.bootstrap import ensure_project_root
->
-> ensure_project_root()
+> ensure_streamlit_entrypoint(__file__)
 > ```
 >
-> Esto garantiza que la carpeta raíz del repositorio esté en `sys.path` cuando se
-> ejecutan archivos sueltos con `streamlit run` o `python app/...`. El helper
-> legacy `_bootstrap.py` ya no existe; todo el bootstrap vive en
-> `app/bootstrap.py`.
+> Esto fuerza la inclusión de la raíz del repositorio en `sys.path` cuando se
+> ejecutan archivos sueltos con `streamlit run` o `python app/...` y evita los
+> `ModuleNotFoundError` al importar `app.*`.
 
 El script `app/Home.py` renderiza la misma vista de *Mission Overview* que la
 entrada multipágina `app/pages/0_Mission_Overview.py`, de modo que la pantalla

--- a/app/Home.py
+++ b/app/Home.py
@@ -1,16 +1,10 @@
-"""Streamlit entrypoint that mirrors the mission overview page."""
+from app.bootstrap import ensure_streamlit_entrypoint
 
-from __future__ import annotations
+ensure_streamlit_entrypoint(__file__)
+
+__doc__ = """Streamlit entrypoint that mirrors the mission overview page."""
 
 from typing import Iterable
-
-from app.bootstrap import ensure_streamlit_imports
-
-ensure_streamlit_imports(__file__)
-
-from app.bootstrap import ensure_streamlit_path
-
-ensure_streamlit_path(__file__)
 
 import streamlit as st
 

--- a/app/bootstrap.py
+++ b/app/bootstrap.py
@@ -7,6 +7,16 @@ from pathlib import Path
 from typing import Iterable
 
 
+def ensure_streamlit_entrypoint(module_file: str | Path) -> Path:
+    """Ensure the Streamlit entrypoint can import ``app`` modules."""
+
+    root = Path(module_file).resolve().parents[2]
+    root_str = str(root)
+    if root_str not in sys.path:
+        sys.path.insert(0, root_str)
+    return root
+
+
 def ensure_streamlit_imports(module_file: str | Path | None = None) -> Path:
     """Ensure entrypoints can import the project without circular hacks."""
 
@@ -66,6 +76,7 @@ def ensure_project_root(start: str | Path | None = None) -> Path:
 
 
 __all__ = [
+    "ensure_streamlit_entrypoint",
     "ensure_project_root",
     "ensure_streamlit_imports",
     "ensure_streamlit_path",

--- a/app/pages/0_Mission_Overview.py
+++ b/app/pages/0_Mission_Overview.py
@@ -1,12 +1,8 @@
-"""Mission overview entrypoint consolidating mission status panels."""
+from app.bootstrap import ensure_streamlit_entrypoint
 
-from app.bootstrap import ensure_streamlit_imports
+ensure_streamlit_entrypoint(__file__)
 
-ensure_streamlit_imports(__file__)
-
-from app.bootstrap import ensure_streamlit_path
-
-ensure_streamlit_path(__file__)
+__doc__ = """Mission overview entrypoint consolidating mission status panels."""
 
 from app.Home import render_page
 

--- a/app/pages/2_Target_Designer.py
+++ b/app/pages/2_Target_Designer.py
@@ -1,10 +1,6 @@
-from app.bootstrap import ensure_streamlit_imports
+from app.bootstrap import ensure_streamlit_entrypoint
 
-ensure_streamlit_imports(__file__)
-
-from app.bootstrap import ensure_streamlit_path
-
-ensure_streamlit_path(__file__)
+ensure_streamlit_entrypoint(__file__)
 
 import streamlit as st
 

--- a/app/pages/3_Generator.py
+++ b/app/pages/3_Generator.py
@@ -1,13 +1,9 @@
+from app.bootstrap import ensure_streamlit_entrypoint
+
+ensure_streamlit_entrypoint(__file__)
+
 from contextlib import contextmanager
 from typing import Any, Generator, Mapping
-
-from app.bootstrap import ensure_streamlit_imports
-
-ensure_streamlit_imports(__file__)
-
-from app.bootstrap import ensure_streamlit_path
-
-ensure_streamlit_path(__file__)
 
 import math
 

--- a/app/pages/4_Results_and_Tradeoffs.py
+++ b/app/pages/4_Results_and_Tradeoffs.py
@@ -1,12 +1,8 @@
+from app.bootstrap import ensure_streamlit_entrypoint
+
+ensure_streamlit_entrypoint(__file__)
+
 from collections.abc import Mapping
-
-from app.bootstrap import ensure_streamlit_imports
-
-ensure_streamlit_imports(__file__)
-
-from app.bootstrap import ensure_streamlit_path
-
-ensure_streamlit_path(__file__)
 
 import altair as alt
 import pandas as pd

--- a/app/pages/5_Compare_and_Explain.py
+++ b/app/pages/5_Compare_and_Explain.py
@@ -1,10 +1,6 @@
-from app.bootstrap import ensure_streamlit_imports
+from app.bootstrap import ensure_streamlit_entrypoint
 
-ensure_streamlit_imports(__file__)
-
-from app.bootstrap import ensure_streamlit_path
-
-ensure_streamlit_path(__file__)
+ensure_streamlit_entrypoint(__file__)
 
 import numpy as np
 import streamlit as st

--- a/app/pages/6_Pareto_and_Export.py
+++ b/app/pages/6_Pareto_and_Export.py
@@ -1,14 +1,10 @@
-"""Streamlined Pareto exploration and export centre."""
+from app.bootstrap import ensure_streamlit_entrypoint
+
+ensure_streamlit_entrypoint(__file__)
+
+__doc__ = """Streamlined Pareto exploration and export centre."""
 
 from typing import Iterable
-
-from app.bootstrap import ensure_streamlit_imports
-
-ensure_streamlit_imports(__file__)
-
-from app.bootstrap import ensure_streamlit_path
-
-ensure_streamlit_path(__file__)
 
 import math
 

--- a/app/pages/7_Scenario_Playbooks.py
+++ b/app/pages/7_Scenario_Playbooks.py
@@ -1,14 +1,10 @@
-"""Simplified scenario playbooks with actionable summaries."""
+from app.bootstrap import ensure_streamlit_entrypoint
+
+ensure_streamlit_entrypoint(__file__)
+
+__doc__ = """Simplified scenario playbooks with actionable summaries."""
 
 from typing import Iterable
-
-from app.bootstrap import ensure_streamlit_imports
-
-ensure_streamlit_imports(__file__)
-
-from app.bootstrap import ensure_streamlit_path
-
-ensure_streamlit_path(__file__)
 
 import pandas as pd
 import streamlit as st

--- a/app/pages/8_Feedback_and_Impact.py
+++ b/app/pages/8_Feedback_and_Impact.py
@@ -1,14 +1,10 @@
-"""Consolidated feedback capture and mission impact tracking."""
+from app.bootstrap import ensure_streamlit_entrypoint
+
+ensure_streamlit_entrypoint(__file__)
+
+__doc__ = """Consolidated feedback capture and mission impact tracking."""
 
 from datetime import datetime
-
-from app.bootstrap import ensure_streamlit_imports
-
-ensure_streamlit_imports(__file__)
-
-from app.bootstrap import ensure_streamlit_path
-
-ensure_streamlit_path(__file__)
 
 import pandas as pd
 import streamlit as st

--- a/app/pages/9_Capacity_Simulator.py
+++ b/app/pages/9_Capacity_Simulator.py
@@ -1,12 +1,8 @@
-"""Lightweight capacity simulator driven by shared helpers."""
+from app.bootstrap import ensure_streamlit_entrypoint
 
-from app.bootstrap import ensure_streamlit_imports
+ensure_streamlit_entrypoint(__file__)
 
-ensure_streamlit_imports(__file__)
-
-from app.bootstrap import ensure_streamlit_path
-
-ensure_streamlit_path(__file__)
+__doc__ = """Lightweight capacity simulator driven by shared helpers."""
 
 import pandas as pd
 import streamlit as st


### PR DESCRIPTION
## Summary
- add an `ensure_streamlit_entrypoint` helper that ensures Streamlit entrypoints resolve the project root
- update `app/Home.py` and every page module to invoke the new helper before importing `app.*`
- document the new bootstrap requirement in the README for future entrypoints

## Testing
- pytest -k streamlit *(fails: ModuleNotFoundError: No module named 'streamlit.testing'; 'streamlit' is not a package)*

------
https://chatgpt.com/codex/tasks/task_e_68df4d41abf483318345229c45036a26