### PR TITLE
Fix io generator import and add smoke test

### DIFF
--- a/app/modules/io.py
+++ b/app/modules/io.py
@@ -15,7 +15,6 @@ import pandas as pd
 import polars as pl
 
 from .dataset_validation import InvalidWasteDatasetError, validate_waste_inventory
-from .generator import prepare_waste_frame
 from .data_sources import official_features_bundle
 from .paths import DATA_ROOT
 from .problematic import problematic_mask
@@ -152,6 +151,8 @@ def _load_waste_df_cached() -> pd.DataFrame:
     family_display = base_df.get("material_family", "").astype(str).str.strip()
     material_display = category_display.where(family_display.eq(""), category_display + " — " + family_display)
     base_df["material_display"] = material_display.replace({" — ": ""})
+
+    from .generator import prepare_waste_frame
 
     prepared = prepare_waste_frame(base_df)
     result = prepared.copy(deep=True)

--- a/tests/test_io_module.py
+++ b/tests/test_io_module.py
@@ -3,8 +3,18 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 
 from app.modules import io
+
+
+def _write_sample_waste_csv(path: Path) -> None:
+    path.write_text(
+        """id,category,material_family,mass_kg,volume_l,flags,material,key_materials
+W1,Packaging,Polymer,1.5,0.3,,Polymer Film,Polymer Film
+""",
+        encoding="utf-8",
+    )
 
 
 def test_load_process_df_only_requires_process_dataset(tmp_path, monkeypatch):
@@ -41,3 +51,20 @@ def test_load_targets_only_requires_targets_dataset(tmp_path, monkeypatch):
     assert payload == [{"id": "alpha"}]
 
     io.invalidate_all_io_caches()
+
+
+def test_app_modules_import_can_load_waste_df(monkeypatch, tmp_path):
+    import app.modules as modules
+
+    waste_csv = tmp_path / "waste_inventory_sample.csv"
+    _write_sample_waste_csv(waste_csv)
+
+    monkeypatch.setattr(modules.io, "WASTE_CSV", waste_csv)
+    monkeypatch.setattr(modules.io, "official_features_bundle", lambda: None)
+
+    modules.invalidate_all_io_caches()
+
+    frame = modules.load_waste_df()
+
+    assert list(frame["id"]) == ["W1"]
+    assert frame.iloc[0]["kg"] == 1.5


### PR DESCRIPTION
## Summary
- move the `prepare_waste_frame` import inside the waste loader to avoid eager generator dependencies
- add a smoke test that imports `app.modules` and exercises `load_waste_df` with a sample dataset

## Testing
- pytest tests/test_io_module.py::test_app_modules_import_can_load_waste_df -q

------
https://chatgpt.com/codex/tasks/task_e_68e084009d308331b375692898ade670