### PR TITLE
Refactor Streamlit entrypoint bootstrap

### DIFF
--- a/app/Home.py
+++ b/app/Home.py
@@ -1,15 +1,5 @@
-from pathlib import Path
-import sys
-
-if __package__ in {None, ""}:
-    project_root = Path(__file__).resolve().parents[1]
-    project_root_str = str(project_root)
-    if project_root_str not in sys.path:
-        sys.path.insert(0, project_root_str)
-
 from app.bootstrap import ensure_streamlit_entrypoint
-
-_PROJECT_ROOT = ensure_streamlit_entrypoint(__file__)
+ensure_streamlit_entrypoint(__file__)
 
 __doc__ = """Streamlit entrypoint that mirrors the mission overview page."""
 

--- a/app/bootstrap.py
+++ b/app/bootstrap.py
@@ -12,11 +12,6 @@ def ensure_streamlit_entrypoint(module_file: str | Path) -> Path:
 
     module_path = Path(module_file).resolve()
     root = _find_project_root(module_path.parent)
-    module_path = Path(module_file)
-    try:
-        root = module_path.resolve().parents[1]
-    except IndexError:
-        root = _find_project_root(module_path)
     root_str = str(root)
     if root_str not in sys.path:
         sys.path.insert(0, root_str)

--- a/app/pages/2_Target_Designer.py
+++ b/app/pages/2_Target_Designer.py
@@ -1,15 +1,5 @@
-from pathlib import Path
-import sys
-
-if __package__ in {None, ""}:
-    project_root = Path(__file__).resolve().parents[1]
-    project_root_str = str(project_root)
-    if project_root_str not in sys.path:
-        sys.path.insert(0, project_root_str)
-
 from app.bootstrap import ensure_streamlit_entrypoint
-
-_PROJECT_ROOT = ensure_streamlit_entrypoint(__file__)
+ensure_streamlit_entrypoint(__file__)
 
 import streamlit as st
 

--- a/app/pages/3_Generator.py
+++ b/app/pages/3_Generator.py
@@ -1,15 +1,5 @@
-from pathlib import Path
-import sys
-
-if __package__ in {None, ""}:
-    project_root = Path(__file__).resolve().parents[1]
-    project_root_str = str(project_root)
-    if project_root_str not in sys.path:
-        sys.path.insert(0, project_root_str)
-
 from app.bootstrap import ensure_streamlit_entrypoint
-
-_PROJECT_ROOT = ensure_streamlit_entrypoint(__file__)
+ensure_streamlit_entrypoint(__file__)
 
 from contextlib import contextmanager
 from typing import Any, Generator, Mapping

--- a/app/pages/4_Results_and_Tradeoffs.py
+++ b/app/pages/4_Results_and_Tradeoffs.py
@@ -1,15 +1,5 @@
-from pathlib import Path
-import sys
-
-if __package__ in {None, ""}:
-    project_root = Path(__file__).resolve().parents[1]
-    project_root_str = str(project_root)
-    if project_root_str not in sys.path:
-        sys.path.insert(0, project_root_str)
-
 from app.bootstrap import ensure_streamlit_entrypoint
-
-_PROJECT_ROOT = ensure_streamlit_entrypoint(__file__)
+ensure_streamlit_entrypoint(__file__)
 
 from collections.abc import Mapping
 

--- a/app/pages/5_Compare_and_Explain.py
+++ b/app/pages/5_Compare_and_Explain.py
@@ -1,15 +1,5 @@
-from pathlib import Path
-import sys
-
-if __package__ in {None, ""}:
-    project_root = Path(__file__).resolve().parents[1]
-    project_root_str = str(project_root)
-    if project_root_str not in sys.path:
-        sys.path.insert(0, project_root_str)
-
 from app.bootstrap import ensure_streamlit_entrypoint
-
-_PROJECT_ROOT = ensure_streamlit_entrypoint(__file__)
+ensure_streamlit_entrypoint(__file__)
 
 import numpy as np
 import streamlit as st

--- a/app/pages/6_Pareto_and_Export.py
+++ b/app/pages/6_Pareto_and_Export.py
@@ -1,15 +1,5 @@
-from pathlib import Path
-import sys
-
-if __package__ in {None, ""}:
-    project_root = Path(__file__).resolve().parents[1]
-    project_root_str = str(project_root)
-    if project_root_str not in sys.path:
-        sys.path.insert(0, project_root_str)
-
 from app.bootstrap import ensure_streamlit_entrypoint
-
-_PROJECT_ROOT = ensure_streamlit_entrypoint(__file__)
+ensure_streamlit_entrypoint(__file__)
 
 __doc__ = """Streamlined Pareto exploration and export centre."""
 

--- a/app/pages/7_Scenario_Playbooks.py
+++ b/app/pages/7_Scenario_Playbooks.py
@@ -1,15 +1,5 @@
-from pathlib import Path
-import sys
-
-if __package__ in {None, ""}:
-    project_root = Path(__file__).resolve().parents[1]
-    project_root_str = str(project_root)
-    if project_root_str not in sys.path:
-        sys.path.insert(0, project_root_str)
-
 from app.bootstrap import ensure_streamlit_entrypoint
-
-_PROJECT_ROOT = ensure_streamlit_entrypoint(__file__)
+ensure_streamlit_entrypoint(__file__)
 
 __doc__ = """Simplified scenario playbooks with actionable summaries."""
 

--- a/app/pages/8_Feedback_and_Impact.py
+++ b/app/pages/8_Feedback_and_Impact.py
@@ -1,15 +1,5 @@
-from pathlib import Path
-import sys
-
-if __package__ in {None, ""}:
-    project_root = Path(__file__).resolve().parents[1]
-    project_root_str = str(project_root)
-    if project_root_str not in sys.path:
-        sys.path.insert(0, project_root_str)
-
 from app.bootstrap import ensure_streamlit_entrypoint
-
-_PROJECT_ROOT = ensure_streamlit_entrypoint(__file__)
+ensure_streamlit_entrypoint(__file__)
 
 __doc__ = """Consolidated feedback capture and mission impact tracking."""
 

--- a/app/pages/9_Capacity_Simulator.py
+++ b/app/pages/9_Capacity_Simulator.py
@@ -1,15 +1,5 @@
-from pathlib import Path
-import sys
-
-if __package__ in {None, ""}:
-    project_root = Path(__file__).resolve().parents[1]
-    project_root_str = str(project_root)
-    if project_root_str not in sys.path:
-        sys.path.insert(0, project_root_str)
-
 from app.bootstrap import ensure_streamlit_entrypoint
-
-_PROJECT_ROOT = ensure_streamlit_entrypoint(__file__)
+ensure_streamlit_entrypoint(__file__)
 
 __doc__ = """Lightweight capacity simulator driven by shared helpers."""
 

--- a/tests/ui/test_entrypoints_import.py
+++ b/tests/ui/test_entrypoints_import.py
@@ -1,0 +1,58 @@
+"""Ensure Streamlit entrypoints can be imported without path hacks."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+
+class _StreamlitAbort(RuntimeError):
+    """Sentinel exception raised when ``st.stop`` is invoked."""
+
+
+ENTRYPOINT_FILES = [
+    Path("app/Home.py"),
+    *sorted(Path("app/pages").glob("*.py")),
+]
+
+
+def _sanitise_module_name(path: Path) -> str:
+    stem = path.stem
+    sanitized = "".join(char if char.isalnum() or char == "_" else "_" for char in stem)
+    if sanitized and sanitized[0].isdigit():
+        sanitized = f"page_{sanitized}"
+    return f"tests.ui.entrypoints.{sanitized}"
+
+
+@pytest.mark.parametrize("module_path", ENTRYPOINT_FILES)
+def test_entrypoint_imports_without_module_not_found(
+    module_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Import each Streamlit entrypoint and ensure dependencies resolve."""
+
+    module_name = _sanitise_module_name(module_path)
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    assert spec is not None, f"Expected import spec for '{module_path}'"
+    assert spec.loader is not None, f"Expected loader in import spec for '{module_path}'"
+    sys.modules.pop(module_name, None)
+    module = importlib.util.module_from_spec(spec)
+    try:
+        import streamlit as st
+    except ModuleNotFoundError:
+        pytest.skip("streamlit is required for entrypoint imports")
+
+    def _stop() -> None:
+        raise _StreamlitAbort
+
+    monkeypatch.setattr(st, "stop", _stop, raising=False)
+    try:
+        spec.loader.exec_module(module)
+    except ModuleNotFoundError as error:  # pragma: no cover - explicit failure path
+        pytest.fail(f"Unexpected ModuleNotFoundError importing '{module_path}': {error}")
+    except _StreamlitAbort:
+        pass
+    assert module.__name__ == module_name
+


### PR DESCRIPTION
## Summary
- ensure `ensure_streamlit_entrypoint` resolves the repository root via `_find_project_root` and adds it to `sys.path`
- prepend `ensure_streamlit_entrypoint(__file__)` to the Home view and all Streamlit page entrypoints, removing manual path hacks
- add a regression test that imports each entrypoint to guard against `ModuleNotFoundError`

## Testing
- pytest tests/test_bootstrap.py tests/ui/test_entrypoints_import.py

------
https://chatgpt.com/codex/tasks/task_e_68e02e5b67988331bf11045df4ce9d01