### PR TITLE
Refine brand header proportions

### DIFF
--- a/app/modules/ui_blocks.py
+++ b/app/modules/ui_blocks.py
@@ -102,37 +102,37 @@ def inject_css(show_hud: bool = False) -> None:
 
 
 def render_brand_header(
-    tagline: str | None = None,
+    tagline: str | None = "Interplanetary Recycling",
     *,
     alt_text: str = "RexAI mission control logo",
 ) -> None:
-    """Render the RexAI logo and tagline centred within the layout."""
+    """Render the RexAI logo and optional tagline centred within the layout."""
 
     load_theme(show_hud=False)
 
-    resolved_tagline = tagline or "Inteligencia de misión para residuos orbitales."
     logo_path = _static_path(_BRAND_LOGO_FILENAME)
     data_uri = _encode_svg_base64(logo_path)
     alt_attr = escape(alt_text) if alt_text else ""
 
     if data_uri is None:
-        markup = (
-            f"<div class='mission-brand-header'>"
-            f"<div class='mission-brand-header__logo'>"
-            f"<img src='{escape(str(logo_path))}' alt='{alt_attr}' />"
-            f"</div>"
-            f"<p class='mission-brand-header__tagline'>{escape(resolved_tagline)}</p>"
-            f"</div>"
-        )
+        logo_markup = f"<img src='{escape(str(logo_path))}' alt='{alt_attr}' />"
     else:
-        markup = (
-            f"<div class='mission-brand-header'>"
-            f"<div class='mission-brand-header__logo'>"
-            f"<img src='{data_uri}' alt='{alt_attr}' />"
-            f"</div>"
-            f"<p class='mission-brand-header__tagline'>{escape(resolved_tagline)}</p>"
-            f"</div>"
+        logo_markup = f"<img src='{data_uri}' alt='{alt_attr}' />"
+
+    tagline_markup = ""
+    if tagline:
+        tagline_markup = (
+            f"<p class='mission-brand-header__tagline'>{escape(tagline)}</p>"
         )
+
+    markup = (
+        "<div class='mission-brand-header'>"
+        "<div class='mission-brand-header__logo'>"
+        f"{logo_markup}"
+        "</div>"
+        f"{tagline_markup}"
+        "</div>"
+    )
 
     st.markdown(markup, unsafe_allow_html=True)
 

--- a/app/static/logo_rexai.svg
+++ b/app/static/logo_rexai.svg
@@ -65,13 +65,4 @@
       <path d="M-6,128 L42,128" />
     </g>
   </g>
-  <text
-    x="410"
-    y="188"
-    text-anchor="middle"
-    font-family="Montserrat, 'Source Sans 3', sans-serif"
-    font-size="48"
-    letter-spacing="4"
-    fill="#FFFFFF"
-  >Interplanetary Recycling</text>
 </svg>

--- a/app/static/styles/base.css
+++ b/app/static/styles/base.css
@@ -190,34 +190,38 @@ table {
 }
 
 .mission-brand-header {
+  --mission-brand-width: clamp(120px, 18vw, 168px);
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: var(--mission-space-xs);
+  gap: var(--mission-space-4xs);
   text-align: center;
   margin-block: var(--mission-space-lg);
-  padding: var(--mission-space-md) var(--mission-space-lg);
-  background: rgba(255, 255, 255, 0.92);
-  border: 1px solid rgba(11, 21, 38, 0.12);
-  border-radius: var(--mission-radius-md);
-  box-shadow: 0 8px 24px rgba(11, 21, 38, 0.08);
+  padding: 0;
+  color: var(--mission-color-text);
+}
+
+.mission-brand-header__logo {
+  width: var(--mission-brand-width);
 }
 
 .mission-brand-header__logo img {
   display: block;
-  width: min(220px, 60vw);
+  width: 100%;
   height: auto;
-  filter: drop-shadow(0 4px 12px rgba(11, 21, 38, 0.15));
+  margin: 0;
 }
 
 .mission-brand-header__tagline {
-  margin: 0;
-  font-size: 0.95rem;
+  display: block;
+  width: var(--mission-brand-width);
+  margin: var(--mission-space-4xs) auto 0;
+  font-size: 0.72rem;
   font-weight: 600;
-  letter-spacing: 0.08em;
+  letter-spacing: 0.22em;
   text-transform: uppercase;
-  color: var(--mission-color-text);
+  color: var(--mission-color-muted);
 }
 
 :focus-visible {


### PR DESCRIPTION
## Summary
- update the brand header styles to size the Rex-AI mark more compactly and align the tagline width to the logo
- adjust spacing so the "Interplanetary Recycling" slogan sits with a subtle margin beneath the wordmark for balanced branding

## Testing
- pytest tests/modules/test_ui_blocks.py

------
https://chatgpt.com/codex/tasks/task_e_68dd845c2aa883318dcd9b94d22e45a0