### PR TITLE
Add mixing metadata parsing and expose candidate mixing profiles

### DIFF
--- a/app/modules/generator/service.py
+++ b/app/modules/generator/service.py
@@ -2774,6 +2774,10 @@ def _finalize_candidate(
         features["recipe_id"] = recipe_id
     features["prediction_mode"] = "heuristic"
 
+    mixing_profile = _ASSEMBLER.build_mixing_profile(picks, regolith_pct)
+    if mixing_profile:
+        features["mixing_profile"] = mixing_profile
+
     heuristic = heuristic_props(picks, proc, weights, regolith_pct)
     if heuristic.source != "heuristic" and features.get("prediction_mode") == "heuristic":
         features["prediction_model"] = heuristic.source


### PR DESCRIPTION
## Summary
- parse the MNL1 Mecha workbook and regolith properties to populate material mixing rules and compatibility matrices
- expose the new structures through the material reference bundle and propagate mixing profiles into generated candidate features
- extend unit tests to validate the new metadata and alias resolution paths

## Testing
- pytest tests/test_data_sources.py

------
https://chatgpt.com/codex/tasks/task_e_68e0a779f8988331bc7488e31ecee7d3