### PR TITLE
Add category synonym extension API

### DIFF
--- a/app/modules/data_sources.py
+++ b/app/modules/data_sources.py
@@ -41,6 +41,7 @@ __all__ = [
     "slugify",
     "normalize_text",
     "normalize_category",
+    "extend_category_synonyms",
     "normalize_item",
     "token_set",
     "merge_reference_dataset",
@@ -154,6 +155,32 @@ _CATEGORY_SYNONYMS = {
 def normalize_category(value: Any) -> str:
     normalized = normalize_text(value)
     return _CATEGORY_SYNONYMS.get(normalized, normalized)
+
+
+def extend_category_synonyms(
+    synonyms: Mapping[str, str] | Iterable[tuple[str, str]],
+) -> None:
+    """Extend the category synonym map with *synonyms*.
+
+    The provided mapping is normalised using :func:`normalize_text` to ensure
+    consistent lookups regardless of capitalisation or punctuation.  Existing
+    entries with the same normalised key are overwritten so callers can update
+    canonical targets when ingesting new inventories.
+    """
+
+    if isinstance(synonyms, Mapping):
+        items = synonyms.items()
+    else:
+        items = synonyms
+
+    for source, target in items:
+        normalized_source = normalize_text(source)
+        if not normalized_source:
+            continue
+        normalized_target = normalize_text(target)
+        if not normalized_target:
+            normalized_target = normalized_source
+        _CATEGORY_SYNONYMS[normalized_source] = normalized_target
 
 
 def normalize_item(value: Any) -> str:

--- a/app/modules/generator.py
+++ b/app/modules/generator.py
@@ -159,7 +159,7 @@ _SEED_ENV_VAR = "REXAI_GENERATOR_SEED"
 # and EVA Waste) into a single "other packaging glove" bucket.  The updated
 # mapping keeps these families distinct so downstream heuristics can reason
 # about them independently while still tolerating legacy spellings.
-_CATEGORY_SYNONYMS.update(
+ds.extend_category_synonyms(
     {
         "packaging": "packaging",
         "packaging material": "packaging",

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -52,6 +52,16 @@ def reference_dataset_tables(monkeypatch):
         generator._official_features_bundle.cache_clear()
 
 
+def test_extend_category_synonyms_updates_normalization(monkeypatch):
+    synonyms_copy = data_sources._CATEGORY_SYNONYMS.copy()
+    monkeypatch.setattr(data_sources, "_CATEGORY_SYNONYMS", synonyms_copy)
+    monkeypatch.setattr(generator, "_CATEGORY_SYNONYMS", synonyms_copy, raising=False)
+
+    data_sources.extend_category_synonyms({"Experimental Packaging": "Packaging"})
+
+    assert generator.normalize_category("Experimental Packaging") == "packaging"
+
+
 def test_load_regolith_vector_matches_data_sources():
     polars_vector = generator._load_regolith_vector()
     pandas_vector = data_sources._load_regolith_vector()


### PR DESCRIPTION
## Summary
- expose a public helper for extending category synonym mappings
- update the generator to rely on the new helper instead of mutating the shared map
- add a regression test to cover the new extension path

## Testing
- pytest tests/test_generator.py::test_extend_category_synonyms_updates_normalization

------
https://chatgpt.com/codex/tasks/task_e_68e0600451b88331b9c952e808cd9606