### PR TITLE
Adjust warn pill contrast for accessibility

### DIFF
--- a/app/static/styles/base.css
+++ b/app/static/styles/base.css
@@ -17,7 +17,7 @@
   --mission-color-accent-soft: #4d6fb8;
   --mission-color-positive: #19624d;
   --mission-color-positive-soft: #c7e5d9;
-  --mission-color-warning: #b35c1a;
+  --mission-color-warning: #944109;
   --mission-color-warning-soft: #f2dfcd;
   --mission-color-critical: #8c2f3a;
   --mission-color-critical-soft: #f2d3da;


### PR DESCRIPTION
## Summary
- darken the mission warning color token so the warn status pill reaches AA contrast against its soft background

## Testing
- python - <<'PY' ... (contrast calculation)
- streamlit run /tmp/warn_pill_demo.py --server.port 8502 --server.address 0.0.0.0

------
https://chatgpt.com/codex/tasks/task_e_68e05025d7488331b9e532a8595836db