### PR TITLE
Clean up Streamlit entrypoint imports

### DIFF
--- a/app/Home.py
+++ b/app/Home.py
@@ -1,4 +1,5 @@
 from app.bootstrap import ensure_streamlit_entrypoint
+
 ensure_streamlit_entrypoint(__file__)
 
 __doc__ = """Streamlit entrypoint that mirrors the mission overview page."""

--- a/app/pages/2_Target_Designer.py
+++ b/app/pages/2_Target_Designer.py
@@ -1,4 +1,5 @@
 from app.bootstrap import ensure_streamlit_entrypoint
+
 ensure_streamlit_entrypoint(__file__)
 
 import streamlit as st

--- a/app/pages/3_Generator.py
+++ b/app/pages/3_Generator.py
@@ -1,10 +1,10 @@
 from app.bootstrap import ensure_streamlit_entrypoint
+
 ensure_streamlit_entrypoint(__file__)
 
+import math
 from contextlib import contextmanager
 from typing import Any, Generator, Mapping
-
-import math
 
 import altair as alt
 import pandas as pd
@@ -12,20 +12,27 @@ import streamlit as st
 
 from app.modules.candidate_showroom import render_candidate_showroom
 from app.modules.generator import generate_candidates
-from app.modules.io import (
+from app.modules.io import (  # si tu IO usa load_process_catalog, cámbialo aquí
     MissingDatasetError,
     format_missing_dataset_message,
     load_process_df,
     load_waste_df,
-)  # si tu IO usa load_process_catalog, cámbialo aquí
+)
 from app.modules.ml_models import get_model_registry
 from app.modules.navigation import render_breadcrumbs, set_active_step
+from app.modules.page_data import build_ranking_table
 from app.modules.process_planner import choose_process
 from app.modules.safety import check_safety, safety_badge
+from app.modules.schema import (
+    ALUMINIUM_LABEL_COLUMNS,
+    ALUMINIUM_NUMERIC_COLUMNS,
+    POLYMER_LABEL_COLUMNS,
+    POLYMER_METRIC_COLUMNS,
+)
 from app.modules.ui_blocks import (
     action_button,
-    initialise_frontend,
     chipline,
+    initialise_frontend,
     layout_block,
     layout_stack,
     load_theme,
@@ -34,13 +41,6 @@ from app.modules.ui_blocks import (
     render_brand_header,
 )
 from app.modules.visualizations import ConvergenceScene
-from app.modules.schema import (
-    ALUMINIUM_LABEL_COLUMNS,
-    ALUMINIUM_NUMERIC_COLUMNS,
-    POLYMER_LABEL_COLUMNS,
-    POLYMER_METRIC_COLUMNS,
-)
-from app.modules.page_data import build_ranking_table
 
 st.set_page_config(page_title="Rex-AI • Generador", page_icon="🤖", layout="wide")
 initialise_frontend()

--- a/app/pages/4_Results_and_Tradeoffs.py
+++ b/app/pages/4_Results_and_Tradeoffs.py
@@ -1,4 +1,5 @@
 from app.bootstrap import ensure_streamlit_entrypoint
+
 ensure_streamlit_entrypoint(__file__)
 
 from collections.abc import Mapping
@@ -7,9 +8,6 @@ import altair as alt
 import pandas as pd
 import plotly.graph_objects as go
 import streamlit as st
-
-from app.modules.navigation import render_breadcrumbs, set_active_step
-from app.modules.ui_blocks import initialise_frontend, layout_block, load_theme, render_brand_header
 
 from app.modules.data_sources import (
     load_regolith_granulometry,
@@ -22,13 +20,20 @@ from app.modules.io import (
     format_missing_dataset_message,
     load_waste_df,
 )
+from app.modules.navigation import render_breadcrumbs, set_active_step
+from app.modules.page_data import build_candidate_metric_table, build_resource_table
 from app.modules.schema import (
     ALUMINIUM_LABEL_COLUMNS,
     ALUMINIUM_NUMERIC_COLUMNS,
     POLYMER_LABEL_COLUMNS,
     POLYMER_METRIC_COLUMNS,
 )
-from app.modules.page_data import build_candidate_metric_table, build_resource_table
+from app.modules.ui_blocks import (
+    initialise_frontend,
+    layout_block,
+    load_theme,
+    render_brand_header,
+)
 
 st.set_page_config(page_title="Rex-AI • Resultados", page_icon="📊", layout="wide")
 initialise_frontend()

--- a/app/pages/5_Compare_and_Explain.py
+++ b/app/pages/5_Compare_and_Explain.py
@@ -1,20 +1,26 @@
 from app.bootstrap import ensure_streamlit_entrypoint
+
 ensure_streamlit_entrypoint(__file__)
 
 import numpy as np
-import streamlit as st
 import pandas as pd
 import plotly.express as px
 import plotly.graph_objects as go
+import streamlit as st
 from streamlit_sortables import sort_items
 
 from app.modules.explain import compare_table, score_breakdown
-from app.modules.navigation import render_breadcrumbs, set_active_step
-from app.modules.ui_blocks import initialise_frontend, load_theme, pill, render_brand_header
 from app.modules.io import (
     MissingDatasetError,
     format_missing_dataset_message,
     load_waste_df,
+)
+from app.modules.navigation import render_breadcrumbs, set_active_step
+from app.modules.ui_blocks import (
+    initialise_frontend,
+    load_theme,
+    pill,
+    render_brand_header,
 )
 
 

--- a/app/pages/6_Pareto_and_Export.py
+++ b/app/pages/6_Pareto_and_Export.py
@@ -1,11 +1,11 @@
 from app.bootstrap import ensure_streamlit_entrypoint
+
 ensure_streamlit_entrypoint(__file__)
 
 __doc__ = """Streamlined Pareto exploration and export centre."""
 
-from typing import Iterable
-
 import math
+from typing import Iterable
 
 import streamlit as st
 
@@ -31,7 +31,6 @@ from app.modules.ui_blocks import (
     render_brand_header,
 )
 from app.modules.utils import safe_int
-
 
 st.set_page_config(page_title="Pareto & Export", page_icon="📤", layout="wide")
 initialise_frontend()

--- a/app/pages/7_Scenario_Playbooks.py
+++ b/app/pages/7_Scenario_Playbooks.py
@@ -1,4 +1,5 @@
 from app.bootstrap import ensure_streamlit_entrypoint
+
 ensure_streamlit_entrypoint(__file__)
 
 __doc__ = """Simplified scenario playbooks with actionable summaries."""
@@ -10,8 +11,12 @@ import streamlit as st
 
 from app.modules.navigation import render_breadcrumbs, set_active_step
 from app.modules.scenarios import PLAYBOOKS
-from app.modules.ui_blocks import initialise_frontend, layout_stack, load_theme, render_brand_header
-
+from app.modules.ui_blocks import (
+    initialise_frontend,
+    layout_stack,
+    load_theme,
+    render_brand_header,
+)
 
 st.set_page_config(page_title="Scenario Playbooks", page_icon="📚", layout="wide")
 initialise_frontend()

--- a/app/pages/8_Feedback_and_Impact.py
+++ b/app/pages/8_Feedback_and_Impact.py
@@ -1,4 +1,5 @@
 from app.bootstrap import ensure_streamlit_entrypoint
+
 ensure_streamlit_entrypoint(__file__)
 
 __doc__ = """Consolidated feedback capture and mission impact tracking."""
@@ -20,9 +21,13 @@ from app.modules.impact import (
 )
 from app.modules.navigation import render_breadcrumbs, set_active_step
 from app.modules.page_data import build_feedback_summary_table
-from app.modules.ui_blocks import initialise_frontend, layout_stack, load_theme, render_brand_header
+from app.modules.ui_blocks import (
+    initialise_frontend,
+    layout_stack,
+    load_theme,
+    render_brand_header,
+)
 from app.modules.utils import safe_int
-
 
 st.set_page_config(page_title="Feedback & Impact", page_icon="📝", layout="wide")
 initialise_frontend()

--- a/app/pages/9_Capacity_Simulator.py
+++ b/app/pages/9_Capacity_Simulator.py
@@ -1,4 +1,5 @@
 from app.bootstrap import ensure_streamlit_entrypoint
+
 ensure_streamlit_entrypoint(__file__)
 
 __doc__ = """Lightweight capacity simulator driven by shared helpers."""
@@ -8,8 +9,12 @@ import streamlit as st
 
 from app.modules.capacity import LineConfig, simulate
 from app.modules.navigation import render_breadcrumbs, set_active_step
-from app.modules.ui_blocks import initialise_frontend, layout_stack, load_theme, render_brand_header
-
+from app.modules.ui_blocks import (
+    initialise_frontend,
+    layout_stack,
+    load_theme,
+    render_brand_header,
+)
 
 st.set_page_config(page_title="Capacity Simulator", page_icon="🧮", layout="wide")
 initialise_frontend()


### PR DESCRIPTION
## Summary
- reorder imports across all Streamlit entrypoints so they rely solely on `ensure_streamlit_entrypoint`
- normalize import grouping to remove ad-hoc path handling and keep only real module imports

## Testing
- pytest tests/pages/test_page_imports.py

------
https://chatgpt.com/codex/tasks/task_e_68e0307bcde88331a4ea6e95773cab5f