### PR TITLE
Ensure Streamlit entrypoint helper locates app package

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,12 +23,13 @@ No se requieren variables de entorno adicionales para el arranque interactivo.
 > ```python
 > from app.bootstrap import ensure_streamlit_entrypoint
 >
-> ensure_streamlit_entrypoint(__file__)
+> PROJECT_ROOT = ensure_streamlit_entrypoint(__file__)
 > ```
 >
 > Esto fuerza la inclusión de la raíz del repositorio en `sys.path` cuando se
-> ejecutan archivos sueltos con `streamlit run` o `python app/...` y evita los
-> `ModuleNotFoundError` al importar `app.*`.
+> ejecutan archivos sueltos con `streamlit run` o `python app/...`, devuelve el
+> directorio que contiene `app/__init__.py` y evita los `ModuleNotFoundError`
+> al importar `app.*`.
 >
 > 🧪 **Scripts y tests**: para utilidades CLI o fixtures de Pytest, usa
 > `ensure_project_root(__file__)` en vez de manipular `sys.path` a mano:

--- a/app/bootstrap.py
+++ b/app/bootstrap.py
@@ -10,7 +10,8 @@ from typing import Iterable
 def ensure_streamlit_entrypoint(module_file: str | Path) -> Path:
     """Ensure the Streamlit entrypoint can import ``app`` modules."""
 
-    root = _find_project_root(Path(module_file))
+    module_path = Path(module_file).resolve()
+    root = _find_project_root(module_path.parent)
     root_str = str(root)
     if root_str not in sys.path:
         sys.path.insert(0, root_str)

--- a/app/bootstrap.py
+++ b/app/bootstrap.py
@@ -10,7 +10,7 @@ from typing import Iterable
 def ensure_streamlit_entrypoint(module_file: str | Path) -> Path:
     """Ensure the Streamlit entrypoint can import ``app`` modules."""
 
-    root = Path(module_file).resolve().parents[2]
+    root = _find_project_root(Path(module_file))
     root_str = str(root)
     if root_str not in sys.path:
         sys.path.insert(0, root_str)

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -28,3 +28,12 @@ def test_ensure_streamlit_entrypoint_for_nested_page_includes_app(monkeypatch) -
 
     assert sys.path[0] == str(root)
     _assert_app_package_present(root)
+
+
+def test_ensure_streamlit_entrypoint_accepts_string_path(monkeypatch) -> None:
+    monkeypatch.setattr(sys, "path", [])
+
+    root = ensure_streamlit_entrypoint("app/pages/another_page.py")
+
+    assert sys.path[0] == str(root)
+    _assert_app_package_present(root)

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from app.bootstrap import ensure_streamlit_entrypoint
+
+
+def _assert_app_package_present(root: Path) -> None:
+    app_package = root / "app"
+    assert app_package.is_dir()
+    assert (app_package / "__init__.py").is_file()
+
+
+def test_ensure_streamlit_entrypoint_for_home_includes_app(monkeypatch) -> None:
+    monkeypatch.setattr(sys, "path", [])
+
+    root = ensure_streamlit_entrypoint(Path("app/Home.py"))
+
+    assert sys.path[0] == str(root)
+    _assert_app_package_present(root)
+
+
+def test_ensure_streamlit_entrypoint_for_nested_page_includes_app(monkeypatch) -> None:
+    monkeypatch.setattr(sys, "path", [])
+
+    root = ensure_streamlit_entrypoint(Path("app/pages/x.py"))
+
+    assert sys.path[0] == str(root)
+    _assert_app_package_present(root)


### PR DESCRIPTION
## Summary
- update `ensure_streamlit_entrypoint` to reuse `_find_project_root` so Streamlit entrypoints always expose the `app` package
- add regression tests covering the helper with home and nested page entrypoints
- document the recommended bootstrap snippet for new Streamlit entrypoints in the README

## Testing
- pytest tests/test_bootstrap.py


------
https://chatgpt.com/codex/tasks/task_e_68e010ddeffc8331a0bc89891b2c71af