### PR TITLE
Refactor generator module into package with GeneratorService entry point

### DIFF
--- a/app/modules/generator/__init__.py
+++ b/app/modules/generator/__init__.py
@@ -1,0 +1,27 @@
+"""Generator package exposing candidate production services."""
+from __future__ import annotations
+
+from .adapters import optional_jit, optional_jnp
+from .assembly import CandidateAssembler
+from .normalization import build_match_key, normalize_category, normalize_item, token_set
+from . import service as _service
+from .service import GeneratorService, generate_candidates
+
+__all__ = [
+    "CandidateAssembler",
+    "GeneratorService",
+    "build_match_key",
+    "generate_candidates",
+    "normalize_category",
+    "normalize_item",
+    "optional_jit",
+    "optional_jnp",
+    "token_set",
+]
+
+
+def __getattr__(name: str) -> object:
+    return getattr(_service, name)
+
+
+__all__ = sorted(set(__all__ + list(getattr(_service, "__all__", []))))

--- a/app/modules/generator/adapters.py
+++ b/app/modules/generator/adapters.py
@@ -1,0 +1,106 @@
+"""Adapter utilities for optional machine learning dependencies."""
+from __future__ import annotations
+
+import importlib
+import importlib.util
+from functools import lru_cache
+from typing import Any, Callable, NamedTuple
+
+from app.modules import logging_utils
+
+
+class _JaxNamespace(NamedTuple):
+    """Namespace container for the optional :mod:`jax` dependency."""
+
+    jnp: Any
+    jit: Callable[[Callable[..., Any]], Callable[..., Any]]
+
+
+class _PyArrowNamespace(NamedTuple):
+    """Namespace container for the optional :mod:`pyarrow` dependency."""
+
+    pa: Any
+    pq: Any
+
+
+@lru_cache(maxsize=1)
+def _load_jax_namespace() -> _JaxNamespace | None:
+    """Return the imported :mod:`jax` namespace when available."""
+
+    if importlib.util.find_spec("jax") is None:
+        return None
+
+    try:
+        jax_module = importlib.import_module("jax")
+        jnp_module = importlib.import_module("jax.numpy")
+    except Exception:
+        return None
+
+    jit_impl = getattr(jax_module, "jit", None)
+    if not callable(jit_impl):
+
+        def _identity(fn: Callable[..., Any]) -> Callable[..., Any]:
+            return fn
+
+        jit_impl = _identity
+
+    return _JaxNamespace(jnp=jnp_module, jit=jit_impl)
+
+
+@lru_cache(maxsize=1)
+def _load_torch_module() -> Any | None:
+    """Return the :mod:`torch` module if it can be imported."""
+
+    if importlib.util.find_spec("torch") is None:
+        return None
+
+    try:
+        return importlib.import_module("torch")
+    except Exception:
+        return None
+
+
+@lru_cache(maxsize=1)
+def _load_pyarrow_namespace() -> _PyArrowNamespace | None:
+    """Return the :mod:`pyarrow` namespace when present."""
+
+    pa_mod = getattr(logging_utils, "pa", None)
+    pq_mod = getattr(logging_utils, "pq", None)
+    if pa_mod is not None and pq_mod is not None:
+        return _PyArrowNamespace(pa=pa_mod, pq=pq_mod)
+
+    if importlib.util.find_spec("pyarrow") is None:
+        return None
+
+    try:
+        pa_mod = importlib.import_module("pyarrow")
+        pq_mod = importlib.import_module("pyarrow.parquet")
+    except Exception:
+        return None
+
+    return _PyArrowNamespace(pa=pa_mod, pq=pq_mod)
+
+
+def optional_jnp() -> Any | None:
+    """Return the ``jax.numpy`` module when :mod:`jax` is installed."""
+
+    namespace = _load_jax_namespace()
+    return None if namespace is None else namespace.jnp
+
+
+def optional_jit() -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    """Return :func:`jax.jit` when available, otherwise a passthrough."""
+
+    namespace = _load_jax_namespace()
+    if namespace is None:
+        return lambda fn: fn
+    return namespace.jit
+
+
+__all__ = [
+    "_load_jax_namespace",
+    "_load_pyarrow_namespace",
+    "_load_torch_module",
+    "optional_jit",
+    "optional_jnp",
+]

--- a/app/modules/generator/assembly.py
+++ b/app/modules/generator/assembly.py
@@ -1,0 +1,101 @@
+"""Domain helpers for assembling candidate feature rows."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Mapping
+
+import numpy as np
+import pandas as pd
+
+from .normalization import normalize_category
+
+
+_COMPOSITION_DENSITY_MAP: Mapping[str, float] = {
+    "Aluminum_pct": 2700.0,
+    "Carbon_Fiber_pct": 1700.0,
+    "Polyethylene_pct": 950.0,
+    "PVDF_pct": 1780.0,
+    "Nomex_pct": 1350.0,
+    "Nylon_pct": 1140.0,
+    "Polyester_pct": 1380.0,
+    "Cotton_Cellulose_pct": 1550.0,
+    "EVOH_pct": 1250.0,
+    "PET_pct": 1370.0,
+    "Nitrile_pct": 1030.0,
+    "approx_moisture_pct": 1000.0,
+    "Other_pct": 500.0,
+    "Plastic_Resin_pct": 950.0,
+}
+
+_CATEGORY_DENSITY_DEFAULTS: Mapping[str, float] = {
+    "foam packaging": 100.0,
+    "food packaging": 650.0,
+    "structural elements": 1800.0,
+    "structural element": 1800.0,
+    "packaging": 420.0,
+    "other packaging": 420.0,
+    "gloves": 420.0,
+    "eva waste": 240.0,
+    "fabric": 350.0,
+}
+
+
+@dataclass(slots=True)
+class CandidateAssembler:
+    """Utility responsible for candidate level feature derivations."""
+
+    composition_density_map: Mapping[str, float] = field(
+        default_factory=lambda: dict(_COMPOSITION_DENSITY_MAP)
+    )
+    category_density_defaults: Mapping[str, float] = field(
+        default_factory=lambda: dict(_CATEGORY_DENSITY_DEFAULTS)
+    )
+
+    def estimate_density_from_row(self, row: pd.Series) -> float | None:
+        """Estimate a material density with packaging-aware fallbacks."""
+
+        category = normalize_category(row.get("category", ""))
+
+        try:
+            cat_mass = float(row.get("category_total_mass_kg"))
+            cat_volume = float(row.get("category_total_volume_m3"))
+        except (TypeError, ValueError):
+            cat_mass = cat_volume = float("nan")
+
+        if pd.notna(cat_mass) and pd.notna(cat_volume) and cat_volume > 0:
+            return float(np.clip(cat_mass / cat_volume, 20.0, 4000.0))
+
+        composition_weights: list[tuple[float, float]] = []
+        total = 0.0
+        for column, density in self.composition_density_map.items():
+            try:
+                pct = float(row.get(column, 0.0))
+            except (TypeError, ValueError):
+                pct = 0.0
+            if pct and not np.isnan(pct):
+                frac = pct / 100.0
+                if frac > 0:
+                    composition_weights.append((frac, density))
+                    total += frac
+
+        if total > 0 and composition_weights:
+            weighted = sum(frac * density for frac, density in composition_weights) / total
+            if category == "foam packaging":
+                return float(min(weighted, self.category_density_defaults.get(category, weighted)))
+            return float(np.clip(weighted, 20.0, 4000.0))
+
+        if category in self.category_density_defaults:
+            return float(self.category_density_defaults[category])
+
+        return None
+
+
+COMPOSITION_DENSITY_MAP: Mapping[str, float] = dict(_COMPOSITION_DENSITY_MAP)
+CATEGORY_DENSITY_DEFAULTS: Mapping[str, float] = dict(_CATEGORY_DENSITY_DEFAULTS)
+
+
+__all__ = [
+    "CandidateAssembler",
+    "CATEGORY_DENSITY_DEFAULTS",
+    "COMPOSITION_DENSITY_MAP",
+]

--- a/app/modules/generator/normalization.py
+++ b/app/modules/generator/normalization.py
@@ -1,0 +1,26 @@
+"""Helpers that proxy the shared data normalisation primitives."""
+from __future__ import annotations
+
+from typing import Any
+
+from app.modules import data_sources as ds
+
+__all__ = [
+    "normalize_category",
+    "normalize_item",
+    "token_set",
+    "build_match_key",
+]
+
+
+normalize_category = ds.normalize_category
+normalize_item = ds.normalize_item
+token_set = ds.token_set
+
+
+def build_match_key(category: Any, subitem: Any | None = None) -> str:
+    """Return the canonical key used to match NASA reference tables."""
+
+    if subitem:
+        return f"{normalize_category(category)}|{normalize_item(subitem)}"
+    return normalize_category(category)


### PR DESCRIPTION
## Summary
- break the monolithic generator module into a package with adapters, normalization, and candidate assembly helpers
- introduce a GeneratorService facade that wraps the existing generate_candidates implementation while preserving legacy exports
- update generator tests to import the new service layout and exercise the class-based entry point

## Testing
- pytest tests/test_generator.py tests/test_latent_optimizer.py

------
https://chatgpt.com/codex/tasks/task_e_68e067e685248331a062b28509824e2b