### PR TITLE
Fix mission header tagline contrast

### DIFF
--- a/app/modules/ui_blocks.py
+++ b/app/modules/ui_blocks.py
@@ -198,8 +198,7 @@ def render_brand_header(
     tagline_style = (
         "display:block; width: min(180px, 45vw); margin: var(--mission-space-2xs, 0.25rem) auto 0; "
         "font-size: 0.82rem; font-weight: 600; letter-spacing: 0.16em; text-transform: uppercase; "
-        "color: var(--mission-color-surface, #FFFFFF); opacity: 0.9; "
-        "filter: drop-shadow(0 6px 18px rgba(0, 0, 0, 0.35));"
+        "opacity: 0.9; filter: drop-shadow(0 6px 18px rgba(0, 0, 0, 0.35));"
     )
 
     logo_markup = _get_logo_markup(alt_text=alt_text)

--- a/app/static/styles/base.css
+++ b/app/static/styles/base.css
@@ -225,27 +225,15 @@ table {
 
 .mission-brand-header__tagline {
   display: block;
-  width: 100%;
-  margin: var(--mission-space-2xs) auto 0;
-  font-size: 0.68rem;
-  font-weight: 600;
-  letter-spacing: 0.18em;
-  text-transform: uppercase;
-  color: var(--mission-color-muted);
   width: min(180px, 45vw);
-  height: auto;
-  margin: 0;
-  filter: drop-shadow(0 6px 18px rgba(0, 0, 0, 0.35));
-}
-
-.mission-brand-header__tagline {
-  margin: var(--mission-space-2xs) 0 0;
+  margin: var(--mission-space-2xs) auto 0;
   font-size: 0.82rem;
   font-weight: 600;
   letter-spacing: 0.16em;
   text-transform: uppercase;
-  color: var(--mission-color-surface);
+  color: var(--mission-color-muted);
   opacity: 0.9;
+  filter: drop-shadow(0 6px 18px rgba(0, 0, 0, 0.35));
 }
 
 :focus-visible {


### PR DESCRIPTION
## Summary
- deduplicate the mission header tagline styles so it inherits the muted text token
- remove the inline tagline color in the Streamlit block to defer to the shared CSS palette

## Testing
- streamlit run app/Home.py --server.headless true --server.port 8501


------
https://chatgpt.com/codex/tasks/task_e_68e04cdfb8c88331a095cdfdef68dcb9