### PR TITLE
Ensure Streamlit entrypoints register project root

### DIFF
--- a/app/Home.py
+++ b/app/Home.py
@@ -1,6 +1,15 @@
+from pathlib import Path
+import sys
+
+if __package__ in {None, ""}:
+    project_root = Path(__file__).resolve().parents[1]
+    project_root_str = str(project_root)
+    if project_root_str not in sys.path:
+        sys.path.insert(0, project_root_str)
+
 from app.bootstrap import ensure_streamlit_entrypoint
 
-ensure_streamlit_entrypoint(__file__)
+_PROJECT_ROOT = ensure_streamlit_entrypoint(__file__)
 
 __doc__ = """Streamlit entrypoint that mirrors the mission overview page."""
 

--- a/app/bootstrap.py
+++ b/app/bootstrap.py
@@ -10,7 +10,11 @@ from typing import Iterable
 def ensure_streamlit_entrypoint(module_file: str | Path) -> Path:
     """Ensure the Streamlit entrypoint can import ``app`` modules."""
 
-    root = Path(module_file).resolve().parents[2]
+    module_path = Path(module_file)
+    try:
+        root = module_path.resolve().parents[1]
+    except IndexError:
+        root = _find_project_root(module_path)
     root_str = str(root)
     if root_str not in sys.path:
         sys.path.insert(0, root_str)

--- a/app/pages/2_Target_Designer.py
+++ b/app/pages/2_Target_Designer.py
@@ -1,6 +1,15 @@
+from pathlib import Path
+import sys
+
+if __package__ in {None, ""}:
+    project_root = Path(__file__).resolve().parents[1]
+    project_root_str = str(project_root)
+    if project_root_str not in sys.path:
+        sys.path.insert(0, project_root_str)
+
 from app.bootstrap import ensure_streamlit_entrypoint
 
-ensure_streamlit_entrypoint(__file__)
+_PROJECT_ROOT = ensure_streamlit_entrypoint(__file__)
 
 import streamlit as st
 

--- a/app/pages/3_Generator.py
+++ b/app/pages/3_Generator.py
@@ -1,6 +1,15 @@
+from pathlib import Path
+import sys
+
+if __package__ in {None, ""}:
+    project_root = Path(__file__).resolve().parents[1]
+    project_root_str = str(project_root)
+    if project_root_str not in sys.path:
+        sys.path.insert(0, project_root_str)
+
 from app.bootstrap import ensure_streamlit_entrypoint
 
-ensure_streamlit_entrypoint(__file__)
+_PROJECT_ROOT = ensure_streamlit_entrypoint(__file__)
 
 from contextlib import contextmanager
 from typing import Any, Generator, Mapping

--- a/app/pages/4_Results_and_Tradeoffs.py
+++ b/app/pages/4_Results_and_Tradeoffs.py
@@ -1,6 +1,15 @@
+from pathlib import Path
+import sys
+
+if __package__ in {None, ""}:
+    project_root = Path(__file__).resolve().parents[1]
+    project_root_str = str(project_root)
+    if project_root_str not in sys.path:
+        sys.path.insert(0, project_root_str)
+
 from app.bootstrap import ensure_streamlit_entrypoint
 
-ensure_streamlit_entrypoint(__file__)
+_PROJECT_ROOT = ensure_streamlit_entrypoint(__file__)
 
 from collections.abc import Mapping
 

--- a/app/pages/5_Compare_and_Explain.py
+++ b/app/pages/5_Compare_and_Explain.py
@@ -1,6 +1,15 @@
+from pathlib import Path
+import sys
+
+if __package__ in {None, ""}:
+    project_root = Path(__file__).resolve().parents[1]
+    project_root_str = str(project_root)
+    if project_root_str not in sys.path:
+        sys.path.insert(0, project_root_str)
+
 from app.bootstrap import ensure_streamlit_entrypoint
 
-ensure_streamlit_entrypoint(__file__)
+_PROJECT_ROOT = ensure_streamlit_entrypoint(__file__)
 
 import numpy as np
 import streamlit as st

--- a/app/pages/6_Pareto_and_Export.py
+++ b/app/pages/6_Pareto_and_Export.py
@@ -1,6 +1,15 @@
+from pathlib import Path
+import sys
+
+if __package__ in {None, ""}:
+    project_root = Path(__file__).resolve().parents[1]
+    project_root_str = str(project_root)
+    if project_root_str not in sys.path:
+        sys.path.insert(0, project_root_str)
+
 from app.bootstrap import ensure_streamlit_entrypoint
 
-ensure_streamlit_entrypoint(__file__)
+_PROJECT_ROOT = ensure_streamlit_entrypoint(__file__)
 
 __doc__ = """Streamlined Pareto exploration and export centre."""
 

--- a/app/pages/7_Scenario_Playbooks.py
+++ b/app/pages/7_Scenario_Playbooks.py
@@ -1,6 +1,15 @@
+from pathlib import Path
+import sys
+
+if __package__ in {None, ""}:
+    project_root = Path(__file__).resolve().parents[1]
+    project_root_str = str(project_root)
+    if project_root_str not in sys.path:
+        sys.path.insert(0, project_root_str)
+
 from app.bootstrap import ensure_streamlit_entrypoint
 
-ensure_streamlit_entrypoint(__file__)
+_PROJECT_ROOT = ensure_streamlit_entrypoint(__file__)
 
 __doc__ = """Simplified scenario playbooks with actionable summaries."""
 

--- a/app/pages/8_Feedback_and_Impact.py
+++ b/app/pages/8_Feedback_and_Impact.py
@@ -1,6 +1,15 @@
+from pathlib import Path
+import sys
+
+if __package__ in {None, ""}:
+    project_root = Path(__file__).resolve().parents[1]
+    project_root_str = str(project_root)
+    if project_root_str not in sys.path:
+        sys.path.insert(0, project_root_str)
+
 from app.bootstrap import ensure_streamlit_entrypoint
 
-ensure_streamlit_entrypoint(__file__)
+_PROJECT_ROOT = ensure_streamlit_entrypoint(__file__)
 
 __doc__ = """Consolidated feedback capture and mission impact tracking."""
 

--- a/app/pages/9_Capacity_Simulator.py
+++ b/app/pages/9_Capacity_Simulator.py
@@ -1,6 +1,15 @@
+from pathlib import Path
+import sys
+
+if __package__ in {None, ""}:
+    project_root = Path(__file__).resolve().parents[1]
+    project_root_str = str(project_root)
+    if project_root_str not in sys.path:
+        sys.path.insert(0, project_root_str)
+
 from app.bootstrap import ensure_streamlit_entrypoint
 
-ensure_streamlit_entrypoint(__file__)
+_PROJECT_ROOT = ensure_streamlit_entrypoint(__file__)
 
 __doc__ = """Lightweight capacity simulator driven by shared helpers."""
 

--- a/tests/pages/test_page_imports.py
+++ b/tests/pages/test_page_imports.py
@@ -1,0 +1,27 @@
+"""Smoke tests that ensure Streamlit pages remain importable."""
+
+from __future__ import annotations
+
+import importlib.util
+
+import pytest
+
+PAGE_MODULES = [
+    "app.Home",
+    "app.pages.2_Target_Designer",
+    "app.pages.3_Generator",
+    "app.pages.4_Results_and_Tradeoffs",
+    "app.pages.5_Compare_and_Explain",
+    "app.pages.6_Pareto_and_Export",
+    "app.pages.7_Scenario_Playbooks",
+    "app.pages.8_Feedback_and_Impact",
+    "app.pages.9_Capacity_Simulator",
+]
+
+
+@pytest.mark.parametrize("module_name", PAGE_MODULES)
+def test_streamlit_pages_are_importable(module_name: str) -> None:
+    """Import each Streamlit page to catch missing dependencies early."""
+
+    spec = importlib.util.find_spec(module_name)
+    assert spec is not None, f"Module spec for {module_name} could not be found"


### PR DESCRIPTION
## Summary
- update `ensure_streamlit_entrypoint` to resolve the repository root correctly
- bootstrap every Streamlit entrypoint so the repo root is on `sys.path` before other imports
- add a smoke test that checks each Streamlit page has an importable module spec

## Testing
- pytest tests/pages/test_page_imports.py

------
https://chatgpt.com/codex/tasks/task_e_68e010dcb3b08331aad22bbcefbc48e7