### PR TITLE
Align Home docs and UI tests with Home-first flow

### DIFF
--- a/docs/ux-copy-minimal.md
+++ b/docs/ux-copy-minimal.md
@@ -17,8 +17,8 @@
 
 ## Ejemplos antes / después
 ### Home (`app/Home.py`)
-- La vista inicial replica el panel de *Mission Overview* para evitar saltos
-  visuales entre la portada y el paso `Overview`.
+- La vista inicial consolida el panel principal directamente en Home para
+  mantener la consistencia del flujo sin depender de un paso intermedio.
 - **Antes:** "Rex-AI orquesta el reciclaje orbital y marciano".
 - **Después:** "Rex-AI coordina el reciclaje orbital y marciano" (sustituye la metáfora por un verbo directo).
 

--- a/docs/ux-inventory.md
+++ b/docs/ux-inventory.md
@@ -1,7 +1,7 @@
 # UX Inventory Builder
 
-## Overview
-The inventory builder page now combines Streamlit layout primitives with an AG Grid-based editor to provide a hybrid workspace optimised for astronaut operations.
+## Home inventory workspace
+The inventory builder now lives on the Home flow and combines Streamlit layout primitives with an AG Grid-based editor to provide a hybrid workspace optimised for astronaut operations.
 
 ## Hybrid grid experience
 - **Tesla-style validation colours**: mass and volume columns display a teal-to-red gradient that highlights invalid or negative values instantly.

--- a/tests/ui/test_home_dashboard.py
+++ b/tests/ui/test_home_dashboard.py
@@ -88,7 +88,7 @@ def test_inventory_table_and_captions() -> None:
 
 
 def test_home_page_shows_error_for_missing_dataset(monkeypatch: pytest.MonkeyPatch) -> None:
-    missing_path = Path("missing_overview.csv")
+    missing_path = Path("missing_home_inventory.csv")
 
     def _raise_missing() -> pd.DataFrame:
         raise MissingDatasetError(missing_path)
@@ -96,7 +96,7 @@ def test_home_page_shows_error_for_missing_dataset(monkeypatch: pytest.MonkeyPat
     app = _run_home_app(monkeypatch, inventory_loader=_raise_missing)
 
     error_messages = " ".join(block.body for block in app.error)
-    assert "missing_overview.csv" in error_messages
+    assert "missing_home_inventory.csv" in error_messages
     assert "python scripts/download_datasets.py" in error_messages
     expected_message = format_missing_dataset_message(MissingDatasetError(missing_path))
     assert expected_message in error_messages

--- a/tests/ui/test_home_timestamp.py
+++ b/tests/ui/test_home_timestamp.py
@@ -6,7 +6,7 @@ import pytest
 
 from app.modules.paths import DATA_ROOT
 
-from tests.ui.test_mission_overview_page import _run_home_app, _load_inventory_fixture
+from tests.ui.test_home_dashboard import _run_home_app, _load_inventory_fixture
 
 
 def test_home_page_shows_last_modified_caption(


### PR DESCRIPTION
## Summary
- update UX docs to describe the Home-first dashboard instead of the retired Overview step
- rename the Home dashboard UI test module and refresh dataset expectations to avoid legacy Overview wording
- fix dependent imports so timestamp checks use the new Home dashboard helper

## Testing
- `pytest tests/ui` *(fails: ModuleNotFoundError: No module named 'streamlit.testing')*

------
https://chatgpt.com/codex/tasks/task_e_68e00e176a548331a9946611eee06c1e