### PR TITLE
Refactor bootstrap helpers and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,18 @@ No se requieren variables de entorno adicionales para el arranque interactivo.
 > Esto fuerza la inclusión de la raíz del repositorio en `sys.path` cuando se
 > ejecutan archivos sueltos con `streamlit run` o `python app/...` y evita los
 > `ModuleNotFoundError` al importar `app.*`.
+>
+> 🧪 **Scripts y tests**: para utilidades CLI o fixtures de Pytest, usa
+> `ensure_project_root(__file__)` en vez de manipular `sys.path` a mano:
+>
+> ```python
+> from app.bootstrap import ensure_project_root
+>
+> PROJECT_ROOT = ensure_project_root(__file__)
+> ```
+>
+> Así mantenemos un único helper oficial para exponer el paquete `app` sin
+> reintroducir hacks circulares.
 
 El script `app/Home.py` centraliza la vista de *Mission Overview* y actúa como
 único entrypoint interactivo, manteniendo alineada la pantalla principal con el

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from .bootstrap import ensure_project_root, ensure_streamlit_path
+from .bootstrap import ensure_project_root
 
-ROOT = ensure_streamlit_path()
+ROOT = ensure_project_root()
 
-__all__ = ["ROOT", "ensure_project_root", "ensure_streamlit_path"]
+__all__ = ["ROOT", "ensure_project_root"]

--- a/app/bootstrap.py
+++ b/app/bootstrap.py
@@ -17,22 +17,6 @@ def ensure_streamlit_entrypoint(module_file: str | Path) -> Path:
     return root
 
 
-def ensure_streamlit_imports(module_file: str | Path | None = None) -> Path:
-    """Ensure entrypoints can import the project without circular hacks."""
-
-    resolved = Path(module_file) if module_file is not None else Path(__file__)
-    resolved = resolved.resolve()
-    parents = resolved.parents
-    try:
-        root = parents[2]
-    except IndexError:  # pragma: no cover - defensive fallback
-        root = parents[-1]
-    root_str = str(root)
-    if root_str not in sys.path:
-        sys.path.insert(0, root_str)
-    return root
-
-
 def _candidate_roots(start: Path) -> Iterable[Path]:
     """Yield candidate roots from ``start`` up to the filesystem root."""
 
@@ -51,7 +35,7 @@ def _find_project_root(start: Path) -> Path:
     return start.resolve().parents[-1]
 
 
-def ensure_streamlit_path(start: str | Path | None = None) -> Path:
+def ensure_project_root(start: str | Path | None = None) -> Path:
     """Ensure the repository root is present on ``sys.path``.
 
     Parameters
@@ -69,15 +53,7 @@ def ensure_streamlit_path(start: str | Path | None = None) -> Path:
     return root
 
 
-def ensure_project_root(start: str | Path | None = None) -> Path:
-    """Backward compatible alias for :func:`ensure_streamlit_path`."""
-
-    return ensure_streamlit_path(start)
-
-
 __all__ = [
     "ensure_streamlit_entrypoint",
     "ensure_project_root",
-    "ensure_streamlit_imports",
-    "ensure_streamlit_path",
 ]

--- a/docs/environment_setup.md
+++ b/docs/environment_setup.md
@@ -42,6 +42,19 @@ Training pipeline para Rex-AI
 
 Los *warnings* de Streamlit (`missing ScriptRunContext`) son esperados cuando se ejecuta fuera de `streamlit run` y no afectan la carga del módulo.
 
+> 🔁 **Import helper oficial**: evitá añadir rutas manuales en los scripts CLI
+> o en las pruebas. Llama a `ensure_project_root(__file__)` antes de importar
+> módulos de `app`:
+>
+> ```python
+> from app.bootstrap import ensure_project_root
+>
+> PROJECT_ROOT = ensure_project_root(__file__)
+> ```
+>
+> Esto mantiene estable la resolución de `app.*` y evita reintroducir hacks
+> circulares en `sys.path`.
+
 ## 3. Próximos pasos
 
 1. Evaluar si es necesario fijar versiones adicionales (p. ej. `torch==2.4.x`) antes de entrenar modelos TabTransformer.

--- a/scripts/run_benchmarks.py
+++ b/scripts/run_benchmarks.py
@@ -32,14 +32,22 @@ from typing import Dict, Iterable, List, Mapping, Sequence
 import sys
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
-if str(REPO_ROOT) not in sys.path:
-    sys.path.insert(0, str(REPO_ROOT))
+
+try:
+    from app.bootstrap import ensure_project_root
+except ModuleNotFoundError:  # pragma: no cover - defensive import path fix
+    if str(REPO_ROOT) not in sys.path:
+        sys.path.insert(0, str(REPO_ROOT))
+    from app.bootstrap import ensure_project_root
+
+REPO_ROOT = ensure_project_root(REPO_ROOT)
 
 import numpy as np
 import pandas as pd
 
 from app.modules.generator import compute_feature_vector, heuristic_props, prepare_waste_frame
 from app.modules.ml_models import ModelRegistry
+
 DATA_DIR = REPO_ROOT / "data"
 WASTE_SAMPLE = DATA_DIR / "waste_inventory_sample.csv"
 PROCESS_CATALOG = DATA_DIR / "process_catalog.csv"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,10 +7,16 @@ from pathlib import Path
 
 import pytest
 
-PROJECT_ROOT = Path(__file__).resolve().parents[1]
+PROJECT_ROOT_CANDIDATE = Path(__file__).resolve().parents[1]
 
-if str(PROJECT_ROOT) not in sys.path:
-    sys.path.insert(0, str(PROJECT_ROOT))
+try:
+    from app.bootstrap import ensure_project_root
+except ModuleNotFoundError:  # pragma: no cover - fallback when PYTHONPATH lacks repo
+    if str(PROJECT_ROOT_CANDIDATE) not in sys.path:
+        sys.path.insert(0, str(PROJECT_ROOT_CANDIDATE))
+    from app.bootstrap import ensure_project_root
+
+PROJECT_ROOT = ensure_project_root(PROJECT_ROOT_CANDIDATE)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/pages/test_compare_and_explain_page.py
+++ b/tests/pages/test_compare_and_explain_page.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
 import os
-import runpy
-import sys
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Callable
@@ -14,13 +12,13 @@ pytest.importorskip("streamlit")
 
 from pytest_streamlit import StreamlitRunner
 
+from app.bootstrap import ensure_project_root
 from app.modules.io import format_missing_dataset_message, MissingDatasetError
 
 
 def _compare_page_app(*, missing_dataset: bool = False) -> None:
     import os
     import runpy
-    import sys
     import types
     from pathlib import Path
     from types import SimpleNamespace
@@ -31,11 +29,9 @@ def _compare_page_app(*, missing_dataset: bool = False) -> None:
     import streamlit as st
 
     root_env = os.environ.get("REXAI_PROJECT_ROOT")
-    root = Path(root_env) if root_env else Path.cwd()
+    start = Path(root_env) if root_env else Path(__file__).resolve()
+    root = ensure_project_root(start)
     app_dir = root / "app"
-    for candidate in (root, app_dir):
-        if str(candidate) not in sys.path:
-            sys.path.insert(0, str(candidate))
 
     original_page_config = st.set_page_config
     st.set_page_config = lambda *args, **kwargs: None

--- a/tests/pages/test_feedback_page.py
+++ b/tests/pages/test_feedback_page.py
@@ -6,6 +6,8 @@ pytest.importorskip("streamlit")
 
 from pytest_streamlit import StreamlitRunner
 
+from app.bootstrap import ensure_project_root
+
 
 def _feedback_page_app(
     *,
@@ -16,7 +18,6 @@ def _feedback_page_app(
 ) -> None:
     import os
     import runpy
-    import sys
     from pathlib import Path
     from types import SimpleNamespace
 
@@ -24,11 +25,9 @@ def _feedback_page_app(
     import streamlit as st
 
     root_env = os.environ.get("REXAI_PROJECT_ROOT")
-    root = Path(root_env) if root_env else Path.cwd()
+    start = Path(root_env) if root_env else Path(__file__).resolve()
+    root = ensure_project_root(start)
     app_dir = root / "app"
-    for candidate in (root, app_dir):
-        if str(candidate) not in sys.path:
-            sys.path.insert(0, str(candidate))
 
     st.session_state.clear()
 

--- a/tests/pages/test_generator_page.py
+++ b/tests/pages/test_generator_page.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
 import os
-import runpy
-import sys
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, Callable
@@ -14,6 +12,8 @@ pytest.importorskip("streamlit")
 
 from pytest_streamlit import StreamlitRunner
 
+from app.bootstrap import ensure_project_root
+
 
 def _generator_page_app(
     inventory=None,
@@ -23,7 +23,6 @@ def _generator_page_app(
 ) -> None:
     import os
     import runpy
-    import sys
     from pathlib import Path
     from types import SimpleNamespace
 
@@ -32,11 +31,9 @@ def _generator_page_app(
     from streamlit.delta_generator import DeltaGenerator
 
     root_env = os.environ.get("REXAI_PROJECT_ROOT")
-    root = Path(root_env) if root_env else Path.cwd()
+    start = Path(root_env) if root_env else Path(__file__).resolve()
+    root = ensure_project_root(start)
     app_dir = root / "app"
-    for candidate in (root, app_dir):
-        if str(candidate) not in sys.path:
-            sys.path.insert(0, str(candidate))
 
     st.set_page_config = lambda *args, **kwargs: None  # type: ignore[assignment]
 

--- a/tests/pages/test_results_and_export_pages.py
+++ b/tests/pages/test_results_and_export_pages.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
 import os
-import runpy
-import sys
 from pathlib import Path
 
 import pandas as pd
@@ -12,6 +10,7 @@ pytest.importorskip("streamlit")
 
 from pytest_streamlit import StreamlitRunner
 
+from app.bootstrap import ensure_project_root
 from app.modules.io import format_missing_dataset_message, MissingDatasetError
 
 
@@ -20,16 +19,13 @@ def _results_page_app(*, missing_dataset: bool = False, inventory=None) -> None:
     import pandas as pd
     from types import SimpleNamespace as _SimpleNamespace
     import runpy
-    import sys
     import streamlit as st
     from pathlib import Path
 
     root_env = os.environ.get("REXAI_PROJECT_ROOT")
-    root = Path(root_env) if root_env else Path.cwd()
+    start = Path(root_env) if root_env else Path(__file__).resolve()
+    root = ensure_project_root(start)
     app_dir = root / "app"
-    for candidate in (root, app_dir):
-        if str(candidate) not in sys.path:
-            sys.path.insert(0, str(candidate))
 
     st.session_state.clear()
 
@@ -114,18 +110,15 @@ def _pareto_page_app(
     import os
     import pandas as pd
     import runpy
-    import sys
     from pathlib import Path
     from types import SimpleNamespace
 
     import streamlit as st
 
     root_env = os.environ.get("REXAI_PROJECT_ROOT")
-    root = Path(root_env) if root_env else Path.cwd()
+    start = Path(root_env) if root_env else Path(__file__).resolve()
+    root = ensure_project_root(start)
     app_dir = root / "app"
-    for candidate in (root, app_dir):
-        if str(candidate) not in sys.path:
-            sys.path.insert(0, str(candidate))
 
     st.session_state.clear()
 


### PR DESCRIPTION
## Summary
- remove the legacy Streamlit bootstrap helpers in favour of ensure_project_root
- refactor scripts and page tests to rely on ensure_project_root rather than manual sys.path tweaks
- document the official snippets for entrypoints and test/CLI usage in README and environment guide

## Testing
- pytest tests/pages/test_export.py

------
https://chatgpt.com/codex/tasks/task_e_68e00e158e848331a2d2dca1b16eabe4