### PR TITLE
Cache brand logo markup and add tests

### DIFF
--- a/app/modules/ui_blocks.py
+++ b/app/modules/ui_blocks.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import base64
 import hashlib
+from functools import lru_cache
 from contextlib import contextmanager
 from html import escape
 from pathlib import Path
@@ -47,6 +48,7 @@ _THEME_HASH_KEY = "__rexai_theme_hash__"
 _BRAND_LOGO_FILENAME = "logo_rexai.svg"
 
 
+@lru_cache(maxsize=None)
 def _encode_svg_base64(path: Path) -> str | None:
     try:
         svg_markup = path.read_text(encoding="utf-8")
@@ -101,6 +103,19 @@ def inject_css(show_hud: bool = False) -> None:
     load_theme(show_hud=show_hud)
 
 
+def _get_logo_markup(*, alt_text: str = "RexAI mission control logo") -> str:
+    logo_path = _static_path(_BRAND_LOGO_FILENAME)
+    data_uri = _encode_svg_base64(logo_path)
+    alt_attr = escape(alt_text) if alt_text else ""
+
+    if data_uri is None:
+        src = escape(str(logo_path))
+    else:
+        src = data_uri
+
+    return f"<img src='{src}' alt='{alt_attr}' />"
+
+
 def render_brand_header(
     tagline: str | None = "Interplanetary Recycling",
     *,
@@ -110,14 +125,7 @@ def render_brand_header(
 
     load_theme(show_hud=False)
 
-    logo_path = _static_path(_BRAND_LOGO_FILENAME)
-    data_uri = _encode_svg_base64(logo_path)
-    alt_attr = escape(alt_text) if alt_text else ""
-
-    if data_uri is None:
-        logo_markup = f"<img src='{escape(str(logo_path))}' alt='{alt_attr}' />"
-    else:
-        logo_markup = f"<img src='{data_uri}' alt='{alt_attr}' />"
+    logo_markup = _get_logo_markup(alt_text=alt_text)
 
     tagline_markup = ""
     if tagline:

--- a/tests/modules/test_ui_blocks.py
+++ b/tests/modules/test_ui_blocks.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import pytest
 
 
@@ -23,3 +25,37 @@ def test_pill_serialises_extended_tones(kind, expected_title):
     assert f"data-mission-pill='{kind}'" in html
     assert f"data-kind='{kind}'" in html
     assert f"title='{expected_title}'" in html
+
+
+def test_logo_markup_reuses_cached_svg(monkeypatch, tmp_path):
+    from app.modules import ui_blocks
+
+    svg_path = tmp_path / "logo.svg"
+    svg_path.write_text("<svg></svg>", encoding="utf-8")
+
+    original_static_path = ui_blocks._static_path
+
+    def fake_static_path(filename: str | Path) -> Path:
+        if Path(filename) == Path(ui_blocks._BRAND_LOGO_FILENAME):
+            return svg_path
+        return original_static_path(filename)
+
+    ui_blocks._encode_svg_base64.cache_clear()
+    monkeypatch.setattr(ui_blocks, "_static_path", fake_static_path)
+
+    read_count = 0
+    original_read_text = Path.read_text
+
+    def counting_read_text(self, *args, **kwargs):
+        nonlocal read_count
+        if self == svg_path:
+            read_count += 1
+        return original_read_text(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", counting_read_text)
+
+    first_markup = ui_blocks._get_logo_markup()
+    second_markup = ui_blocks._get_logo_markup()
+
+    assert first_markup == second_markup
+    assert read_count == 1


### PR DESCRIPTION
## Summary
- cache the SVG logo encoding so the data URI is reused across requests
- expose a reusable `_get_logo_markup` helper for the brand header markup
- add a regression test ensuring the logo file is read only once when reused

## Testing
- pytest tests/modules/test_ui_blocks.py

------
https://chatgpt.com/codex/tasks/task_e_68e031f022148331977e720a7c2c837a