### PR TITLE
Generate Mars Control demo audio procedurally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 __pycache__/
 *.pyc
 
+# Generated demo audio clips (synthesised at runtime)
+app/static/audio/*.wav
+
 # Machine learning artifacts
 # By default ignore model outputs but allow committed reference artefacts
 /data/models/

--- a/app/static/audio/README.md
+++ b/app/static/audio/README.md
@@ -1,0 +1,3 @@
+# Demo audio clips
+
+Este directorio se llena en tiempo de ejecución con clips WAV sintéticos generados por `app.modules.mars_control`. No se versionan archivos binarios; los tonos se crean cuando se dispara el guion demo.

--- a/app/static/styles/base.css
+++ b/app/static/styles/base.css
@@ -351,3 +351,158 @@ table {
   outline: 2px solid var(--mission-color-accent);
   outline-offset: 2px;
 }
+
+.demo-event-card {
+  display: flex;
+  align-items: center;
+  gap: var(--mission-space-md);
+  background: linear-gradient(135deg, rgba(17, 27, 45, 0.92), rgba(12, 21, 38, 0.88));
+  border-radius: var(--mission-radius-md);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-left: 4px solid var(--mission-color-accent);
+  padding: var(--mission-space-md);
+  margin-block: var(--mission-space-md);
+  box-shadow: 0 18px 32px rgba(3, 10, 22, 0.35);
+  backdrop-filter: blur(10px);
+}
+
+.demo-event-card__icon {
+  font-size: 2.8rem;
+  line-height: 1;
+  filter: drop-shadow(0 6px 16px rgba(90, 169, 255, 0.35));
+}
+
+.demo-event-card__content {
+  display: flex;
+  flex-direction: column;
+  gap: var(--mission-space-2xs);
+}
+
+.demo-event-card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--mission-color-muted);
+}
+
+.demo-event-card__title {
+  font-size: 1.3rem;
+  font-weight: 700;
+  color: var(--mission-color-text);
+}
+
+.demo-event-card__message {
+  font-size: 1rem;
+  color: var(--mission-color-muted);
+}
+
+.demo-event-card__meta-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--mission-space-2xs);
+  margin-top: var(--mission-space-2xs);
+}
+
+.demo-event-card__tag {
+  font-size: 0.78rem;
+  padding: 0.25rem 0.6rem;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.12);
+  color: var(--mission-color-text);
+}
+
+.demo-event-card--warning {
+  border-left-color: var(--mission-color-warning);
+  box-shadow: 0 18px 40px rgba(242, 192, 87, 0.25);
+}
+
+.demo-event-card--critical {
+  border-left-color: var(--mission-color-critical);
+  box-shadow: 0 20px 46px rgba(241, 136, 130, 0.35);
+}
+
+.demo-event-card--critical .demo-event-card__icon {
+  color: var(--mission-color-critical);
+  animation: demo-critical-pulse 1.2s ease-in-out infinite;
+}
+
+@keyframes demo-critical-pulse {
+  0%,
+  100% {
+    transform: scale(1);
+    filter: drop-shadow(0 6px 18px rgba(241, 136, 130, 0.45));
+  }
+  50% {
+    transform: scale(1.15);
+    filter: drop-shadow(0 10px 24px rgba(241, 136, 130, 0.65));
+  }
+}
+
+.demo-event-ticker {
+  display: flex;
+  gap: var(--mission-space-sm);
+  overflow-x: auto;
+  padding: var(--mission-space-sm);
+  margin-block: var(--mission-space-sm);
+  border-radius: var(--mission-radius-md);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  background: rgba(10, 17, 30, 0.75);
+  scroll-snap-type: x proximity;
+}
+
+.demo-event-ticker__item {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--mission-space-2xs);
+  padding: 0.4rem 0.85rem;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(20, 32, 52, 0.9);
+  color: var(--mission-color-muted);
+  font-size: 0.85rem;
+  white-space: nowrap;
+  scroll-snap-align: center;
+  transition: transform 0.2s ease, border-color 0.2s ease;
+}
+
+.demo-event-ticker__item:hover {
+  transform: translateY(-2px);
+}
+
+.demo-event-ticker__item--warning {
+  border-color: rgba(242, 192, 87, 0.65);
+  color: var(--mission-color-warning);
+}
+
+.demo-event-ticker__item--critical {
+  border-color: rgba(241, 136, 130, 0.75);
+  color: var(--mission-color-critical);
+  animation: demo-ticker-pulse 1.8s ease-in-out infinite;
+}
+
+@keyframes demo-ticker-pulse {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-3px);
+  }
+}
+
+.demo-event-ticker__icon {
+  font-size: 1.1rem;
+}
+
+.demo-event-ticker__text {
+  font-weight: 600;
+}
+
+.demo-event-ticker__time {
+  font-size: 0.75rem;
+  color: var(--mission-color-muted);
+  margin-left: var(--mission-space-2xs);
+}


### PR DESCRIPTION
## Summary
- synthesize Mars Control demo event audio clips at runtime and attach them to history/state without storing binary assets in git
- update the demo tab to play in-memory audio (falling back to on-disk files) and document how the audio directory is populated
- ignore generated WAV clips so the demo loop can emit tones without committing binaries

## Testing
- pytest tests/modules/test_navigation.py *(fails: navigation stepper expectation mismatch in existing test)*

------
https://chatgpt.com/codex/tasks/task_e_68e14276b63883319d9d291bb59a1093