### PR TITLE
Handle Streamlit theme configuration compatibility

### DIFF
--- a/app/modules/ui_blocks.py
+++ b/app/modules/ui_blocks.py
@@ -93,14 +93,21 @@ def configure_page(
 ) -> None:
     """Apply shared Streamlit page configuration with the mission theme."""
 
-    st.set_page_config(
-        page_title=page_title,
-        page_icon=page_icon,
-        layout=layout,
-        initial_sidebar_state=initial_sidebar_state,
-        menu_items=menu_items,
-        theme=_PAGE_THEME,
-    )
+    page_config: dict[str, Any] = {
+        "page_title": page_title,
+        "page_icon": page_icon,
+        "layout": layout,
+        "initial_sidebar_state": initial_sidebar_state,
+        "menu_items": menu_items,
+    }
+
+    try:
+        st.set_page_config(**page_config, theme=_PAGE_THEME)
+    except TypeError:
+        # Streamlit versions prior to 1.38 do not accept a ``theme`` keyword.
+        # Falling back to the base configuration avoids a hard crash while the
+        # visual styling is applied via :func:`initialise_frontend`.
+        st.set_page_config(**page_config)
 
 
 def load_theme(*, show_hud: bool = True) -> None:


### PR DESCRIPTION
## Summary
- adjust the shared page configuration helper to tolerate Streamlit versions that lack the theme keyword argument
- retain the mission control theming by falling back to the existing CSS-based initialisation when necessary

## Testing
- pytest -q *(fails: streamlit.testing import unavailable in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e04b50462083319d02f29183c589ea