### PR TITLE
Add spectral mixing solver, generator hook, and Streamlit UI

### DIFF
--- a/app/modules/spectral_mixer.py
+++ b/app/modules/spectral_mixer.py
@@ -1,0 +1,275 @@
+"""Spectral mixing utilities.
+
+This module exposes a convenience wrapper on top of the material reference
+bundle so downstream services can propose FTIR mixes that approximate a target
+signature under logistic constraints.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Mapping, Sequence
+
+import numpy as np
+import pandas as pd
+from scipy import optimize
+
+from app.modules import data_sources as ds
+
+
+_NUMERIC_PRIORITY = (
+    "absorbance_norm_1um",
+    "absorbance",
+    "reflectance_pct",
+    "transmittance_pct",
+)
+
+
+@dataclass(slots=True)
+class SpectralMixResult:
+    """Container returned by :func:`solve_spectral_recipe`."""
+
+    basis: list[str]
+    coefficients: np.ndarray
+    target_curve: pd.DataFrame
+    synthetic_curve: pd.DataFrame
+    error_metrics: dict[str, float]
+
+    def as_dict(self) -> dict[str, object]:
+        """Return a serialisable payload used by Streamlit views."""
+
+        return {
+            "coefficients": [
+                {"material": key, "fraction": float(value)}
+                for key, value in zip(self.basis, self.coefficients, strict=False)
+            ],
+            "synthetic_curve": self.synthetic_curve,
+            "target_curve": self.target_curve,
+            "error": dict(self.error_metrics),
+        }
+
+
+def _load_target_curve(target_curve: pd.DataFrame | Sequence[Mapping[str, float]] | str | Path) -> pd.DataFrame:
+    if isinstance(target_curve, pd.DataFrame):
+        df = target_curve.copy()
+    elif isinstance(target_curve, (str, Path)):
+        df = pd.read_csv(target_curve)
+    else:
+        df = pd.DataFrame(list(target_curve))
+
+    if df.empty:
+        raise ValueError("target_curve must contain at least one row")
+
+    df = df.copy()
+    wave_column = _resolve_wavenumber_column(df)
+    value_column = _resolve_value_column(df)
+    df = df[[wave_column, value_column]].dropna()
+    df = df.rename(columns={wave_column: "wavenumber_cm_1", value_column: "intensity"})
+    df = df.sort_values("wavenumber_cm_1").reset_index(drop=True)
+    return df
+
+
+def _resolve_wavenumber_column(df: pd.DataFrame) -> str:
+    for candidate in df.columns:
+        normalized = candidate.lower()
+        if "wavenumber" in normalized or normalized.endswith("_cm_1"):
+            return candidate
+    raise ValueError("target_curve must include a wavenumber column")
+
+
+def _resolve_value_column(df: pd.DataFrame) -> str:
+    numeric_columns = [col for col in df.columns if np.issubdtype(df[col].dtype, np.number)]
+    for preferred in _NUMERIC_PRIORITY:
+        if preferred in df.columns and preferred in numeric_columns:
+            return preferred
+    if numeric_columns:
+        return numeric_columns[0]
+    raise ValueError("target_curve must include a numeric spectral column")
+
+
+def _resolve_available_basis(
+    availability: Mapping[str, object] | pd.DataFrame | Sequence[Mapping[str, object]] | Sequence[str] | None,
+    bundle: ds.MaterialReferenceBundle,
+) -> list[str]:
+    if availability is None:
+        return list(bundle.spectral_curves.keys())
+
+    keys: set[str] = set()
+    rows: Iterable[Mapping[str, object]]
+    if isinstance(availability, pd.DataFrame):
+        rows = availability.to_dict("records")
+    elif isinstance(availability, Mapping):
+        rows = [availability]
+    elif isinstance(availability, Sequence):
+        if availability and isinstance(availability[0], Mapping):
+            rows = availability  # type: ignore[assignment]
+        else:
+            values = [str(value) for value in availability]
+            rows = [{"value": value} for value in values]
+    else:
+        return list(bundle.spectral_curves.keys())
+
+    alias_index: dict[str, str] = {}
+    for spectral_key, meta in bundle.metadata.items():
+        tokens = {spectral_key, ds.slugify(spectral_key)}
+        for value in meta.values():
+            if isinstance(value, str):
+                slug = ds.slugify(ds.normalize_item(value))
+                if slug:
+                    tokens.add(slug)
+        for token in tokens:
+            if token:
+                alias_index[token] = spectral_key
+
+    for row in rows:
+        for candidate in ("spectral_key", "material_key", "material", "value"):
+            value = row.get(candidate) if isinstance(row, Mapping) else None
+            if not value:
+                continue
+            text = str(value).strip()
+            if not text:
+                continue
+            if text in bundle.spectral_curves:
+                keys.add(text)
+                continue
+            slug = ds.slugify(ds.normalize_item(text))
+            if not slug:
+                continue
+            resolved = alias_index.get(slug)
+            if resolved:
+                keys.add(resolved)
+    if not keys:
+        return list(bundle.spectral_curves.keys())
+    return sorted(keys)
+
+
+def _build_design_matrix(
+    basis: list[str],
+    bundle: ds.MaterialReferenceBundle,
+    target_grid: np.ndarray,
+) -> np.ndarray:
+    matrix = np.zeros((target_grid.size, len(basis)), dtype=float)
+    for idx, key in enumerate(basis):
+        curve = bundle.spectral_curves.get(key)
+        if curve is None or curve.empty:
+            continue
+        curve = curve.copy()
+        if "wavenumber_cm_1" not in curve.columns:
+            raise ValueError(f"spectral curve '{key}' is missing 'wavenumber_cm_1'")
+        value_column = _resolve_value_column(curve)
+        sorted_curve = curve.sort_values("wavenumber_cm_1")
+        x = sorted_curve["wavenumber_cm_1"].to_numpy(dtype=float)
+        y = sorted_curve[value_column].to_numpy(dtype=float)
+        matrix[:, idx] = np.interp(target_grid, x, y, left=y[0], right=y[-1])
+    return matrix
+
+
+def _apply_component_cap(coefficients: np.ndarray, max_components: int | None) -> np.ndarray:
+    if not max_components or max_components <= 0:
+        return coefficients
+    if max_components >= coefficients.size:
+        return coefficients
+    mask = np.argsort(coefficients)[::-1]
+    keep = mask[:max_components]
+    filtered = np.zeros_like(coefficients)
+    filtered[keep] = coefficients[keep]
+    return filtered
+
+
+def _run_constrained_least_squares(
+    design_matrix: np.ndarray,
+    target: np.ndarray,
+    upper_bounds: np.ndarray,
+    total_cap: float,
+) -> np.ndarray:
+    initial, _ = optimize.nnls(design_matrix, target)
+    bounds = optimize.Bounds(lb=np.zeros_like(initial), ub=upper_bounds)
+    linear_constraint = optimize.LinearConstraint(np.ones_like(initial), lb=0.0, ub=total_cap)
+
+    def objective(x: np.ndarray) -> float:
+        residual = design_matrix @ x - target
+        return 0.5 * float(residual @ residual)
+
+    def gradient(x: np.ndarray) -> np.ndarray:
+        residual = design_matrix @ x - target
+        return design_matrix.T @ residual
+
+    result = optimize.minimize(
+        objective,
+        x0=initial,
+        jac=gradient,
+        bounds=bounds,
+        constraints=[linear_constraint],
+        method="SLSQP",
+        options={"maxiter": 200, "ftol": 1e-9},
+    )
+    if result.success and isinstance(result.x, np.ndarray):
+        return result.x
+
+    # Fallback to projecting the NNLS solution if optimisation fails.
+    solution = initial
+    total = float(solution.sum())
+    if total <= total_cap + 1e-9:
+        return solution
+    scale = total_cap / total if total > 0 else 0.0
+    return np.clip(solution * scale, 0.0, upper_bounds)
+
+
+def solve_spectral_recipe(
+    target_curve: pd.DataFrame | Sequence[Mapping[str, float]] | str | Path,
+    availability: Mapping[str, object] | pd.DataFrame | Sequence[Mapping[str, object]] | Sequence[str] | None,
+    constraints: Mapping[str, object] | None = None,
+) -> SpectralMixResult:
+    """Solve a constrained least squares mixing problem for FTIR curves."""
+
+    constraints = dict(constraints or {})
+    bundle = ds.load_material_reference_bundle()
+    target_df = _load_target_curve(target_curve)
+    target_grid = target_df["wavenumber_cm_1"].to_numpy(dtype=float)
+    target_vector = target_df["intensity"].to_numpy(dtype=float)
+
+    basis = _resolve_available_basis(availability, bundle)
+    if not basis:
+        raise ValueError("No spectral curves available to build a mix")
+
+    design_matrix = _build_design_matrix(basis, bundle, target_grid)
+
+    per_material_max = {
+        key: float(value)
+        for key, value in dict(constraints.get("per_material_max", {})).items()
+        if key in basis
+    }
+    default_cap = float(constraints.get("max_fraction_per_component", 1.0))
+    upper_bounds = np.full(len(basis), default_cap, dtype=float)
+    for idx, key in enumerate(basis):
+        cap = per_material_max.get(key)
+        if cap is not None:
+            upper_bounds[idx] = min(default_cap, float(cap))
+    total_cap = float(constraints.get("max_fraction", 1.0))
+
+    coefficients = _run_constrained_least_squares(design_matrix, target_vector, upper_bounds, total_cap)
+    coefficients = _apply_component_cap(coefficients, constraints.get("max_components"))
+
+    total = coefficients.sum()
+    if total > total_cap + 1e-9:
+        coefficients *= total_cap / total
+
+    synthetic = design_matrix @ coefficients
+    residual = synthetic - target_vector
+    mae = float(np.mean(np.abs(residual)))
+    rmse = float(np.sqrt(np.mean(residual**2)))
+    max_abs = float(np.max(np.abs(residual)))
+
+    synthetic_df = target_df.copy()
+    synthetic_df["synthetic_intensity"] = synthetic
+
+    return SpectralMixResult(
+        basis=basis,
+        coefficients=coefficients,
+        target_curve=target_df,
+        synthetic_curve=synthetic_df,
+        error_metrics={"mae": mae, "rmse": rmse, "max_abs": max_abs},
+    )
+
+
+__all__ = ["solve_spectral_recipe", "SpectralMixResult"]

--- a/app/pages/8_Spectral_Mix_Designer.py
+++ b/app/pages/8_Spectral_Mix_Designer.py
@@ -1,0 +1,174 @@
+import sys
+from pathlib import Path
+
+if not __package__:
+    repo_root = Path(__file__).resolve().parents[2]
+    repo_root_str = str(repo_root)
+    if repo_root_str not in sys.path:
+        sys.path.insert(0, repo_root_str)
+
+from app.bootstrap import ensure_streamlit_entrypoint
+
+ensure_streamlit_entrypoint(__file__)
+
+import altair as alt
+import pandas as pd
+import streamlit as st
+
+from app.modules import data_sources as ds
+from app.modules.generator.service import GeneratorService
+from app.modules.ui_blocks import configure_page, initialise_frontend, layout_block, render_brand_header
+
+configure_page(page_title="Rex-AI • Mezclador espectral", page_icon="🌈")
+initialise_frontend()
+render_brand_header()
+
+st.title("🌈 Mezclador espectral FTIR")
+st.caption("Subí una firma objetivo y Rex-AI propondrá una mezcla viable usando el stock disponible.")
+
+try:
+    bundle = ds.load_material_reference_bundle()
+except Exception as error:  # pragma: no cover - fallback for missing datasets
+    st.error(f"No fue posible cargar las curvas de referencia: {error}")
+    st.stop()
+
+if not bundle.spectral_curves:
+    st.info("El bundle de referencia no incluye curvas FTIR para mezclar todavía.")
+    st.stop()
+
+spectral_keys = sorted(bundle.spectral_curves.keys())
+generator = GeneratorService()
+
+with layout_block("layout-stack"):
+    uploaded_file = st.file_uploader(
+        "Arrastrá un CSV con la firma FTIR objetivo",
+        type=["csv"],
+        accept_multiple_files=False,
+    )
+
+    selected_materials = st.multiselect(
+        "Seleccioná materiales base",
+        spectral_keys,
+        default=spectral_keys,
+        help="Las curvas provienen del bundle de referencia Zenodo.",
+    )
+
+    stock_entries: list[dict[str, float | str]] = []
+    if selected_materials:
+        st.markdown("#### Stock disponible")
+        columns = st.columns(max(1, min(3, len(selected_materials))))
+        for column, key in zip(columns, selected_materials, strict=False):
+            stock_entries.append(
+                {
+                    "spectral_key": key,
+                    "kg": column.number_input(
+                        f"{key}",
+                        min_value=0.0,
+                        value=1.0,
+                        step=0.1,
+                        help="Cantidad máxima disponible en kg.",
+                        key=f"spectral-stock-{key}",
+                    ),
+                }
+            )
+    stock_df = pd.DataFrame(stock_entries) if stock_entries else pd.DataFrame(columns=["spectral_key", "kg"])
+
+    max_components = 1
+    if selected_materials:
+        max_components = st.slider(
+            "Máx. componentes en la mezcla",
+            min_value=1,
+            max_value=len(selected_materials),
+            value=min(3, len(selected_materials)),
+        )
+    max_fraction = st.slider(
+        "Fracción total máxima",
+        min_value=0.1,
+        max_value=1.0,
+        value=1.0,
+        step=0.05,
+    )
+
+    result_payload: dict[str, object] | None = None
+    if uploaded_file is not None and selected_materials:
+        try:
+            target_df = pd.read_csv(uploaded_file)
+        except Exception as error:
+            st.error(f"No se pudo leer el CSV: {error}")
+            target_df = pd.DataFrame()
+        if not target_df.empty:
+            try:
+                constraints = {"max_components": max_components, "max_fraction": max_fraction}
+                result_payload = generator.propose_spectral_mix(
+                    target_curve=target_df,
+                    stock_df=stock_df,
+                    constraints=constraints,
+                )
+            except Exception as error:  # pragma: no cover - surfaced to the UI
+                st.error(f"El solver no pudo encontrar una mezcla: {error}")
+        else:
+            st.info("El CSV no contiene filas con datos numéricos.")
+    elif uploaded_file is None:
+        st.info("Cargá un CSV para obtener la mezcla propuesta.")
+    elif not selected_materials:
+        st.info("Seleccioná al menos un material base.")
+
+if not result_payload:
+    st.stop()
+
+coefficients = pd.DataFrame(result_payload.get("coefficients", []))
+synthetic_curve = result_payload.get("synthetic_curve")
+target_curve = result_payload.get("target_curve")
+error_metrics = result_payload.get("error", {})
+
+st.subheader("Comparativa espectral")
+if isinstance(synthetic_curve, pd.DataFrame) and isinstance(target_curve, pd.DataFrame):
+    target_df = target_curve.rename(columns={"intensity": "value"})
+    target_df["serie"] = "Objetivo"
+    synthetic_df = synthetic_curve.rename(columns={"synthetic_intensity": "value"})[["wavenumber_cm_1", "synthetic_intensity"]]
+    synthetic_df = synthetic_df.rename(columns={"synthetic_intensity": "value"})
+    synthetic_df["serie"] = "Mezcla"
+    chart_df = pd.concat([target_df[["wavenumber_cm_1", "value", "serie"]], synthetic_df], ignore_index=True)
+    chart = (
+        alt.Chart(chart_df)
+        .mark_line()
+        .encode(
+            x=alt.X("wavenumber_cm_1", title="Número de onda (cm⁻¹)"),
+            y=alt.Y("value", title="Intensidad"),
+            color=alt.Color("serie", title="Curva"),
+        )
+        .interactive()
+    )
+    st.altair_chart(chart, use_container_width=True)
+else:
+    st.warning("No se pudieron graficar las curvas generadas.")
+
+if not coefficients.empty:
+    st.subheader("Receta recomendada")
+    stock_limits = {}
+    if not stock_df.empty and stock_df["kg"].sum() > 0:
+        total_stock = float(stock_df["kg"].sum())
+        stock_limits = {
+            row["spectral_key"]: float(row["kg"]) / total_stock
+            for _, row in stock_df.iterrows()
+            if float(total_stock) > 0
+        }
+    coefficients["stock_limit"] = coefficients["material"].map(stock_limits).fillna(1.0)
+    coefficients = coefficients.rename(columns={"material": "Material", "fraction": "Fracción", "stock_limit": "Máx. logística"})
+    coefficients["Máx. logística"] = coefficients["Máx. logística"].map(lambda x: f"{x:.2f}")
+    coefficients["Fracción"] = coefficients["Fracción"].map(lambda x: f"{x:.3f}")
+    st.dataframe(coefficients, hide_index=True)
+
+if error_metrics:
+    st.subheader("Errores de ajuste")
+    metrics_df = pd.DataFrame(
+        {
+            "Métrica": ["MAE", "RMSE", "Error máximo"],
+            "Valor": [
+                f"{float(error_metrics.get('mae', float('nan'))):.4f}",
+                f"{float(error_metrics.get('rmse', float('nan'))):.4f}",
+                f"{float(error_metrics.get('max_abs', float('nan'))):.4f}",
+            ],
+        }
+    )
+    st.table(metrics_df)

--- a/tests/test_spectral_mixer.py
+++ b/tests/test_spectral_mixer.py
@@ -1,0 +1,78 @@
+import numpy as np
+import pandas as pd
+import polars as pl
+import pytest
+
+from app.modules import data_sources as ds
+from app.modules.generator import GeneratorService
+from app.modules.spectral_mixer import solve_spectral_recipe
+
+
+@pytest.fixture
+def spectral_bundle(monkeypatch):
+    wavenumbers = np.linspace(500.0, 1500.0, 10)
+    base_a = pd.DataFrame(
+        {
+            "wavenumber_cm_1": wavenumbers,
+            "absorbance": np.linspace(0.1, 0.9, wavenumbers.size),
+        }
+    )
+    base_b = pd.DataFrame(
+        {
+            "wavenumber_cm_1": wavenumbers,
+            "absorbance": np.linspace(0.9, 0.1, wavenumbers.size),
+        }
+    )
+    bundle = ds.MaterialReferenceBundle(
+        pl.DataFrame(),
+        {},
+        {},
+        {},
+        tuple(),
+        {
+            "spec_a": base_a,
+            "spec_b": base_b,
+        },
+        {
+            "spec_a": {"material": "Specimen A"},
+            "spec_b": {"material": "Specimen B"},
+        },
+        {},
+        {},
+    )
+    monkeypatch.setattr(ds, "load_material_reference_bundle", lambda: bundle)
+    return bundle
+
+
+def test_solve_spectral_recipe_recovers_known_mix(spectral_bundle):
+    target_curve = spectral_bundle.spectral_curves["spec_a"].copy()
+    target_curve["absorbance"] = 0.6 * target_curve["absorbance"] + 0.3 * spectral_bundle.spectral_curves["spec_b"]["absorbance"]
+
+    availability = pd.DataFrame({"spectral_key": ["spec_a", "spec_b"]})
+    result = solve_spectral_recipe(target_curve, availability, constraints={"max_fraction": 1.0})
+
+    coefficients = dict(zip(result.basis, result.coefficients, strict=False))
+    assert coefficients["spec_a"] == pytest.approx(0.6, rel=1e-3, abs=1e-3)
+    assert coefficients["spec_b"] == pytest.approx(0.3, rel=1e-3, abs=1e-3)
+    assert result.error_metrics["mae"] == pytest.approx(0.0, abs=1e-9)
+
+
+def test_generator_service_propose_spectral_mix_returns_payload(spectral_bundle):
+    generator = GeneratorService()
+    target_curve = spectral_bundle.spectral_curves["spec_a"].copy()
+    target_curve["absorbance"] = 0.7 * target_curve["absorbance"] + 0.2 * spectral_bundle.spectral_curves["spec_b"]["absorbance"]
+
+    stock_df = pd.DataFrame(
+        {
+            "spectral_key": ["spec_a", "spec_b"],
+            "kg": [2.0, 1.0],
+        }
+    )
+
+    payload = generator.propose_spectral_mix(target_curve, stock_df, constraints={"max_fraction": 1.0})
+    assert "coefficients" in payload and payload["coefficients"]
+    coeff_map = {row["material"]: row["fraction"] for row in payload["coefficients"]}
+    assert coeff_map["spec_a"] == pytest.approx(min(0.7, 2.0 / 3.0), rel=1e-3, abs=1e-3)
+    assert coeff_map["spec_b"] == pytest.approx(0.2, rel=1e-2, abs=3e-2)
+    error = payload.get("error", {})
+    assert error["mae"] == pytest.approx(0.0, abs=2e-2)


### PR DESCRIPTION
## Summary
- implement a constrained spectral mixing solver backed by the material reference bundle
- expose GeneratorService.propose_spectral_mix and surface a Streamlit workflow for FTIR curve uploads
- add targeted tests covering the solver and service payloads

## Testing
- pytest tests/test_spectral_mixer.py

------
https://chatgpt.com/codex/tasks/task_e_68e0aa6e4cc883319db523fd83182735