### PR TITLE
Improve UI contrast for mission control surfaces

### DIFF
--- a/app/pages/3_Generator.py
+++ b/app/pages/3_Generator.py
@@ -293,7 +293,7 @@ def _render_reference_distribution(
     histogram_color: str,
     reference_color: str,
     empty_message: str,
-    opacity: float = 0.55,
+    opacity: float = 0.85,
 ) -> None:
     if series.empty:
         st.info(empty_message)

--- a/app/pages/4_Results_and_Tradeoffs.py
+++ b/app/pages/4_Results_and_Tradeoffs.py
@@ -310,7 +310,7 @@ if external_profiles:
             elif density_value:
                 base = alt.Chart(
                     pd.DataFrame({"density": polymer_density_distribution})
-                ).mark_bar(color="#22d3ee", opacity=0.55).encode(
+                ).mark_bar(color="#22d3ee", opacity=0.85).encode(
                     x=alt.X("density:Q", bin=alt.Bin(maxbins=18), title="Densidad inventario (g/cm³)"),
                     y=alt.Y("count()", title="Ítems"),
                 )
@@ -326,7 +326,7 @@ if external_profiles:
             elif tensile_value:
                 base = alt.Chart(
                     pd.DataFrame({"tensile": polymer_tensile_distribution})
-                ).mark_bar(color="#f472b6", opacity=0.55).encode(
+                ).mark_bar(color="#f472b6", opacity=0.85).encode(
                     x=alt.X("tensile:Q", bin=alt.Bin(maxbins=18), title="σₜ inventario (MPa)"),
                     y=alt.Y("count()", title="Ítems"),
                 )
@@ -361,7 +361,7 @@ if external_profiles:
             elif tensile_value:
                 base = alt.Chart(
                     pd.DataFrame({"tensile": aluminium_tensile_distribution})
-                ).mark_bar(color="#f97316", opacity=0.55).encode(
+                ).mark_bar(color="#f97316", opacity=0.85).encode(
                     x=alt.X("tensile:Q", bin=alt.Bin(maxbins=18), title="σₜ inventario (MPa)"),
                     y=alt.Y("count()", title="Ítems"),
                 )
@@ -377,7 +377,7 @@ if external_profiles:
             elif yield_value:
                 base = alt.Chart(
                     pd.DataFrame({"yield_strength": aluminium_yield_distribution})
-                ).mark_bar(color="#fb923c", opacity=0.55).encode(
+                ).mark_bar(color="#fb923c", opacity=0.85).encode(
                     x=alt.X("yield_strength:Q", bin=alt.Bin(maxbins=18), title="σᵧ inventario (MPa)"),
                     y=alt.Y("count()", title="Ítems"),
                 )
@@ -519,7 +519,7 @@ with st.expander("🛰️ Contexto y trazabilidad", expanded=True):
                 if not others_curve.empty:
                     base_chart = (
                         alt.Chart(others_curve)
-                        .mark_line(color="#64748b", opacity=0.35)
+                        .mark_line(color="#94a3b8", opacity=0.7)
                         .encode(
                             x=alt.X("wavelength_nm:Q", title="Longitud de onda (nm)"),
                             y=alt.Y("reflectance:Q", title="Reflectancia"),

--- a/app/static/styles/base.css
+++ b/app/static/styles/base.css
@@ -109,6 +109,116 @@ button,
 .stButton > button,
 button[kind="secondary"] {
   border-radius: var(--mission-radius-md);
+  border: var(--mission-line-weight) solid var(--mission-color-accent);
+  background-color: var(--mission-color-accent);
+  color: var(--mission-color-surface);
+  font-weight: 600;
+  padding: 0.65rem 1.25rem;
+  box-shadow: 0 2px 6px rgba(11, 61, 145, 0.25);
+  transition: background-color 0.18s ease, border-color 0.18s ease, color 0.18s ease,
+    box-shadow 0.18s ease;
+}
+
+button:hover,
+.stButton > button:hover,
+button[kind="secondary"]:hover,
+button:focus-visible,
+.stButton > button:focus-visible,
+button[kind="secondary"]:focus-visible {
+  background-color: var(--mission-color-accent-soft);
+  border-color: var(--mission-color-accent-soft);
+  color: var(--mission-color-surface);
+}
+
+button:focus-visible,
+.stButton > button:focus-visible,
+button[kind="secondary"]:focus-visible {
+  outline: 3px solid var(--mission-color-accent-soft);
+  outline-offset: 2px;
+  box-shadow: 0 0 0 3px rgba(11, 61, 145, 0.2);
+}
+
+button:disabled,
+.stButton > button:disabled,
+button[kind="secondary"]:disabled {
+  background-color: var(--mission-color-border);
+  border-color: var(--mission-color-border-strong);
+  color: var(--mission-color-muted);
+  box-shadow: none;
+  cursor: not-allowed;
+  opacity: 1;
+}
+
+button[kind="secondary"] {
+  background-color: var(--mission-color-surface);
+  border-color: var(--mission-color-border-strong);
+  color: var(--mission-color-text);
+  box-shadow: none;
+}
+
+button[kind="secondary"]:hover,
+button[kind="secondary"]:focus-visible {
+  background-color: var(--mission-color-panel);
+  border-color: var(--mission-color-border-strong);
+  color: var(--mission-color-text);
+}
+
+button[kind="secondary"]:disabled {
+  background-color: var(--mission-color-panel);
+  color: var(--mission-color-muted);
+}
+
+input,
+textarea,
+select,
+.stTextInput input,
+.stTextArea textarea,
+.stNumberInput input,
+.stDateInput input,
+.stTimeInput input,
+.stSelectbox [data-baseweb="select"] > div,
+.stMultiSelect [data-baseweb="select"] > div,
+[data-baseweb="input"] input {
+  color: var(--mission-color-text);
+  background-color: var(--mission-color-surface);
+  border: var(--mission-line-weight) solid var(--mission-color-border-strong);
+  border-radius: var(--mission-radius-md);
+  box-shadow: none;
+  transition: border-color 0.18s ease, box-shadow 0.18s ease;
+}
+
+input:focus,
+textarea:focus,
+select:focus,
+.stTextInput input:focus,
+.stTextArea textarea:focus,
+.stNumberInput input:focus,
+.stDateInput input:focus,
+.stTimeInput input:focus,
+.stSelectbox [data-baseweb="select"] > div:focus,
+.stSelectbox [data-baseweb="select"] > div:focus-within,
+.stMultiSelect [data-baseweb="select"] > div:focus,
+.stMultiSelect [data-baseweb="select"] > div:focus-within,
+[data-baseweb="input"] input:focus {
+  border-color: var(--mission-color-accent);
+  box-shadow: 0 0 0 3px rgba(11, 61, 145, 0.18);
+  outline: none;
+}
+
+input::placeholder,
+textarea::placeholder {
+  color: var(--mission-color-muted);
+  opacity: 1;
+}
+
+[data-testid="stAlert"] {
+  border: var(--mission-line-weight) solid var(--mission-color-border-strong);
+  background-color: var(--mission-color-surface);
+  color: var(--mission-color-text);
+}
+
+[data-testid="stAlert"] p {
+  color: inherit;
 }
 
 hr {


### PR DESCRIPTION
## Summary
- style Streamlit buttons, inputs, and alerts with high-contrast NASA-inspired tokens for readability
- increase opacity on generator and results histograms and VNIR overlays so chart data stands out
- raise default distribution opacity to keep comparison guides visible across the app

## Testing
- streamlit run app/Home.py --server.headless true --server.port=8501 --browser.serverAddress=0.0.0.0

------
https://chatgpt.com/codex/tasks/task_e_68e0548d10508331a1f261c74ab01280