### PR TITLE
Centralize material profile helpers

### DIFF
--- a/app/modules/schema.py
+++ b/app/modules/schema.py
@@ -1,4 +1,11 @@
-"""Shared schema constants for external reference columns."""
+"""Shared schema constants and helpers for material profile data."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+import pandas as pd
+
 
 POLYMER_SAMPLE_COLUMNS: tuple[str, ...] = (
     "pc_density_sample_label",
@@ -54,4 +61,44 @@ ALUMINIUM_LABEL_COLUMNS: tuple[str, ...] = (
     "aluminium_processing_route",
     "aluminium_class_id",
 )
+
+
+POLYMER_LABEL_MAP: dict[str, str] = {
+    "density_g_cm3": "ρ ref (g/cm³)",
+    "tensile_mpa": "σₜ ref (MPa)",
+    "modulus_gpa": "E ref (GPa)",
+    "glass_c": "Tg (°C)",
+    "ignition_c": "Ignición (°C)",
+    "burn_min": "Burn (min)",
+}
+
+ALUMINIUM_LABEL_MAP: dict[str, str] = {
+    "tensile_mpa": "σₜ ref (MPa)",
+    "yield_mpa": "σᵧ ref (MPa)",
+    "elongation_pct": "ε ref (%)",
+}
+
+
+def numeric_series(
+    df: pd.DataFrame | Mapping[str, object] | None, column: str
+) -> pd.Series:
+    """Return a cleaned numeric series for the requested ``column``.
+
+    The helper accepts either a :class:`pandas.DataFrame` or a mapping that
+    contains a DataFrame for the given key. Non-numeric entries are coerced and
+    missing values are dropped to simplify downstream visualisations.
+    """
+
+    if isinstance(df, Mapping):
+        candidate = df.get(column)
+        if isinstance(candidate, pd.DataFrame):
+            df = candidate
+        else:
+            return pd.Series(dtype=float)
+
+    if not isinstance(df, pd.DataFrame) or column not in df.columns:
+        return pd.Series(dtype=float)
+
+    series = pd.to_numeric(df[column], errors="coerce")
+    return series.dropna()
 

--- a/app/pages/3_Generator.py
+++ b/app/pages/3_Generator.py
@@ -25,9 +25,12 @@ from app.modules.process_planner import choose_process
 from app.modules.safety import check_safety, safety_badge
 from app.modules.schema import (
     ALUMINIUM_LABEL_COLUMNS,
+    ALUMINIUM_LABEL_MAP,
     ALUMINIUM_NUMERIC_COLUMNS,
     POLYMER_LABEL_COLUMNS,
+    POLYMER_LABEL_MAP,
     POLYMER_METRIC_COLUMNS,
+    numeric_series,
 )
 from app.modules.ui_blocks import (
     action_button,
@@ -74,22 +77,6 @@ TARGET_DISPLAY = {
     "water_l": "Agua (L)",
     "crew_min": "Crew (min)",
 }
-
-POLYMER_LABEL_MAP = {
-    "density_g_cm3": "ρ ref (g/cm³)",
-    "tensile_mpa": "σₜ ref (MPa)",
-    "modulus_gpa": "E ref (GPa)",
-    "glass_c": "Tg (°C)",
-    "ignition_c": "Ignición (°C)",
-    "burn_min": "Burn (min)",
-}
-
-ALUMINIUM_LABEL_MAP = {
-    "tensile_mpa": "σₜ ref (MPa)",
-    "yield_mpa": "σᵧ ref (MPa)",
-    "elongation_pct": "ε ref (%)",
-}
-
 
 @contextmanager
 def _optional_container_expander(
@@ -156,23 +143,6 @@ def _safe_float(value: object) -> float | None:
     if math.isnan(number):
         return None
     return number
-
-
-def _numeric_series(
-    df: pd.DataFrame | Mapping[str, object] | None, column: str
-) -> pd.Series:
-    if isinstance(df, Mapping):
-        candidate = df.get(column)
-        if isinstance(candidate, pd.DataFrame):
-            df = candidate
-        else:
-            return pd.Series([], dtype=float)
-
-    if not isinstance(df, pd.DataFrame) or column not in df.columns:
-        return pd.Series([], dtype=float)
-
-    series = pd.to_numeric(df[column], errors="coerce")
-    return series.dropna()
 
 
 def _format_number(value: object, precision: int = 2) -> str:
@@ -967,16 +937,16 @@ try:
 except MissingDatasetError as error:
     st.error(format_missing_dataset_message(error))
     st.stop()
-polymer_density_distribution = _numeric_series(
+polymer_density_distribution = numeric_series(
     waste_df, "pc_density_density_g_per_cm3"
 )
-polymer_tensile_distribution = _numeric_series(
+polymer_tensile_distribution = numeric_series(
     waste_df, "pc_mechanics_tensile_strength_mpa"
 )
-aluminium_tensile_distribution = _numeric_series(
+aluminium_tensile_distribution = numeric_series(
     waste_df, "aluminium_tensile_strength_mpa"
 )
-aluminium_yield_distribution = _numeric_series(
+aluminium_yield_distribution = numeric_series(
     waste_df, "aluminium_yield_strength_mpa"
 )
 proc_filtered = choose_process(

--- a/app/pages/4_Results_and_Tradeoffs.py
+++ b/app/pages/4_Results_and_Tradeoffs.py
@@ -2,8 +2,6 @@ from app.bootstrap import ensure_streamlit_entrypoint
 
 ensure_streamlit_entrypoint(__file__)
 
-from collections.abc import Mapping
-
 import altair as alt
 import pandas as pd
 import plotly.graph_objects as go
@@ -24,9 +22,12 @@ from app.modules.navigation import render_breadcrumbs, set_active_step
 from app.modules.page_data import build_candidate_metric_table, build_resource_table
 from app.modules.schema import (
     ALUMINIUM_LABEL_COLUMNS,
+    ALUMINIUM_LABEL_MAP,
     ALUMINIUM_NUMERIC_COLUMNS,
     POLYMER_LABEL_COLUMNS,
+    POLYMER_LABEL_MAP,
     POLYMER_METRIC_COLUMNS,
+    numeric_series,
 )
 from app.modules.ui_blocks import (
     initialise_frontend,
@@ -72,35 +73,16 @@ try:
 except MissingDatasetError as error:
     st.error(format_missing_dataset_message(error))
     st.stop()
-
-
-def _numeric_series(
-    df: pd.DataFrame | Mapping[str, object] | None, column: str
-) -> pd.Series:
-    if isinstance(df, Mapping):
-        candidate = df.get(column)
-        if isinstance(candidate, pd.DataFrame):
-            df = candidate
-        else:
-            return pd.Series(dtype=float)
-
-    if not isinstance(df, pd.DataFrame) or column not in df.columns:
-        return pd.Series(dtype=float)
-
-    series = pd.to_numeric(df[column], errors="coerce")
-    return series.dropna()
-
-
-polymer_density_distribution = _numeric_series(
+polymer_density_distribution = numeric_series(
     inventory_df, "pc_density_density_g_per_cm3"
 )
-polymer_tensile_distribution = _numeric_series(
+polymer_tensile_distribution = numeric_series(
     inventory_df, "pc_mechanics_tensile_strength_mpa"
 )
-aluminium_tensile_distribution = _numeric_series(
+aluminium_tensile_distribution = numeric_series(
     inventory_df, "aluminium_tensile_strength_mpa"
 )
-aluminium_yield_distribution = _numeric_series(
+aluminium_yield_distribution = numeric_series(
     inventory_df, "aluminium_yield_strength_mpa"
 )
 
@@ -113,24 +95,6 @@ def _get_value(source, attr, default=0.0):
     if isinstance(source, dict):
         return source.get(attr, default)
     return default
-
-
-POLYMER_LABEL_MAP = {
-    "density_g_cm3": "ρ ref (g/cm³)",
-    "tensile_mpa": "σₜ ref (MPa)",
-    "modulus_gpa": "E ref (GPa)",
-    "glass_c": "Tg (°C)",
-    "ignition_c": "Ignición (°C)",
-    "burn_min": "Burn (min)",
-}
-
-ALUMINIUM_LABEL_MAP = {
-    "tensile_mpa": "σₜ ref (MPa)",
-    "yield_mpa": "σᵧ ref (MPa)",
-    "elongation_pct": "ε ref (%)",
-}
-
-
 def _collect_external_profiles(candidate: dict, inventory: pd.DataFrame) -> dict[str, dict[str, object]]:
     if not isinstance(candidate, dict) or inventory.empty:
         return {}

--- a/tests/modules/test_material_profiles.py
+++ b/tests/modules/test_material_profiles.py
@@ -1,0 +1,52 @@
+import pandas as pd
+
+from app.modules import schema
+
+
+def test_numeric_series_from_dataframe_handles_non_numeric_values():
+    df = pd.DataFrame({"value": ["1", 2, None, "nan", "3.5"]})
+
+    series = schema.numeric_series(df, "value")
+
+    assert series.tolist() == [1.0, 2.0, 3.5]
+    assert series.dtype == float
+
+
+def test_numeric_series_from_mapping_extracts_dataframe():
+    df = pd.DataFrame({"value": ["10", " ", "8.5"]})
+
+    series = schema.numeric_series({"value": df}, "value")
+
+    assert series.tolist() == [10.0, 8.5]
+
+
+def test_numeric_series_missing_dataframe_returns_empty_series():
+    series = schema.numeric_series({}, "missing")
+
+    assert series.empty
+    assert series.dtype == float
+
+
+def test_polymer_label_map_contains_expected_labels():
+    expected = {
+        "density_g_cm3": "ρ ref (g/cm³)",
+        "tensile_mpa": "σₜ ref (MPa)",
+        "modulus_gpa": "E ref (GPa)",
+        "glass_c": "Tg (°C)",
+        "ignition_c": "Ignición (°C)",
+        "burn_min": "Burn (min)",
+    }
+
+    for key, value in expected.items():
+        assert schema.POLYMER_LABEL_MAP[key] == value
+
+
+def test_aluminium_label_map_contains_expected_labels():
+    expected = {
+        "tensile_mpa": "σₜ ref (MPa)",
+        "yield_mpa": "σᵧ ref (MPa)",
+        "elongation_pct": "ε ref (%)",
+    }
+
+    for key, value in expected.items():
+        assert schema.ALUMINIUM_LABEL_MAP[key] == value


### PR DESCRIPTION
## Summary
- move shared material label maps and numeric helper into app.modules.schema for reuse
- update generator and results pages to consume the shared helpers instead of local copies
- add unit tests covering numeric_series conversion behavior and centralized label maps

## Testing
- pytest tests/modules/test_material_profiles.py

------
https://chatgpt.com/codex/tasks/task_e_68e031f0aaec83318eda4d48c28aea50