### PR TITLE
Consolidate Mission Overview entrypoint and refresh UI tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ No se requieren variables de entorno adicionales para el arranque interactivo.
 > ejecutan archivos sueltos con `streamlit run` o `python app/...` y evita los
 > `ModuleNotFoundError` al importar `app.*`.
 
-El script `app/Home.py` renderiza la misma vista de *Mission Overview* que la
-entrada multipágina `app/pages/0_Mission_Overview.py`, de modo que la pantalla
-principal y el paso "Overview" permanecen sincronizados.
+El script `app/Home.py` centraliza la vista de *Mission Overview* y actúa como
+único entrypoint interactivo, manteniendo alineada la pantalla principal con el
+paso "Overview" de la navegación multipaso.
 
 ## Módulos principales
 

--- a/app/Home.py
+++ b/app/Home.py
@@ -4,81 +4,13 @@ ensure_streamlit_entrypoint(__file__)
 
 __doc__ = """Streamlit entrypoint that mirrors the mission overview page."""
 
-from typing import Iterable
-
-import streamlit as st
-
 from app.modules import mission_overview
-from app.modules.ml_models import get_model_registry
-from app.modules.navigation import render_breadcrumbs, render_stepper, set_active_step
-from app.modules.ui_blocks import initialise_frontend, load_theme
-from app.modules.io import (
-    MissingDatasetError,
-    format_missing_dataset_message,
-    get_last_modified,
-)
-from app.modules.paths import DATA_ROOT
 
 
 def render_page() -> None:
     """Render the combined home + mission overview experience."""
 
-    # ⚠️ Debe ser la PRIMERA llamada de Streamlit en la página
-    st.set_page_config(page_title="Mission Overview", page_icon="🛰️", layout="wide")
-    initialise_frontend()
-
-    current_step = set_active_step("overview")
-
-    load_theme(show_hud=False)
-
-    render_breadcrumbs(current_step)
-    render_stepper(current_step)
-
-    st.title("0) Mission Overview")
-
-    try:
-        inventory_df = mission_overview.load_inventory_overview()
-    except MissingDatasetError as error:
-        st.error(format_missing_dataset_message(error))
-        st.stop()
-    mission_metrics = mission_overview.compute_mission_summary(inventory_df)
-    mission_overview.render_mission_objective(mission_metrics)
-
-    registry = get_model_registry()
-    metadata = getattr(registry, "metadata", {}) if registry else {}
-    model_summary = mission_overview.summarize_model_state(metadata)
-    mission_overview.render_model_health(model_summary)
-
-    if inventory_df is None or inventory_df.empty:
-        st.info("No se encontró inventario para la misión actual.")
-        return
-
-    categories_column = inventory_df.get("category")
-    unique_categories: list[str] = []
-    if categories_column is not None:
-        categories: Iterable[str] = (
-            str(value).strip() for value in categories_column if str(value).strip()
-        )
-        unique_categories = sorted({category for category in categories})
-
-    problematic_column = inventory_df.get("_problematic")
-    problematic = 0
-    if problematic_column is not None:
-        problematic = int(problematic_column.astype(bool).sum())
-
-    if unique_categories:
-        categories_label = ", ".join(unique_categories[:5])
-        if len(unique_categories) > 5:
-            categories_label += "…"
-        st.caption(f"Categorías: {categories_label}")
-    st.caption(f"Problemáticos detectados: {problematic}")
-
-    data_path = DATA_ROOT / "waste_inventory_sample.csv"
-    last_modified = get_last_modified(data_path)
-    if last_modified:
-        st.caption(last_modified.strftime("Actualizado: %Y-%m-%d %H:%M"))
-
-    mission_overview.render_material_summary(inventory_df, max_rows=20)
+    mission_overview.render_overview_dashboard()
 
 
 if __name__ == "__main__":  # pragma: no cover - Streamlit entrypoint

--- a/app/modules/mission_overview.py
+++ b/app/modules/mission_overview.py
@@ -16,7 +16,7 @@ that they can be reused from multiple pages without duplicating markup.
 from __future__ import annotations
 
 from datetime import datetime, timezone
-from typing import Any, Iterable, Mapping
+from typing import Any, Callable, Iterable, Mapping
 
 import pandas as pd
 import streamlit as st
@@ -24,6 +24,7 @@ import streamlit as st
 from app.modules.io import (
     MissingDatasetError,
     format_missing_dataset_message,
+    get_last_modified,
     load_waste_df,
 )
 
@@ -336,4 +337,80 @@ def render_material_summary(
             hide_index=True,
             use_container_width=True,
         )
+
+
+def _resolve_inventory_loader(
+    inventory_loader: Callable[[], pd.DataFrame] | None = None,
+) -> pd.DataFrame:
+    if inventory_loader is None:
+        return load_inventory_overview()
+    return inventory_loader()
+
+
+def render_overview_dashboard(
+    *, inventory_loader: Callable[[], pd.DataFrame] | None = None
+) -> None:
+    """Render the combined mission overview dashboard used on the home page."""
+
+    from app.modules.ml_models import get_model_registry
+    from app.modules.navigation import render_breadcrumbs, render_stepper, set_active_step
+    from app.modules.paths import DATA_ROOT
+    from app.modules.ui_blocks import initialise_frontend, load_theme
+
+    st.set_page_config(page_title="Mission Overview", page_icon="🛰️", layout="wide")
+    initialise_frontend()
+
+    current_step = set_active_step("overview")
+    load_theme(show_hud=False)
+
+    render_breadcrumbs(current_step)
+    render_stepper(current_step)
+
+    st.title("0) Mission Overview")
+
+    try:
+        inventory_df = _resolve_inventory_loader(inventory_loader)
+    except MissingDatasetError as error:
+        st.error(format_missing_dataset_message(error))
+        st.stop()
+        return
+
+    mission_metrics = compute_mission_summary(inventory_df)
+    render_mission_objective(mission_metrics)
+
+    registry = get_model_registry()
+    metadata = getattr(registry, "metadata", {}) if registry else {}
+    model_summary = summarize_model_state(metadata)
+    render_model_health(model_summary)
+
+    if inventory_df is None or inventory_df.empty:
+        st.info("No se encontró inventario para la misión actual.")
+        return
+
+    categories_column = inventory_df.get("category")
+    unique_categories: list[str] = []
+    if categories_column is not None:
+        categories: Iterable[str] = (
+            str(value).strip() for value in categories_column if str(value).strip()
+        )
+        unique_categories = sorted({category for category in categories})
+
+    problematic_column = inventory_df.get("_problematic")
+    problematic = 0
+    if problematic_column is not None:
+        problematic = int(pd.Series(problematic_column).astype(bool).sum())
+
+    if unique_categories:
+        categories_label = ", ".join(unique_categories[:5])
+        if len(unique_categories) > 5:
+            categories_label += "…"
+        st.caption(f"Categorías: {categories_label}")
+    st.caption(f"Problemáticos detectados: {problematic}")
+
+    data_path = DATA_ROOT / "waste_inventory_sample.csv"
+    last_modified = get_last_modified(data_path)
+    if last_modified:
+        st.caption(last_modified.strftime("Actualizado: %Y-%m-%d %H:%M"))
+
+    render_material_summary(inventory_df, max_rows=20)
 

--- a/app/pages/0_Mission_Overview.py
+++ b/app/pages/0_Mission_Overview.py
@@ -1,9 +1,0 @@
-from app.bootstrap import ensure_streamlit_entrypoint
-
-ensure_streamlit_entrypoint(__file__)
-
-__doc__ = """Mission overview entrypoint consolidating mission status panels."""
-
-from app.Home import render_page
-
-render_page()

--- a/tests/ui/test_home_timestamp.py
+++ b/tests/ui/test_home_timestamp.py
@@ -1,72 +1,15 @@
 from __future__ import annotations
 
-import importlib
-import os
-import sys
 from pathlib import Path
 
 import pytest
-from pytest_streamlit import StreamlitRunner
 
 from app.modules.paths import DATA_ROOT
 
-
-def _home_timestamp_app() -> None:
-    import os
-    import importlib
-    import streamlit as st
-    from pathlib import Path
-    import sys
-
-    root_env = os.environ.get("REXAI_PROJECT_ROOT")
-    root = Path(root_env) if root_env else Path.cwd()
-    app_dir = root / "app"
-    for candidate in (root, app_dir):
-        if str(candidate) not in sys.path:
-            sys.path.insert(0, str(candidate))
-
-    original_page_config = st.set_page_config
-    st.set_page_config = lambda *args, **kwargs: None
-
-    import app.modules.ml_models as ml_models
-    import app.modules.mission_overview as mission_overview
-    import app.modules.ui_blocks as ui_blocks
-
-    class _RegistryStub:
-        metadata = {
-            "trained_at": "2024-01-01T00:00:00+00:00",
-            "n_samples": 256,
-            "ready": True,
-        }
-        ready = True
-
-    original_registry = ml_models.get_model_registry
-    original_load_theme = ui_blocks.load_theme
-    original_inventory_loader = mission_overview.load_inventory_overview
-
-    try:
-        ml_models.get_model_registry = lambda: _RegistryStub()  # type: ignore[assignment]
-        ui_blocks.load_theme = lambda **_: None  # type: ignore[assignment]
-        mission_overview.load_inventory_overview = mission_overview.load_waste_df  # type: ignore[assignment]
-
-        sys.modules.pop("app.Home", None)
-        home_module = importlib.import_module("app.Home")
-        home_module.render_page()
-    finally:
-        ml_models.get_model_registry = original_registry  # type: ignore[assignment]
-        ui_blocks.load_theme = original_load_theme  # type: ignore[assignment]
-        mission_overview.load_inventory_overview = original_inventory_loader  # type: ignore[assignment]
-        st.set_page_config = original_page_config
-
-
-@pytest.fixture
-def home_timestamp_runner() -> StreamlitRunner:
-    os.environ.setdefault("REXAI_PROJECT_ROOT", str(Path(__file__).resolve().parents[2]))
-    return StreamlitRunner(_home_timestamp_app)
+from tests.ui.test_mission_overview_page import _run_home_app, _load_inventory_fixture
 
 
 def test_home_page_shows_last_modified_caption(
-    home_timestamp_runner: StreamlitRunner,
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
@@ -75,7 +18,8 @@ def test_home_page_shows_last_modified_caption(
 
     monkeypatch.chdir(tmp_path)
 
-    app = home_timestamp_runner.run()
+    inventory_df = _load_inventory_fixture()
+    app = _run_home_app(monkeypatch, inventory_loader=lambda: inventory_df.copy(deep=True))
 
     caption_texts = [caption.body for caption in app.caption]
     assert any("Actualizado:" in text for text in caption_texts)

--- a/tests/ui/test_page_entrypoints_import.py
+++ b/tests/ui/test_page_entrypoints_import.py
@@ -11,7 +11,6 @@ import pytest
 
 PAGE_MODULES = [
     "app.Home",
-    "app.pages.0_Mission_Overview",
     "app.pages.2_Target_Designer",
     "app.pages.3_Generator",
     "app.pages.4_Results_and_Tradeoffs",


### PR DESCRIPTION
## Summary
- move the Mission Overview layout into `mission_overview.render_overview_dashboard` and have `app/Home.py` delegate to it directly
- drop the redundant `app/pages/0_Mission_Overview.py` entrypoint and adjust README guidance to highlight Home as the single launcher
- update UI tests to run the app via `streamlit run app/Home.py`, reusing fixtures to assert mission metrics and inventory captions

## Testing
- pytest tests/ui/test_mission_overview_page.py tests/ui/test_home_timestamp.py
- pytest tests/ui/test_page_entrypoints_import.py

------
https://chatgpt.com/codex/tasks/task_e_68e0095985308331b98f2bcd91bbe10e