### PR TITLE
Ensure frontend initialisation loads theme once

### DIFF
--- a/app/modules/mission_overview.py
+++ b/app/modules/mission_overview.py
@@ -355,13 +355,12 @@ def render_overview_dashboard(
     from app.modules.ml_models import get_model_registry
     from app.modules.navigation import render_breadcrumbs, render_stepper, set_active_step
     from app.modules.paths import DATA_ROOT
-    from app.modules.ui_blocks import initialise_frontend, load_theme, render_brand_header
+    from app.modules.ui_blocks import initialise_frontend, render_brand_header
 
     st.set_page_config(page_title="Mission Overview", page_icon="🛰️", layout="wide")
     initialise_frontend()
 
     current_step = set_active_step("home")
-    load_theme(show_hud=False)
     render_brand_header()
 
     render_breadcrumbs(current_step)

--- a/app/modules/ui_blocks.py
+++ b/app/modules/ui_blocks.py
@@ -88,8 +88,20 @@ def load_theme(*, show_hud: bool = True) -> None:
     st.session_state[_THEME_HASH_KEY] = css_hash
 
 
-def initialise_frontend() -> None:
-    """Prepare the visual styling for Streamlit pages."""
+def initialise_frontend(*, force: bool = False) -> None:
+    """Prepare the visual styling for Streamlit pages.
+
+    This helper ensures the shared theme is applied, so pages do not need to
+    call :func:`load_theme` immediately afterwards. When ``force`` is ``True``
+    the cached theme hash is cleared so the stylesheet is re-injected on the
+    next call.
+    """
+
+    if force:
+        try:
+            st.session_state.pop(_THEME_HASH_KEY, None)
+        except Exception:  # pragma: no cover - defensive guard for early init
+            pass
 
     load_theme()
     apply_global_visual_theme()

--- a/app/pages/2_Target_Designer.py
+++ b/app/pages/2_Target_Designer.py
@@ -7,15 +7,13 @@ import streamlit as st
 from app.modules.io import load_targets
 from app.modules.navigation import render_breadcrumbs, set_active_step
 from app.modules.target_limits import compute_target_limits
-from app.modules.ui_blocks import initialise_frontend, load_theme, render_brand_header
+from app.modules.ui_blocks import initialise_frontend, render_brand_header
 
 # ⚠️ Debe ser la PRIMERA llamada de Streamlit en la página
 st.set_page_config(page_title="Objetivo", page_icon="🎯", layout="wide")
 initialise_frontend()
 
 current_step = set_active_step("target")
-
-load_theme()
 
 render_brand_header()
 

--- a/app/pages/3_Generator.py
+++ b/app/pages/3_Generator.py
@@ -35,7 +35,6 @@ from app.modules.ui_blocks import (
     initialise_frontend,
     layout_block,
     layout_stack,
-    load_theme,
     micro_divider,
     pill,
     render_brand_header,
@@ -46,8 +45,6 @@ st.set_page_config(page_title="Rex-AI • Generador", page_icon="🤖", layout="
 initialise_frontend()
 
 current_step = set_active_step("generator")
-
-load_theme()
 
 render_brand_header()
 

--- a/app/pages/4_Results_and_Tradeoffs.py
+++ b/app/pages/4_Results_and_Tradeoffs.py
@@ -31,7 +31,6 @@ from app.modules.schema import (
 from app.modules.ui_blocks import (
     initialise_frontend,
     layout_block,
-    load_theme,
     render_brand_header,
 )
 
@@ -39,8 +38,6 @@ st.set_page_config(page_title="Rex-AI • Resultados", page_icon="📊", layout=
 initialise_frontend()
 
 current_step = set_active_step("results")
-
-load_theme()
 
 render_brand_header()
 

--- a/app/pages/5_Compare_and_Explain.py
+++ b/app/pages/5_Compare_and_Explain.py
@@ -18,7 +18,6 @@ from app.modules.io import (
 from app.modules.navigation import render_breadcrumbs, set_active_step
 from app.modules.ui_blocks import (
     initialise_frontend,
-    load_theme,
     pill,
     render_brand_header,
 )
@@ -188,8 +187,6 @@ def _format_reference_value(key: str, value: float) -> str:
 st.set_page_config(page_title="Comparar & Explicar", page_icon="🧪", layout="wide")
 initialise_frontend()
 current_step = set_active_step("compare")
-
-load_theme()
 
 render_brand_header()
 

--- a/app/pages/6_Pareto_and_Export.py
+++ b/app/pages/6_Pareto_and_Export.py
@@ -27,7 +27,6 @@ from app.modules.ui_blocks import (
     action_button,
     initialise_frontend,
     layout_stack,
-    load_theme,
     render_brand_header,
 )
 from app.modules.utils import safe_int
@@ -36,8 +35,6 @@ st.set_page_config(page_title="Pareto & Export", page_icon="📤", layout="wide"
 initialise_frontend()
 
 current_step = set_active_step("export")
-
-load_theme()
 
 render_brand_header()
 

--- a/app/pages/7_Scenario_Playbooks.py
+++ b/app/pages/7_Scenario_Playbooks.py
@@ -14,7 +14,6 @@ from app.modules.scenarios import PLAYBOOKS
 from app.modules.ui_blocks import (
     initialise_frontend,
     layout_stack,
-    load_theme,
     render_brand_header,
 )
 
@@ -22,8 +21,6 @@ st.set_page_config(page_title="Scenario Playbooks", page_icon="📚", layout="wi
 initialise_frontend()
 
 current_step = set_active_step("playbooks")
-
-load_theme()
 
 render_brand_header()
 

--- a/app/pages/8_Feedback_and_Impact.py
+++ b/app/pages/8_Feedback_and_Impact.py
@@ -24,7 +24,6 @@ from app.modules.page_data import build_feedback_summary_table
 from app.modules.ui_blocks import (
     initialise_frontend,
     layout_stack,
-    load_theme,
     render_brand_header,
 )
 from app.modules.utils import safe_int
@@ -33,8 +32,6 @@ st.set_page_config(page_title="Feedback & Impact", page_icon="📝", layout="wid
 initialise_frontend()
 
 current_step = set_active_step("feedback")
-
-load_theme()
 
 render_brand_header()
 

--- a/app/pages/9_Capacity_Simulator.py
+++ b/app/pages/9_Capacity_Simulator.py
@@ -12,7 +12,6 @@ from app.modules.navigation import render_breadcrumbs, set_active_step
 from app.modules.ui_blocks import (
     initialise_frontend,
     layout_stack,
-    load_theme,
     render_brand_header,
 )
 
@@ -20,8 +19,6 @@ st.set_page_config(page_title="Capacity Simulator", page_icon="🧮", layout="wi
 initialise_frontend()
 
 current_step = set_active_step("capacity")
-
-load_theme()
 
 render_brand_header()
 

--- a/tests/modules/test_ui_blocks.py
+++ b/tests/modules/test_ui_blocks.py
@@ -23,3 +23,25 @@ def test_pill_serialises_extended_tones(kind, expected_title):
     assert f"data-mission-pill='{kind}'" in html
     assert f"data-kind='{kind}'" in html
     assert f"title='{expected_title}'" in html
+
+
+def test_initialise_frontend_force_resets_theme_cache(monkeypatch):
+    from types import SimpleNamespace
+
+    from app.modules import ui_blocks
+
+    state = {ui_blocks._THEME_HASH_KEY: "cached"}
+    calls: list[str] = []
+
+    def fake_load_theme() -> None:
+        assert ui_blocks._THEME_HASH_KEY not in state
+        calls.append("load")
+
+    monkeypatch.setattr(ui_blocks, "load_theme", fake_load_theme)
+    monkeypatch.setattr(ui_blocks, "apply_global_visual_theme", lambda: None)
+    monkeypatch.setattr(ui_blocks, "st", SimpleNamespace(session_state=state))
+
+    ui_blocks.initialise_frontend(force=True)
+
+    assert calls == ["load"]
+    assert ui_blocks._THEME_HASH_KEY not in state


### PR DESCRIPTION
## Summary
- document that `initialise_frontend` applies the shared theme and add an optional `force` flag to clear the cached stylesheet
- remove redundant `load_theme` calls from the mission overview and each Streamlit page
- add a regression test to ensure the cached theme hash is cleared when forcing reinitialisation

## Testing
- pytest tests/modules/test_ui_blocks.py tests/test_paths.py


------
https://chatgpt.com/codex/tasks/task_e_68e031eed3ac8331ad3b849339aae8e5