### PR TITLE
Vectorize pareto_front and add performance coverage

### DIFF
--- a/app/modules/analytics.py
+++ b/app/modules/analytics.py
@@ -1,22 +1,37 @@
 import numpy as np
 import pandas as pd
 
-def pareto_front(df: pd.DataFrame, minimize_cols=("Energía (kWh)","Agua (L)","Crew (min)"), maximize_cols=("Score",)):
-    """
-    Devuelve índices de filas no dominadas (Pareto front).
-    Minimiza energía/agua/crew y maximiza score.
-    """
-    data = df.copy()
-    for c in minimize_cols:
-        data[f"min_{c}"] = data[c]
-    for c in maximize_cols:
-        data[f"min_{c}"] = -data[c]  # maximizar = minimizar el negativo
 
-    X = data[[f"min_{c}" for c in minimize_cols] + [f"min_{c}" for c in maximize_cols]].to_numpy()
-    is_dominated = np.zeros(len(X), dtype=bool)
-    for i in range(len(X)):
-        if is_dominated[i]: 
-            continue
-        is_dominated |= np.all(X <= X[i], axis=1) & np.any(X < X[i], axis=1)
-    front_idx = np.where(~is_dominated)[0]
-    return data.iloc[front_idx].index.tolist()
+def pareto_front(
+    df: pd.DataFrame,
+    minimize_cols=("Energía (kWh)", "Agua (L)", "Crew (min)"),
+    maximize_cols=("Score",),
+):
+    """Devuelve los índices de las filas no dominadas (frente de Pareto).
+
+    La función mantiene la interfaz existente (lista de índices del ``DataFrame``
+    original) pero ahora opera directamente sobre ``numpy`` sin crear columnas
+    auxiliares.  Se construye una matriz con las columnas a minimizar y el
+    negativo de las columnas a maximizar, y se utilizan operaciones vectorizadas
+    para evaluar la dominancia entre todas las combinaciones de filas.  Esta
+    versión evita bucles en Python y reduce el coste de copiar datos,
+    proporcionando un mejor rendimiento en ``DataFrames`` grandes.
+    """
+
+    metrics = []
+    if minimize_cols:
+        metrics.append(df.loc[:, list(minimize_cols)].to_numpy())
+    if maximize_cols:
+        metrics.append(-df.loc[:, list(maximize_cols)].to_numpy())
+
+    if not metrics:
+        return df.index.tolist()
+
+    X = np.hstack(metrics) if len(metrics) > 1 else metrics[0]
+
+    less_equal = X[:, None, :] <= X[None, :, :]
+    strictly_less = X[:, None, :] < X[None, :, :]
+    dominates = np.all(less_equal, axis=2) & np.any(strictly_less, axis=2)
+    is_dominated = dominates.any(axis=0)
+    front_idx = np.nonzero(~is_dominated)[0]
+    return df.index[front_idx].tolist()

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -1,0 +1,87 @@
+"""Tests para utilidades de analytics."""
+
+import time
+
+import numpy as np
+import pandas as pd
+
+from app.modules.analytics import pareto_front
+
+
+def _slow_pareto(matrix: np.ndarray) -> np.ndarray:
+    """Implementación de referencia O(n²) para comparar resultados."""
+
+    dominated = np.zeros(len(matrix), dtype=bool)
+    for i in range(len(matrix)):
+        if dominated[i]:
+            continue
+        for j in range(len(matrix)):
+            if i == j:
+                continue
+            if np.all(matrix[j] <= matrix[i]) and np.any(matrix[j] < matrix[i]):
+                dominated[i] = True
+                break
+    return np.nonzero(~dominated)[0]
+
+
+def test_pareto_front_expected_indices():
+    df = pd.DataFrame(
+        {
+            "Energía (kWh)": [10, 8, 12, 9],
+            "Agua (L)": [5, 6, 4, 7],
+            "Crew (min)": [60, 55, 65, 58],
+            "Score": [80, 82, 78, 81],
+        },
+        index=["a", "b", "c", "d"],
+    )
+
+    # "d" es dominada por "b", el resto permanecen en el frente de Pareto.
+    expected = ["a", "b", "c"]
+    assert pareto_front(df) == expected
+
+
+def test_pareto_front_large_dataframe_matches_baseline():
+    rng = np.random.default_rng(42)
+    size = 250
+    df = pd.DataFrame(
+        {
+            "Energía (kWh)": rng.uniform(0, 100, size),
+            "Agua (L)": rng.uniform(0, 100, size),
+            "Crew (min)": rng.uniform(30, 120, size),
+            "Score": rng.uniform(0, 1, size),
+        }
+    )
+
+    result = pareto_front(df)
+    matrix = np.column_stack(
+        [
+            df["Energía (kWh)"].to_numpy(),
+            df["Agua (L)"].to_numpy(),
+            df["Crew (min)"].to_numpy(),
+            -df["Score"].to_numpy(),
+        ]
+    )
+    baseline = _slow_pareto(matrix)
+    assert set(result) == set(baseline)
+
+
+def test_pareto_front_large_dataframe_performance():
+    rng = np.random.default_rng(123)
+    size = 2000
+    df = pd.DataFrame(
+        {
+            "Energía (kWh)": rng.uniform(0, 100, size),
+            "Agua (L)": rng.uniform(0, 100, size),
+            "Crew (min)": rng.uniform(30, 120, size),
+            "Score": rng.uniform(0, 1, size),
+        }
+    )
+
+    start = time.perf_counter()
+    result = pareto_front(df)
+    duration = time.perf_counter() - start
+
+    # Evitar regresiones severas: la implementación vectorizada debe completar
+    # en menos de 1.5 segundos sobre un DataFrame de 2000 filas.
+    assert duration < 1.5, f"pareto_front demasiado lento ({duration:.2f}s)"
+    assert result  # el frente no debe estar vacío


### PR DESCRIPTION
## Summary
- rewrite `pareto_front` to operate directly on numpy arrays via broadcasting without creating temporary DataFrame columns
- document the vectorized behaviour and performance improvements in the function docstring
- add analytics tests, including large-input and baseline comparisons, to guard against performance regressions

## Testing
- pytest tests/test_analytics.py

------
https://chatgpt.com/codex/tasks/task_e_68e05f0e97288331913fb8b5553bbdd6