### PR TITLE
Cache CSS bundle for UI theme and clear on forced init

### DIFF
--- a/app/modules/ui_blocks.py
+++ b/app/modules/ui_blocks.py
@@ -67,6 +67,7 @@ def _base_css_path() -> Path:
     return _static_path(Path("styles") / "base.css")
 
 
+@lru_cache(maxsize=1)
 def _read_css_bundle() -> str:
     try:
         return _base_css_path().read_text(encoding="utf-8")
@@ -103,6 +104,11 @@ def initialise_frontend(*, force: bool = False) -> None:
         try:
             st.session_state.pop(_THEME_HASH_KEY, None)
         except Exception:  # pragma: no cover - defensive guard for early init
+            pass
+
+        try:
+            _read_css_bundle.cache_clear()
+        except AttributeError:  # pragma: no cover - safeguard if decorator removed
             pass
 
     load_theme()


### PR DESCRIPTION
## Summary
- cache the base CSS bundle to avoid repeated disk reads when injecting the theme
- clear both the theme hash and cached CSS when forcing frontend initialisation

## Testing
- streamlit run app/Home.py

------
https://chatgpt.com/codex/tasks/task_e_68e0458f0d84833187122432f948bad3