### PR TITLE
Add inventory category analytics and visualisations

### DIFF
--- a/app/modules/mars_control_center.py
+++ b/app/modules/mars_control_center.py
@@ -13,6 +13,7 @@ from app.modules.io import load_process_df
 from app.modules.mars_control import (
     MarsLogisticsData,
     SimulationEvent,
+    aggregate_inventory_by_category,
     load_jezero_geodata,
     load_logistics_baseline,
     apply_simulation_tick,
@@ -580,12 +581,13 @@ class MarsControlCenterService:
     # Inventory telemetry
     # ------------------------------------------------------------------
 
-    def inventory_snapshot(self) -> tuple[pd.DataFrame, dict[str, float]]:
+    def inventory_snapshot(self) -> tuple[pd.DataFrame, dict[str, float], dict[str, Any]]:
         """Return the latest inventory dataframe with aggregated metrics."""
 
         inventory_df = load_inventory_overview()
         metrics = compute_mission_summary(inventory_df)
-        return inventory_df, metrics
+        category_payload = aggregate_inventory_by_category(inventory_df)
+        return inventory_df, metrics, category_payload
 
     # ------------------------------------------------------------------
     # Timeline & simulation synchronisation


### PR DESCRIPTION
## Summary
- compute inventory category breakdowns, including purity, contamination, water and energy estimates, plus category-to-destination flows inside the mars_control service
- expose the aggregated inventory payload through the MarsControlCenterService for reuse in the dashboard
- redesign the Mars Control Center inventory tab with Sankey and 3D bubble visualisations, badge legend, and stock-synchronised indicators

## Testing
- pytest tests/modules/test_mission_overview.py::test_compute_mass_volume_metrics_aggregates_expected_values

------
https://chatgpt.com/codex/tasks/task_e_68e1391d1778833195593408ef93d14e