### PR TITLE
Add environment overrides for data and model directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,16 @@ streamlit run app/Home.py
 ```
 
 No se requieren variables de entorno adicionales para el arranque interactivo.
+Sin embargo, podés personalizar dónde se buscan los artefactos de datos y
+modelos exportando las siguientes variables antes de ejecutar cualquier
+entrypoint:
+
+- `REXAI_DATA_ROOT`: raíz alternativa que reemplaza a `data/` como punto de
+  partida para datasets curados, logs y archivos "gold". Se admite tanto rutas
+  absolutas como relativas o con `~`; siempre se normalizan a un path absoluto.
+- `REXAI_MODELS_DIR`: ubicación explícita para los bundles de modelos. Si no se
+  define, por defecto se usa `<DATA_ROOT>/models`, aprovechando el valor
+  resultante de `REXAI_DATA_ROOT` cuando está presente.
 
 > ⚙️ **Bootstrap obligatorio:** antes de cualquier `import app.*`, cada entrypoint
 > de Streamlit (incluyendo los módulos dentro de `app/pages/`) debe llamar a

--- a/app/modules/paths.py
+++ b/app/modules/paths.py
@@ -2,17 +2,47 @@
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 
+_ENV_DATA_ROOT = "REXAI_DATA_ROOT"
+_ENV_MODELS_DIR = "REXAI_MODELS_DIR"
+
 _REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _normalise_path(value: str | Path) -> Path:
+    """Return an absolute ``Path`` while being forgiving with inputs."""
+
+    candidate = Path(value).expanduser()
+    try:
+        return candidate.resolve()
+    except RuntimeError:
+        # ``resolve`` can raise on recursive symlinks; fall back to ``absolute``.
+        return candidate.absolute()
+
+
+def _path_from_env(var_name: str, default: Path) -> Path:
+    """Load ``var_name`` from the environment, normalising it when available."""
+
+    raw_value = os.environ.get(var_name)
+    if raw_value is None:
+        return default
+
+    stripped = raw_value.strip()
+    if not stripped:
+        return default
+
+    return _normalise_path(stripped)
+
 
 # Shared data locations -----------------------------------------------------
 
-DATA_ROOT = _REPO_ROOT / "data"
+DATA_ROOT = _path_from_env(_ENV_DATA_ROOT, _normalise_path(_REPO_ROOT / "data"))
 """Directory containing curated datasets and generated artifacts."""
 
-MODELS_DIR = DATA_ROOT / "models"
+MODELS_DIR = _path_from_env(_ENV_MODELS_DIR, DATA_ROOT / "models")
 """Directory storing trained model bundles shipped with the app."""
 
 LOGS_DIR = DATA_ROOT / "logs"

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -1,15 +1,44 @@
 from __future__ import annotations
 
+import importlib
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
 from app.modules import paths, ui_blocks
 
 
-def test_path_constants_align_with_repository_structure() -> None:
+@pytest.fixture
+def reload_paths(monkeypatch):
+    """Reload ``app.modules.paths`` after adjusting environment variables."""
+
+    def _reload(**env: str) -> ModuleType:
+        for key in ("REXAI_DATA_ROOT", "REXAI_MODELS_DIR"):
+            monkeypatch.delenv(key, raising=False)
+        for key, value in env.items():
+            monkeypatch.setenv(key, value)
+        return importlib.reload(paths)
+
+    yield _reload
+
+    for key in ("REXAI_DATA_ROOT", "REXAI_MODELS_DIR"):
+        monkeypatch.delenv(key, raising=False)
+    importlib.reload(paths)
+
+
+def test_path_constants_align_with_repository_structure(reload_paths) -> None:
     """Smoke test ensuring filesystem constants remain in sync."""
 
-    assert paths.DATA_ROOT.is_dir()
-    assert paths.MODELS_DIR.is_dir()
-    assert paths.LOGS_DIR.parent == paths.DATA_ROOT
-    assert paths.LOGS_DIR.name == "logs"
+    module = reload_paths()
+    repo_root = Path(__file__).resolve().parents[1]
+
+    assert module.DATA_ROOT == (repo_root / "data").resolve()
+    assert module.DATA_ROOT.is_dir()
+    assert module.MODELS_DIR == module.DATA_ROOT / "models"
+    assert module.MODELS_DIR.is_dir()
+    assert module.LOGS_DIR.parent == module.DATA_ROOT
+    assert module.LOGS_DIR.name == "logs"
 
 
 def test_initialise_frontend_invokes_theme_helpers(monkeypatch) -> None:
@@ -29,3 +58,30 @@ def test_initialise_frontend_invokes_theme_helpers(monkeypatch) -> None:
     ui_blocks.initialise_frontend()
 
     assert calls == ["load", "apply"]
+
+
+def test_data_root_environment_variable_overrides_default(tmp_path, reload_paths) -> None:
+    """``REXAI_DATA_ROOT`` should take precedence when defined."""
+
+    custom_root = tmp_path / "custom-root"
+    custom_root.mkdir()
+
+    module = reload_paths(REXAI_DATA_ROOT=str(custom_root))
+
+    assert module.DATA_ROOT == custom_root.resolve()
+    assert module.MODELS_DIR == module.DATA_ROOT / "models"
+    assert module.LOGS_DIR == module.DATA_ROOT / "logs"
+    assert module.GOLD_DIR == module.DATA_ROOT / "gold"
+
+
+def test_models_dir_environment_variable_overrides_default(tmp_path, reload_paths) -> None:
+    """``REXAI_MODELS_DIR`` should replace the derived models directory."""
+
+    custom_models = tmp_path / "custom-models"
+    custom_models.mkdir()
+
+    module = reload_paths(REXAI_MODELS_DIR=str(custom_models))
+
+    repo_root = Path(__file__).resolve().parents[1]
+    assert module.DATA_ROOT == (repo_root / "data").resolve()
+    assert module.MODELS_DIR == custom_models.resolve()


### PR DESCRIPTION
## Summary
- allow overriding the data root with the REXAI_DATA_ROOT environment variable and normalise paths
- add support for REXAI_MODELS_DIR while keeping the derived default when unset
- document the new configuration flags and cover the overrides with unit tests

## Testing
- pytest tests/test_paths.py

------
https://chatgpt.com/codex/tasks/task_e_68e05cba0f50833198cd4b9f92450311