### PR TITLE
Decouple IO dataset guards and add regression tests

### DIFF
--- a/tests/test_io_module.py
+++ b/tests/test_io_module.py
@@ -1,0 +1,43 @@
+"""Tests covering high level IO helpers for NASA datasets."""
+
+from __future__ import annotations
+
+import json
+
+from app.modules import io
+
+
+def test_load_process_df_only_requires_process_dataset(tmp_path, monkeypatch):
+    process_path = tmp_path / "process_catalog.csv"
+    process_path.write_text("id,name\nP1,Demo\n", encoding="utf-8")
+
+    monkeypatch.setattr(io, "PROC_CSV", process_path)
+    monkeypatch.setattr(io, "WASTE_CSV", tmp_path / "waste_inventory_sample.csv")
+    monkeypatch.setattr(io, "TARGETS_JSON", tmp_path / "targets_presets.json")
+
+    io.invalidate_all_io_caches()
+
+    frame = io.load_process_df()
+
+    assert list(frame.columns) == ["id", "name"]
+    assert frame.iloc[0]["id"] == "P1"
+    assert frame.iloc[0]["name"] == "Demo"
+
+    io.invalidate_all_io_caches()
+
+
+def test_load_targets_only_requires_targets_dataset(tmp_path, monkeypatch):
+    targets_path = tmp_path / "targets_presets.json"
+    targets_path.write_text(json.dumps([{"id": "alpha"}]), encoding="utf-8")
+
+    monkeypatch.setattr(io, "TARGETS_JSON", targets_path)
+    monkeypatch.setattr(io, "WASTE_CSV", tmp_path / "waste_inventory_sample.csv")
+    monkeypatch.setattr(io, "PROC_CSV", tmp_path / "process_catalog.csv")
+
+    io.invalidate_all_io_caches()
+
+    payload = io.load_targets()
+
+    assert payload == [{"id": "alpha"}]
+
+    io.invalidate_all_io_caches()


### PR DESCRIPTION
## Summary
- replace the shared `_ensure_exists` check with dataset-specific helpers in `app/modules/io.py`
- update the cached waste, process, and target loaders to rely on the new guards and surface clearer missing-dataset errors
- add IO regression tests to ensure `load_process_df` and `load_targets` succeed when unrelated datasets are absent

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'streamlit.testing'; 'streamlit' is not a package)*

------
https://chatgpt.com/codex/tasks/task_e_68e05947422083318584976094103c13