### PR TITLE
Add centralized RexAI brand header across mission dashboards

### DIFF
--- a/app/modules/mission_overview.py
+++ b/app/modules/mission_overview.py
@@ -355,13 +355,14 @@ def render_overview_dashboard(
     from app.modules.ml_models import get_model_registry
     from app.modules.navigation import render_breadcrumbs, render_stepper, set_active_step
     from app.modules.paths import DATA_ROOT
-    from app.modules.ui_blocks import initialise_frontend, load_theme
+    from app.modules.ui_blocks import initialise_frontend, load_theme, render_brand_header
 
     st.set_page_config(page_title="Mission Overview", page_icon="🛰️", layout="wide")
     initialise_frontend()
 
     current_step = set_active_step("home")
     load_theme(show_hud=False)
+    render_brand_header()
 
     render_breadcrumbs(current_step)
     render_stepper(current_step)

--- a/app/pages/2_Target_Designer.py
+++ b/app/pages/2_Target_Designer.py
@@ -16,7 +16,7 @@ import streamlit as st
 from app.modules.io import load_targets
 from app.modules.navigation import render_breadcrumbs, set_active_step
 from app.modules.target_limits import compute_target_limits
-from app.modules.ui_blocks import initialise_frontend, load_theme
+from app.modules.ui_blocks import initialise_frontend, load_theme, render_brand_header
 
 # ⚠️ Debe ser la PRIMERA llamada de Streamlit en la página
 st.set_page_config(page_title="Objetivo", page_icon="🎯", layout="wide")
@@ -25,6 +25,8 @@ initialise_frontend()
 current_step = set_active_step("target")
 
 load_theme()
+
+render_brand_header()
 
 render_breadcrumbs(current_step)
 

--- a/app/pages/3_Generator.py
+++ b/app/pages/3_Generator.py
@@ -41,6 +41,7 @@ from app.modules.ui_blocks import (
     load_theme,
     micro_divider,
     pill,
+    render_brand_header,
 )
 from app.modules.visualizations import ConvergenceScene
 from app.modules.schema import (
@@ -57,6 +58,8 @@ initialise_frontend()
 current_step = set_active_step("generator")
 
 load_theme()
+
+render_brand_header()
 
 render_breadcrumbs(current_step)
 

--- a/app/pages/4_Results_and_Tradeoffs.py
+++ b/app/pages/4_Results_and_Tradeoffs.py
@@ -19,7 +19,7 @@ import plotly.graph_objects as go
 import streamlit as st
 
 from app.modules.navigation import render_breadcrumbs, set_active_step
-from app.modules.ui_blocks import initialise_frontend, layout_block, load_theme
+from app.modules.ui_blocks import initialise_frontend, layout_block, load_theme, render_brand_header
 
 from app.modules.data_sources import (
     load_regolith_granulometry,
@@ -46,6 +46,8 @@ initialise_frontend()
 current_step = set_active_step("results")
 
 load_theme()
+
+render_brand_header()
 
 render_breadcrumbs(current_step)
 

--- a/app/pages/5_Compare_and_Explain.py
+++ b/app/pages/5_Compare_and_Explain.py
@@ -20,7 +20,7 @@ from streamlit_sortables import sort_items
 
 from app.modules.explain import compare_table, score_breakdown
 from app.modules.navigation import render_breadcrumbs, set_active_step
-from app.modules.ui_blocks import initialise_frontend, load_theme, pill
+from app.modules.ui_blocks import initialise_frontend, load_theme, pill, render_brand_header
 from app.modules.io import (
     MissingDatasetError,
     format_missing_dataset_message,
@@ -194,6 +194,8 @@ initialise_frontend()
 current_step = set_active_step("compare")
 
 load_theme()
+
+render_brand_header()
 
 render_breadcrumbs(current_step)
 # ======== estado requerido ========

--- a/app/pages/6_Pareto_and_Export.py
+++ b/app/pages/6_Pareto_and_Export.py
@@ -33,7 +33,13 @@ from app.modules.page_data import (
     build_material_summary_table,
 )
 from app.modules.safety import check_safety, safety_badge
-from app.modules.ui_blocks import action_button, initialise_frontend, layout_stack, load_theme
+from app.modules.ui_blocks import (
+    action_button,
+    initialise_frontend,
+    layout_stack,
+    load_theme,
+    render_brand_header,
+)
 from app.modules.utils import safe_int
 
 
@@ -43,6 +49,8 @@ initialise_frontend()
 current_step = set_active_step("export")
 
 load_theme()
+
+render_brand_header()
 
 render_breadcrumbs(current_step)
 

--- a/app/pages/7_Scenario_Playbooks.py
+++ b/app/pages/7_Scenario_Playbooks.py
@@ -20,7 +20,7 @@ import streamlit as st
 
 from app.modules.navigation import render_breadcrumbs, set_active_step
 from app.modules.scenarios import PLAYBOOKS
-from app.modules.ui_blocks import initialise_frontend, layout_stack, load_theme
+from app.modules.ui_blocks import initialise_frontend, layout_stack, load_theme, render_brand_header
 
 
 st.set_page_config(page_title="Scenario Playbooks", page_icon="📚", layout="wide")
@@ -29,6 +29,8 @@ initialise_frontend()
 current_step = set_active_step("playbooks")
 
 load_theme()
+
+render_brand_header()
 
 render_breadcrumbs(current_step)
 

--- a/app/pages/8_Feedback_and_Impact.py
+++ b/app/pages/8_Feedback_and_Impact.py
@@ -30,7 +30,7 @@ from app.modules.impact import (
 )
 from app.modules.navigation import render_breadcrumbs, set_active_step
 from app.modules.page_data import build_feedback_summary_table
-from app.modules.ui_blocks import initialise_frontend, layout_stack, load_theme
+from app.modules.ui_blocks import initialise_frontend, layout_stack, load_theme, render_brand_header
 from app.modules.utils import safe_int
 
 
@@ -40,6 +40,8 @@ initialise_frontend()
 current_step = set_active_step("feedback")
 
 load_theme()
+
+render_brand_header()
 
 render_breadcrumbs(current_step)
 

--- a/app/pages/9_Capacity_Simulator.py
+++ b/app/pages/9_Capacity_Simulator.py
@@ -18,7 +18,7 @@ import streamlit as st
 
 from app.modules.capacity import LineConfig, simulate
 from app.modules.navigation import render_breadcrumbs, set_active_step
-from app.modules.ui_blocks import initialise_frontend, layout_stack, load_theme
+from app.modules.ui_blocks import initialise_frontend, layout_stack, load_theme, render_brand_header
 
 
 st.set_page_config(page_title="Capacity Simulator", page_icon="🧮", layout="wide")
@@ -27,6 +27,8 @@ initialise_frontend()
 current_step = set_active_step("capacity")
 
 load_theme()
+
+render_brand_header()
 
 render_breadcrumbs(current_step)
 

--- a/app/static/styles/base.css
+++ b/app/static/styles/base.css
@@ -189,6 +189,37 @@ table {
   border-color: var(--mission-color-accent);
 }
 
+.mission-brand-header {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--mission-space-xs);
+  text-align: center;
+  margin-block: var(--mission-space-lg);
+  padding: var(--mission-space-md) var(--mission-space-lg);
+  background: rgba(255, 255, 255, 0.92);
+  border: 1px solid rgba(11, 21, 38, 0.12);
+  border-radius: var(--mission-radius-md);
+  box-shadow: 0 8px 24px rgba(11, 21, 38, 0.08);
+}
+
+.mission-brand-header__logo img {
+  display: block;
+  width: min(220px, 60vw);
+  height: auto;
+  filter: drop-shadow(0 4px 12px rgba(11, 21, 38, 0.15));
+}
+
+.mission-brand-header__tagline {
+  margin: 0;
+  font-size: 0.95rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--mission-color-text);
+}
+
 :focus-visible {
   outline: 2px solid var(--mission-color-accent);
   outline-offset: 2px;


### PR DESCRIPTION
## Summary
- add a reusable `render_brand_header` helper that injects the RexAI logo and tagline with accessible markup
- style the brand header container for consistent contrast on light themes
- invoke the brand header across the mission overview and downstream Streamlit pages after theme initialization

## Testing
- streamlit run app/Home.py --server.headless true --server.port 8501

------
https://chatgpt.com/codex/tasks/task_e_68e02510a8cc83318a5951c009b29ee5