### PR TITLE
Update logo styling and add tagline text

### DIFF
--- a/app/static/logo_rexai.svg
+++ b/app/static/logo_rexai.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 820 160" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 820 220" fill="none">
   <!--
     REX-AI — Minimal tech wordmark for "Rex-AI"
     Style notes:
@@ -7,7 +7,7 @@
       - Built on a 160px cap-height with consistent stroke
       - Uses currentColor so you can recolor via CSS or the 'color' attribute
   -->
-  <g stroke="currentColor" stroke-width="12" stroke-linecap="round" stroke-linejoin="round">
+  <g stroke="#FFFFFF" stroke-width="12" stroke-linecap="round" stroke-linejoin="round">
     <!-- R -->
     <g transform="translate(30,16)">
       <!-- Vertical stem -->
@@ -65,4 +65,13 @@
       <path d="M-6,128 L42,128" />
     </g>
   </g>
+  <text
+    x="410"
+    y="188"
+    text-anchor="middle"
+    font-family="Montserrat, 'Source Sans 3', sans-serif"
+    font-size="48"
+    letter-spacing="4"
+    fill="#FFFFFF"
+  >Interplanetary Recycling</text>
 </svg>


### PR DESCRIPTION
## Summary
- update the RexAI logo SVG to use fixed white strokes instead of currentColor
- enlarge the canvas and add a centered "Interplanetary Recycling" tagline beneath the wordmark

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e01e9789248331a475a45db2d1369e