### PR TITLE
Improve Streamlit theming consistency on first render

### DIFF
--- a/app/modules/mission_overview.py
+++ b/app/modules/mission_overview.py
@@ -355,9 +355,13 @@ def render_overview_dashboard(
     from app.modules.ml_models import get_model_registry
     from app.modules.navigation import render_breadcrumbs, render_stepper, set_active_step
     from app.modules.paths import DATA_ROOT
-    from app.modules.ui_blocks import initialise_frontend, render_brand_header
+    from app.modules.ui_blocks import (
+        configure_page,
+        initialise_frontend,
+        render_brand_header,
+    )
 
-    st.set_page_config(page_title="Mission Overview", page_icon="🛰️", layout="wide")
+    configure_page(page_title="Mission Overview", page_icon="🛰️")
     initialise_frontend()
 
     current_step = set_active_step("home")

--- a/app/modules/ui_blocks.py
+++ b/app/modules/ui_blocks.py
@@ -43,6 +43,14 @@ _LAYOUT_STYLE_MAP: dict[str, str] = {
     "fade-in": "",
     "fade-in-delayed": "",
 }
+
+_PAGE_THEME: dict[str, str] = {
+    "primaryColor": "#0B3D91",
+    "backgroundColor": "#F5F7FA",
+    "secondaryBackgroundColor": "#FFFFFF",
+    "textColor": "#0B1526",
+    "font": "Source Sans 3",
+}
 _THEME_HASH_KEY = "__rexai_theme_hash__"
 
 _BRAND_LOGO_FILENAME = "logo_rexai.svg"
@@ -73,6 +81,26 @@ def _read_css_bundle() -> str:
         return _base_css_path().read_text(encoding="utf-8")
     except FileNotFoundError:
         return ""
+
+
+def configure_page(
+    *,
+    page_title: str,
+    page_icon: str | None = None,
+    layout: Literal["centered", "wide"] = "wide",
+    initial_sidebar_state: Literal["auto", "expanded", "collapsed"] = "collapsed",
+    menu_items: Mapping[str, str] | None = None,
+) -> None:
+    """Apply shared Streamlit page configuration with the mission theme."""
+
+    st.set_page_config(
+        page_title=page_title,
+        page_icon=page_icon,
+        layout=layout,
+        initial_sidebar_state=initial_sidebar_state,
+        menu_items=menu_items,
+        theme=_PAGE_THEME,
+    )
 
 
 def load_theme(*, show_hud: bool = True) -> None:
@@ -131,7 +159,8 @@ def _get_logo_markup(*, alt_text: str = "RexAI mission control logo") -> str:
     else:
         src = data_uri
 
-    return f"<img src='{src}' alt='{alt_attr}' />"
+    image_style = "display:block; width:100%; height:auto; max-width:100%;"
+    return f'<img src="{src}" alt="{alt_attr}" style="{image_style}" />'
 
 
 def render_brand_header(
@@ -143,17 +172,41 @@ def render_brand_header(
 
     load_theme(show_hud=False)
 
+    container_style = (
+        "display:flex; flex-direction:column; align-items:center; justify-content:center; "
+        "gap: var(--mission-space-2xs, 0.25rem); text-align:center; "
+        "width: var(--mission-brand-width, clamp(108px, 12vw, 156px)); "
+        "margin: var(--mission-space-lg, 1.5rem) auto; padding: 0; "
+        "color: var(--mission-color-text, #0B1526);"
+    )
+    logo_container_style = (
+        "width:100%; display:flex; align-items:center; justify-content:center; "
+        "gap: var(--mission-space-sm, 0.75rem); text-align:center; "
+        "margin: 0; padding: var(--mission-space-md, 1rem) var(--mission-space-lg, 1.5rem); "
+        "background: var(--mission-color-text, #0B1526); border-radius: var(--mission-radius-md, 0.5rem); "
+        "border: 1px solid rgba(255, 255, 255, 0.08); "
+        "box-shadow: 0 12px 28px rgba(11, 21, 38, 0.28); "
+        "color: var(--mission-color-surface, #FFFFFF);"
+    )
+    tagline_style = (
+        "display:block; width: min(180px, 45vw); margin: var(--mission-space-2xs, 0.25rem) auto 0; "
+        "font-size: 0.82rem; font-weight: 600; letter-spacing: 0.16em; text-transform: uppercase; "
+        "color: var(--mission-color-surface, #FFFFFF); opacity: 0.9; "
+        "filter: drop-shadow(0 6px 18px rgba(0, 0, 0, 0.35));"
+    )
+
     logo_markup = _get_logo_markup(alt_text=alt_text)
 
     tagline_markup = ""
     if tagline:
         tagline_markup = (
-            f"<p class='mission-brand-header__tagline'>{escape(tagline)}</p>"
+            "<p class='mission-brand-header__tagline' "
+            f"style='{tagline_style}'>{escape(tagline)}</p>"
         )
 
     markup = (
-        "<div class='mission-brand-header'>"
-        "<div class='mission-brand-header__logo'>"
+        f"<div class='mission-brand-header' style='{container_style}'>"
+        f"<div class='mission-brand-header__logo' style='{logo_container_style}'>"
         f"{logo_markup}"
         "</div>"
         f"{tagline_markup}"

--- a/app/pages/2_Target_Designer.py
+++ b/app/pages/2_Target_Designer.py
@@ -16,10 +16,14 @@ import streamlit as st
 from app.modules.io import load_targets
 from app.modules.navigation import render_breadcrumbs, set_active_step
 from app.modules.target_limits import compute_target_limits
-from app.modules.ui_blocks import initialise_frontend, render_brand_header
+from app.modules.ui_blocks import (
+    configure_page,
+    initialise_frontend,
+    render_brand_header,
+)
 
 # ⚠️ Debe ser la PRIMERA llamada de Streamlit en la página
-st.set_page_config(page_title="Objetivo", page_icon="🎯", layout="wide")
+configure_page(page_title="Objetivo", page_icon="🎯")
 initialise_frontend()
 
 current_step = set_active_step("target")

--- a/app/pages/3_Generator.py
+++ b/app/pages/3_Generator.py
@@ -43,6 +43,7 @@ from app.modules.schema import (
 )
 from app.modules.ui_blocks import (
     action_button,
+    configure_page,
     chipline,
     initialise_frontend,
     layout_block,
@@ -53,7 +54,7 @@ from app.modules.ui_blocks import (
 )
 from app.modules.visualizations import ConvergenceScene
 
-st.set_page_config(page_title="Rex-AI • Generador", page_icon="🤖", layout="wide")
+configure_page(page_title="Rex-AI • Generador", page_icon="🤖")
 initialise_frontend()
 
 current_step = set_active_step("generator")

--- a/app/pages/4_Results_and_Tradeoffs.py
+++ b/app/pages/4_Results_and_Tradeoffs.py
@@ -39,12 +39,13 @@ from app.modules.schema import (
     numeric_series,
 )
 from app.modules.ui_blocks import (
+    configure_page,
     initialise_frontend,
     layout_block,
     render_brand_header,
 )
 
-st.set_page_config(page_title="Rex-AI • Resultados", page_icon="📊", layout="wide")
+configure_page(page_title="Rex-AI • Resultados", page_icon="📊")
 initialise_frontend()
 
 current_step = set_active_step("results")

--- a/app/pages/5_Compare_and_Explain.py
+++ b/app/pages/5_Compare_and_Explain.py
@@ -26,6 +26,7 @@ from app.modules.io import (
 )
 from app.modules.navigation import render_breadcrumbs, set_active_step
 from app.modules.ui_blocks import (
+    configure_page,
     initialise_frontend,
     pill,
     render_brand_header,
@@ -193,7 +194,7 @@ def _format_reference_value(key: str, value: float) -> str:
 
 
 # ⚠️ Debe ser la PRIMERA llamada de Streamlit en la página
-st.set_page_config(page_title="Comparar & Explicar", page_icon="🧪", layout="wide")
+configure_page(page_title="Comparar & Explicar", page_icon="🧪")
 initialise_frontend()
 current_step = set_active_step("compare")
 

--- a/app/pages/6_Pareto_and_Export.py
+++ b/app/pages/6_Pareto_and_Export.py
@@ -34,13 +34,14 @@ from app.modules.page_data import (
 from app.modules.safety import check_safety, safety_badge
 from app.modules.ui_blocks import (
     action_button,
+    configure_page,
     initialise_frontend,
     layout_stack,
     render_brand_header,
 )
 from app.modules.utils import safe_int
 
-st.set_page_config(page_title="Pareto & Export", page_icon="📤", layout="wide")
+configure_page(page_title="Pareto & Export", page_icon="📤")
 initialise_frontend()
 
 current_step = set_active_step("export")

--- a/app/pages/7_Scenario_Playbooks.py
+++ b/app/pages/7_Scenario_Playbooks.py
@@ -21,12 +21,13 @@ import streamlit as st
 from app.modules.navigation import render_breadcrumbs, set_active_step
 from app.modules.scenarios import PLAYBOOKS
 from app.modules.ui_blocks import (
+    configure_page,
     initialise_frontend,
     layout_stack,
     render_brand_header,
 )
 
-st.set_page_config(page_title="Scenario Playbooks", page_icon="📚", layout="wide")
+configure_page(page_title="Scenario Playbooks", page_icon="📚")
 initialise_frontend()
 
 current_step = set_active_step("playbooks")

--- a/app/pages/8_Feedback_and_Impact.py
+++ b/app/pages/8_Feedback_and_Impact.py
@@ -31,13 +31,14 @@ from app.modules.impact import (
 from app.modules.navigation import render_breadcrumbs, set_active_step
 from app.modules.page_data import build_feedback_summary_table
 from app.modules.ui_blocks import (
+    configure_page,
     initialise_frontend,
     layout_stack,
     render_brand_header,
 )
 from app.modules.utils import safe_int
 
-st.set_page_config(page_title="Feedback & Impact", page_icon="📝", layout="wide")
+configure_page(page_title="Feedback & Impact", page_icon="📝")
 initialise_frontend()
 
 current_step = set_active_step("feedback")

--- a/app/pages/9_Capacity_Simulator.py
+++ b/app/pages/9_Capacity_Simulator.py
@@ -19,12 +19,13 @@ import streamlit as st
 from app.modules.capacity import LineConfig, simulate
 from app.modules.navigation import render_breadcrumbs, set_active_step
 from app.modules.ui_blocks import (
+    configure_page,
     initialise_frontend,
     layout_stack,
     render_brand_header,
 )
 
-st.set_page_config(page_title="Capacity Simulator", page_icon="🧮", layout="wide")
+configure_page(page_title="Capacity Simulator", page_icon="🧮")
 initialise_frontend()
 
 current_step = set_active_step("capacity")

--- a/tests/modules/test_ui_blocks.py
+++ b/tests/modules/test_ui_blocks.py
@@ -27,6 +27,31 @@ def test_pill_serialises_extended_tones(kind, expected_title):
     assert f"title='{expected_title}'" in html
 
 
+def test_configure_page_applies_theme_defaults(monkeypatch):
+    from types import SimpleNamespace
+
+    from app.modules import ui_blocks
+
+    captured: dict[str, object] = {}
+
+    def fake_set_page_config(**kwargs):
+        captured.update(kwargs)
+
+    monkeypatch.setattr(
+        ui_blocks,
+        "st",
+        SimpleNamespace(set_page_config=fake_set_page_config),
+    )
+
+    ui_blocks.configure_page(page_title="Demo", page_icon="🚀")
+
+    assert captured["page_title"] == "Demo"
+    assert captured["page_icon"] == "🚀"
+    assert captured["layout"] == "wide"
+    assert captured["initial_sidebar_state"] == "collapsed"
+    assert captured["theme"] == ui_blocks._PAGE_THEME
+
+
 def test_initialise_frontend_force_resets_theme_cache(monkeypatch):
     from types import SimpleNamespace
 


### PR DESCRIPTION
## Summary
- add a shared `configure_page` helper that applies the RexAI theme and inline fallbacks for the brand header so visuals are stable on first render
- switch every Streamlit entrypoint to the new helper to avoid duplicate page-config code and keep the logo sized correctly from the start
- cover the helper with a unit test to ensure the shared theme options remain in place

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e0431b9ae08331a8efe99509a0a606