### PR TITLE
Integrate Zenodo material references into generator pipeline

### DIFF
--- a/app/modules/generator/assembly.py
+++ b/app/modules/generator/assembly.py
@@ -2,12 +2,14 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Mapping
+from typing import Any, Dict, Iterable, Mapping
 
 import numpy as np
 import pandas as pd
 
-from .normalization import normalize_category
+from app.modules import data_sources as ds
+
+from .normalization import normalize_category, normalize_item
 
 
 _COMPOSITION_DENSITY_MAP: Mapping[str, float] = {
@@ -44,17 +46,120 @@ _CATEGORY_DENSITY_DEFAULTS: Mapping[str, float] = {
 class CandidateAssembler:
     """Utility responsible for candidate level feature derivations."""
 
+    material_reference: ds.MaterialReferenceBundle = field(
+        default_factory=ds.load_material_reference_bundle
+    )
     composition_density_map: Mapping[str, float] = field(
         default_factory=lambda: dict(_COMPOSITION_DENSITY_MAP)
     )
     category_density_defaults: Mapping[str, float] = field(
         default_factory=lambda: dict(_CATEGORY_DENSITY_DEFAULTS)
     )
+    _alias_map: Dict[str, str] = field(init=False, repr=False, default_factory=dict)
+    _properties: Dict[str, Dict[str, float]] = field(init=False, repr=False, default_factory=dict)
+    _property_columns: tuple[str, ...] = field(init=False, repr=False, default_factory=tuple)
+    _density_map: Dict[str, float] = field(init=False, repr=False, default_factory=dict)
+
+    def __post_init__(self) -> None:
+        reference = self.material_reference
+        self._alias_map = dict(getattr(reference, "alias_map", {}))
+        self._properties = dict(getattr(reference, "properties", {}))
+        self._property_columns = tuple(getattr(reference, "property_columns", ()))
+        self._density_map = dict(getattr(reference, "density_map", {}))
+
+        overrides = {
+            "Polyethylene_pct": "polyethylene",
+            "PVDF_pct": "pvdf",
+            "Nomex_pct": "nomex",
+            "Nylon_pct": "nylon",
+            "Polyester_pct": "pet_p_ertalyte_tx",
+            "Cotton_Cellulose_pct": "cotton_gossypium_hirsutum_barbadense",
+            "Other_pct": "polypropylene",
+        }
+        for column, alias in overrides.items():
+            density = None
+            alias_slug = ds.slugify(alias)
+            if alias_slug:
+                density = self._density_map.get(alias_slug)
+            if density is not None:
+                self.composition_density_map = dict(self.composition_density_map)
+                self.composition_density_map[column] = float(density)
+
+    def _resolve_material_key(self, row: Mapping[str, Any]) -> str | None:
+        for candidate in (
+            row.get("_material_reference_key"),
+            row.get("material"),
+            row.get("material_family"),
+            row.get("key_materials"),
+            row.get("flags"),
+        ):
+            if not candidate:
+                continue
+            normalized = normalize_item(candidate)
+            slug = ds.slugify(normalized)
+            if not slug:
+                continue
+            key = self._alias_map.get(slug)
+            if key:
+                return key
+        return None
+
+    def lookup_properties(self, row: Mapping[str, Any]) -> tuple[dict[str, float], str | None]:
+        key = self._resolve_material_key(row)
+        if key is None:
+            return {}, None
+        props = self._properties.get(key)
+        if not props:
+            return {}, key
+        return dict(props), key
+
+    def aggregate_material_properties(
+        self, picks: pd.DataFrame, weights: Iterable[float]
+    ) -> Dict[str, float]:
+        if picks.empty or not self._property_columns:
+            return {}
+
+        weight_array = np.asarray(list(weights), dtype=float)
+        if weight_array.size == 0:
+            weight_array = picks["kg"].to_numpy(dtype=float)
+        if weight_array.size != len(picks):
+            weight_array = np.resize(weight_array, len(picks))
+        mass = picks.get("kg")
+        if isinstance(mass, pd.Series):
+            mass_weights = mass.to_numpy(dtype=float)
+        else:
+            mass_weights = np.ones(len(picks), dtype=float)
+        weights_combined = weight_array
+        if np.all(weights_combined == 0):
+            weights_combined = mass_weights
+        total = np.sum(weights_combined)
+        if not np.isfinite(total) or total <= 0:
+            total = float(len(picks))
+        normalized = weights_combined / total
+
+        aggregates: Dict[str, float] = {}
+        for column in self._property_columns:
+            if column not in picks.columns:
+                continue
+            values = pd.to_numeric(picks[column], errors="coerce").to_numpy(dtype=float)
+            mask = np.isfinite(values)
+            if not mask.any():
+                continue
+            denom = normalized[mask].sum()
+            if denom <= 0:
+                continue
+            aggregates[column] = float(np.dot(values[mask], normalized[mask]) / denom)
+        return aggregates
 
     def estimate_density_from_row(self, row: pd.Series) -> float | None:
         """Estimate a material density with packaging-aware fallbacks."""
 
         category = normalize_category(row.get("category", ""))
+
+        properties, _ = self.lookup_properties(row)
+        density_from_reference = properties.get("material_density_kg_m3")
+        if density_from_reference and np.isfinite(density_from_reference):
+            return float(np.clip(density_from_reference, 20.0, 4000.0))
 
         try:
             cat_mass = float(row.get("category_total_mass_kg"))

--- a/app/modules/model_training.py
+++ b/app/modules/model_training.py
@@ -93,6 +93,7 @@ except Exception:  # pragma: no cover - environments without torch
     DataLoader = TensorDataset = None  # type: ignore[assignment]
     HAS_TORCH = False
 
+from app.modules import data_sources as ds
 from app.modules.label_mapper import derive_recipe_id, load_curated_labels, lookup_labels
 from .paths import DATA_ROOT, GOLD_DIR, MODELS_DIR
 
@@ -153,6 +154,15 @@ FEATURE_COLUMNS = [
     "packaging_frac",
     "gas_recovery_index",
     "logistics_reuse_index",
+    "material_density_kg_m3",
+    "material_modulus_gpa",
+    "material_tensile_strength_mpa",
+    "material_elongation_pct",
+    "material_oxygen_index_pct",
+    "material_water_absorption_pct",
+    "material_thermal_conductivity_w_mk",
+    "material_glass_transition_c",
+    "material_melting_temperature_c",
     "regolith_d50_um",
     "regolith_spectral_slope_1um",
     "regolith_mass_loss_400c",
@@ -1569,6 +1579,8 @@ def train_and_save(
     trained_on = _infer_trained_on_label(df)
     trained_at_iso = datetime.now(tz=UTC).isoformat()
 
+    material_bundle = ds.load_material_reference_bundle()
+
     metadata = {
         "model_name": "rexai-rf-ensemble",
         "trained_on": trained_on,
@@ -1600,6 +1612,14 @@ def train_and_save(
         "labeling": {
             "columns": {"source": "label_source", "weight": "label_weight"},
             "summary": label_summary_dict,
+        },
+        "material_reference": {
+            "property_columns": list(material_bundle.property_columns),
+            "material_count": int(material_bundle.table.height),
+            "metadata": {
+                str(key): {str(k): v for k, v in value.items()}
+                for key, value in material_bundle.metadata.items()
+            },
         },
     }
 

--- a/tests/test_data_sources.py
+++ b/tests/test_data_sources.py
@@ -14,6 +14,7 @@ from app.modules import data_sources
 from app.modules.data_sources import (
     RegolithCharacterization,
     REGOLITH_CHARACTERIZATION,
+    load_material_reference_bundle,
     load_regolith_characterization,
     load_regolith_particle_size,
     load_regolith_spectra,
@@ -83,6 +84,22 @@ def test_merge_reference_dataset_lazyframe_matches_eager(tmp_path, monkeypatch) 
     ]
     assert eager_df.get_column("extra_value").to_list() == [10.0, 20.0]
     assert eager_df.get_column("extra_new_metric").to_list() == [0.5, 0.75]
+
+
+def test_material_reference_bundle_exposes_properties() -> None:
+    bundle = load_material_reference_bundle.cache_clear() or load_material_reference_bundle()
+
+    assert bundle.table.height > 0
+    assert "material_density_kg_m3" in bundle.property_columns
+
+    slug = data_sources.slugify(data_sources.normalize_item("Nomex 410"))
+    assert bundle.alias_map.get(slug)
+
+    assert "pvdf_alpha_160c" in bundle.spectral_curves
+    assert not bundle.spectral_curves["pvdf_alpha_160c"].empty
+
+    metadata = bundle.metadata.get("pvdf_alpha_160c")
+    assert metadata and "source" in metadata
 
 
 def test_particle_size_loader_produces_expected_metrics() -> None:

--- a/tests/test_model_training.py
+++ b/tests/test_model_training.py
@@ -687,3 +687,7 @@ def test_cli_appends_feedback_logs(monkeypatch: pytest.MonkeyPatch, tmp_path: Pa
     assert trained_at >= start_time
     assert metadata["trained_on"] == "hil_v1"
     assert result["trained_on"] == "hil_v1"
+    material_meta = metadata.get("material_reference")
+    assert material_meta
+    assert material_meta["property_columns"]
+    assert material_meta["material_count"] >= 1


### PR DESCRIPTION
## Summary
- add a consolidated Zenodo material reference bundle loader with normalized aliases, densities, spectral curves, and metadata
- update generator assembly and heuristic logic to consume empirical material properties and respect empirical prediction modes
- propagate material reference features through training data/metadata and extend tests for the new bundle behaviour

## Testing
- pytest tests/test_data_sources.py tests/test_generator.py tests/test_model_training.py

------
https://chatgpt.com/codex/tasks/task_e_68e0a004919c8331b5af4061ca3f3200