### PR TITLE
Improve target designer guidance and summaries

### DIFF
--- a/app/pages/2_Target_Designer.py
+++ b/app/pages/2_Target_Designer.py
@@ -21,6 +21,16 @@ render_breadcrumbs(current_step)
 
 st.title("2) Definir objetivo (TargetSpec)")
 
+st.info(
+    "En esta misión podés elegir entre tres escenarios: **Residence Renovations** "
+    "(rehabilitar hábitats existentes), **Cosmic Celebrations** (montajes rápidos para"
+    " eventos especiales) y **Daring Discoveries** (expediciones de laboratorio)."
+    " Configurá la rigidez y la estanqueidad para alinear la ingeniería del producto "
+    "con cada reto, y fijá límites de agua, energía y minutos de tripulación para "
+    "asegurarte de que la receta resultante respete los recursos disponibles en la "
+    "estación."
+)
+
 presets = load_targets()
 if not presets:
     st.error("No se encontraron presets de objetivos. Verifica `data/targets_presets.json`.")
@@ -51,7 +61,18 @@ scenario = stored_target.get("scenario", default_scenario)
 if scenario not in scenario_options:
     scenario = default_scenario
 
-scenario = st.selectbox("Escenario del reto", scenario_options, index=scenario_options.index(scenario))
+scenario_descriptions = {
+    "Residence Renovations": "rehabilitar y ampliar espacios existentes a largo plazo",
+    "Cosmic Celebrations": "crear montajes efímeros y visuales para eventos orbitales",
+    "Daring Discoveries": "apoyar misiones científicas con prototipos ajustados",
+}
+
+scenario = st.selectbox(
+    "Escenario del reto",
+    scenario_options,
+    index=scenario_options.index(scenario),
+    help="Elegí el contexto operativo principal para adaptar los límites a su propósito específico.",
+)
 
 crew_time_low = st.checkbox(
     "Priorizar procesos de bajo tiempo de tripulación",
@@ -60,59 +81,80 @@ crew_time_low = st.checkbox(
 
 rigidity_bounds = slider_limits["rigidity"]
 rigidity_default = float(stored_target.get("rigidity", selected_preset.get("rigidity", 0.0)))
+rigidity_help = (
+    f"{rigidity_bounds['help']} Ejemplo: cascos modulares para `Residence Renovations`"
+    " requieren más rigidez que decoraciones temporales."
+)
 rigidity = st.slider(
-    "Rigidez deseada",
+    "Rigidez deseada (resistencia estructural)",
     rigidity_bounds["min"],
     rigidity_bounds["max"],
     min(max(rigidity_default, rigidity_bounds["min"]), rigidity_bounds["max"]),
     rigidity_bounds["step"],
-    help=rigidity_bounds["help"],
+    help=rigidity_help,
 )
 
 tightness_bounds = slider_limits["tightness"]
 tightness_default = float(stored_target.get("tightness", selected_preset.get("tightness", 0.0)))
+tightness_help = (
+    f"{tightness_bounds['help']} Ejemplo: cápsulas para `Daring Discoveries`"
+    " necesitan sellos herméticos, mientras que instalaciones festivas pueden"
+    " tolerar más fugas."
+)
 tightness = st.slider(
-    "Estanqueidad deseada",
+    "Estanqueidad deseada (control de fugas)",
     tightness_bounds["min"],
     tightness_bounds["max"],
     min(max(tightness_default, tightness_bounds["min"]), tightness_bounds["max"]),
     tightness_bounds["step"],
-    help=tightness_bounds["help"],
+    help=tightness_help,
 )
 
 water_bounds = slider_limits["max_water_l"]
 water_default = float(stored_target.get("max_water_l", selected_preset.get("max_water_l", 0.0)))
+water_help = (
+    f"{water_bounds['help']} Ejemplo: limpiar módulos habitables exige más agua que"
+    " ajustes decorativos en `Cosmic Celebrations`."
+)
 max_water = st.slider(
-    "Agua máxima (L)",
+    "Agua máxima permitida (L)",
     water_bounds["min"],
     water_bounds["max"],
     min(max(water_default, water_bounds["min"]), water_bounds["max"]),
     water_bounds["step"],
-    help=water_bounds["help"],
+    help=water_help,
 )
 
 energy_bounds = slider_limits["max_energy_kwh"]
 energy_default = float(
     stored_target.get("max_energy_kwh", selected_preset.get("max_energy_kwh", 0.0))
 )
+energy_help = (
+    f"{energy_bounds['help']} Ejemplo: experimentos de `Daring Discoveries`"
+    " consumen más energía que iluminación ambiente en `Cosmic Celebrations`."
+)
 max_energy = st.slider(
-    "Energía máxima (kWh)",
+    "Energía máxima asignada (kWh)",
     energy_bounds["min"],
     energy_bounds["max"],
     min(max(energy_default, energy_bounds["min"]), energy_bounds["max"]),
     energy_bounds["step"],
-    help=energy_bounds["help"],
+    help=energy_help,
 )
 
 crew_bounds = slider_limits["max_crew_min"]
 crew_default = float(stored_target.get("max_crew_min", selected_preset.get("max_crew_min", crew_bounds["min"])))
+crew_help = (
+    f"{crew_bounds['help']} Ejemplo: `Crew` significa minutos humanos disponibles;"
+    " tareas automatizadas en `Residence Renovations` reducen este valor."
+)
 max_crew = st.number_input(
-    "Tiempo máximo de tripulación (min)",
+    "Tiempo máximo de tripulación humana (min)",
     min_value=float(crew_bounds["min"]),
     max_value=float(crew_bounds["max"]),
     value=float(min(max(crew_default, crew_bounds["min"]), crew_bounds["max"])),
     step=float(crew_bounds["step"]),
-    help=crew_bounds["help"],
+    help=crew_help,
 )
 
 target = {
@@ -132,7 +174,7 @@ st.session_state["target"] = target
 summary_cols = st.columns(3)
 summary_cols[0].metric("Rigidez", f"{rigidity:.2f}")
 summary_cols[1].metric("Estanqueidad", f"{tightness:.2f}")
-summary_cols[2].metric("Crew (min)", f"{max_crew:.0f}")
+summary_cols[2].metric("Tiempo de tripulación (min)", f"{max_crew:.0f}")
 
 st.caption("Límites de recursos establecidos")
 limits_table = {
@@ -140,5 +182,16 @@ limits_table = {
     "Máximo": [f"{max_water:.2f}", f"{max_energy:.2f}"],
 }
 st.table(limits_table)
+
+crew_focus_text = "priorizar procesos rápidos" if crew_time_low else "permitir procesos con más supervisión"
+scenario_text = scenario_descriptions.get(scenario, scenario.lower())
+st.markdown(
+    "**Resumen narrativo:** Configuraste el objetivo para "
+    f"**{scenario}**, enfocado en {scenario_text}. La receta deberá respetar una "
+    f"rigidez de {rigidity:.2f} (protege la estructura), una estanqueidad de {tightness:.2f} "
+    "(evita fugas críticas) y usar hasta "
+    f"{max_water:.2f} L de agua y {max_energy:.2f} kWh de energía. También indicaste "
+    f"{crew_focus_text}, con un máximo de {max_crew:.0f} minutos humanos disponibles."
+)
 
 st.success("Objetivo listo. Abrí la página **3) Generador** para obtener recetas.")


### PR DESCRIPTION
## Summary
- add an introductory panel that contextualises the three mission escenarios and los límites clave
- enrich slider labels and help texts with practical examples and clarify el significado de Crew
- provide a narrative summary of the selected target so non-experts understand su impacto

## Testing
- python -m compileall app/pages/2_Target_Designer.py

------
https://chatgpt.com/codex/tasks/task_e_68e0373411048331b172c9eda6b5b4f4