### PR TITLE
Align navigation steps with updated mission menu

### DIFF
--- a/app/modules/mission_overview.py
+++ b/app/modules/mission_overview.py
@@ -360,7 +360,7 @@ def render_overview_dashboard(
     st.set_page_config(page_title="Mission Overview", page_icon="🛰️", layout="wide")
     initialise_frontend()
 
-    current_step = set_active_step("overview")
+    current_step = set_active_step("home")
     load_theme(show_hud=False)
 
     render_breadcrumbs(current_step)

--- a/app/modules/navigation.py
+++ b/app/modules/navigation.py
@@ -19,20 +19,45 @@ class MissionStep:
 
 
 MISSION_STEPS: tuple[MissionStep, ...] = (
-    MissionStep("overview", "Overview", "Home", "Panorama general de la misión"),
-    MissionStep("target", "Target (legacy)", "2_Target_Designer", "Definir objetivos (legacy)"),
-    MissionStep("generator", "Generador (legacy)", "3_Generator", "Recetas asistidas (legacy)"),
+    MissionStep("home", "Home", "Home", "Panel principal de la misión"),
+    MissionStep("target", "Definir objetivo", "2_Target_Designer", "Configura las metas de la misión"),
+    MissionStep("generator", "Generador asistido", "3_Generator", "Explora candidatos sugeridos por IA"),
     MissionStep(
         "results",
-        "Resultados (legacy)",
+        "Resultados y trade-offs",
         "4_Results_and_Tradeoffs",
-        "Trade-offs y métricas (legacy)",
+        "Evalúa resultados y métricas clave",
     ),
-    MissionStep("compare", "Comparar (legacy)", "5_Compare_and_Explain", "Explicabilidad (legacy)"),
-    MissionStep("export", "Export (legacy)", "6_Pareto_and_Export", "Pareto y export (legacy)"),
-    MissionStep("playbooks", "Playbooks (legacy)", "7_Scenario_Playbooks", "Escenarios (legacy)"),
-    MissionStep("feedback", "Feedback (legacy)", "8_Feedback_and_Impact", "Impacto y retraining (legacy)"),
-    MissionStep("capacity", "Capacidad (legacy)", "9_Capacity_Simulator", "Simulación (legacy)"),
+    MissionStep(
+        "compare",
+        "Compare & Explain",
+        "5_Compare_and_Explain",
+        "Compara alternativas y explica decisiones",
+    ),
+    MissionStep(
+        "export",
+        "Pareto & Export",
+        "6_Pareto_and_Export",
+        "Prepara entregables y exporta datos",
+    ),
+    MissionStep(
+        "playbooks",
+        "Scenario Playbooks",
+        "7_Scenario_Playbooks",
+        "Crea playbooks con filtros predefinidos",
+    ),
+    MissionStep(
+        "feedback",
+        "Feedback & Impact",
+        "8_Feedback_and_Impact",
+        "Recoge feedback y mide impacto",
+    ),
+    MissionStep(
+        "capacity",
+        "Capacity Simulator",
+        "9_Capacity_Simulator",
+        "Simula capacidad y recursos disponibles",
+    ),
 )
 
 _STEP_LOOKUP = {step.key: step for step in MISSION_STEPS}
@@ -62,11 +87,12 @@ def set_active_step(step_key: str) -> MissionStep:
 def breadcrumb_labels(step: MissionStep, extra: Sequence[str] | None = None) -> list[str]:
     """Compute the textual breadcrumb trail for ``step``.
 
-    The resulting list always starts with ``Home`` and ends with the active step.
-    Additional labels can be appended through ``extra``.
+    The resulting list ends with the active step and includes every previous
+    milestone in the mission flow. Additional labels can be appended through
+    ``extra``.
     """
 
-    labels: list[str] = ["Home"]
+    labels: list[str] = []
     for candidate in MISSION_STEPS:
         labels.append(candidate.label)
         if candidate.key == step.key:

--- a/tests/modules/test_navigation.py
+++ b/tests/modules/test_navigation.py
@@ -40,14 +40,13 @@ def test_render_breadcrumbs_is_plain_text(monkeypatch: pytest.MonkeyPatch) -> No
 
     assert labels == [
         "Home",
-        "Overview",
-        "Target (legacy)",
-        "Generador (legacy)",
-        "Resultados (legacy)",
+        "Definir objetivo",
+        "Generador asistido",
+        "Resultados y trade-offs",
         "Detalle",
     ]
     assert rendered and rendered[-1] == (
-        "Home › Overview › Target (legacy) › Generador (legacy) › Resultados (legacy) › Detalle"
+        "Home › Definir objetivo › Generador asistido › Resultados y trade-offs › Detalle"
     )
 
 
@@ -65,5 +64,5 @@ def test_render_stepper_returns_summary(monkeypatch: pytest.MonkeyPatch) -> None
     step = navigation.get_step("playbooks")
     summary = navigation.render_stepper(step)
 
-    assert summary == "Paso 7 de 9 · Playbooks (legacy)"
+    assert summary == "Paso 7 de 9 · Scenario Playbooks"
     assert captured[-1] == summary

--- a/tests/ui/test_mission_flow.py
+++ b/tests/ui/test_mission_flow.py
@@ -6,7 +6,7 @@ def test_format_stepper_uses_spanish_labels() -> None:
     summary = navigation.format_stepper(step)
 
     assert summary.startswith("Paso 4 de")
-    assert summary.endswith("Resultados (legacy)")
+    assert summary.endswith("Resultados y trade-offs")
 
 
 def test_set_active_step_invalid_key_raises(monkeypatch) -> None:

--- a/tests/ui/test_mission_navigation.py
+++ b/tests/ui/test_mission_navigation.py
@@ -5,15 +5,15 @@ def test_breadcrumb_labels_stop_at_active_step() -> None:
     step = navigation.get_step("generator")
     labels = navigation.breadcrumb_labels(step)
 
-    assert labels[-1] == "Generador (legacy)"
-    assert labels[:2] == ["Home", "Overview"]
-    assert "Playbooks" not in " ".join(labels)
+    assert labels[-1] == "Generador asistido"
+    assert labels[:2] == ["Home", "Definir objetivo"]
+    assert "Scenario Playbooks" not in " ".join(labels)
 
 
 def test_iter_steps_respects_order() -> None:
     keys = [step.key for step in navigation.iter_steps()]
     assert keys == [
-        "overview",
+        "home",
         "target",
         "generator",
         "results",


### PR DESCRIPTION
## Summary
- rename the mission overview step to Home and refresh the remaining step labels and descriptions
- adjust the breadcrumb helper to avoid duplicate Home entries and update the overview dashboard to the new key
- move the navigation tests to the modules suite and refresh expectations for breadcrumbs and the stepper

## Testing
- pytest tests/modules/test_navigation.py tests/ui/test_mission_navigation.py tests/ui/test_mission_flow.py

------
https://chatgpt.com/codex/tasks/task_e_68e00ce0772083319bb85ffa15dbfe37