### PR TITLE
Expose Jezero bitmap metadata for Mars control map

### DIFF
--- a/datasets/README.md
+++ b/datasets/README.md
@@ -20,6 +20,13 @@ The raw CSVs under `datasets/raw/` contain the literal values transcribed from
 the NASA PDFs and slide decks so the preprocessing logic below remains
 reproducible.
 
+## Mars surface textures
+
+| File | Source | Licence | Notes |
+| ---- | ------ | ------- | ----- |
+| `mars/Katie_1_-_DLR_Jezero_hi_v2.jpg` | HiRISE orthomosaic for the Mars 2020 Jezero landing ellipse · NASA/JPL-Caltech/University of Arizona with processing by DLR/FU Berlin | NASA imagery is released into the public domain; DLR requires the credit line above when reusing the mosaic. | High-resolution texture used for the Jezero bitmap layer. Derived from the Mars 2020 mission press kit curated for the hackathon. |
+| `mars/8k_mars.jpg` | Mars Global Color Map (MGS/MOLA/VO) assembled by NASA/JPL-Caltech/USGS | Public domain (NASA) | Global fallback texture when the Jezero-specific mosaic is not available. Downsampled to 8K resolution for browser rendering. |
+
 ## Polymer composite supplier data
 
 | Processed file | Source asset | Notes |

--- a/tests/test_mars_control.py
+++ b/tests/test_mars_control.py
@@ -1,0 +1,43 @@
+import pandas as pd
+import pytest
+
+from app.modules.mars_control import load_jezero_bitmap
+from app.modules.mars_control_center import MarsControlCenterService
+
+
+def test_load_jezero_bitmap_payload_structure():
+    payload = load_jezero_bitmap()
+
+    assert set(payload.keys()) >= {"image_uri", "image", "bounds", "center", "metadata"}
+    assert payload["image_uri"].startswith("data:image/")
+
+    bounds = payload["bounds"]
+    assert isinstance(bounds, tuple)
+    assert len(bounds) == 4
+
+    min_lon, min_lat, max_lon, max_lat = bounds
+    assert min_lon < max_lon
+    assert min_lat < max_lat
+
+    metadata = payload["metadata"]
+    assert isinstance(metadata, dict)
+    assert "attribution" in metadata
+    assert metadata.get("mime_type") in {"image/jpeg", "image/png"}
+
+
+def test_build_map_payload_includes_bitmap_and_bounds():
+    service = MarsControlCenterService()
+    flights_df = pd.DataFrame()
+
+    payload = service.build_map_payload(flights_df)
+
+    bitmap = payload.get("bitmap_layer")
+    assert isinstance(bitmap, dict)
+    assert bitmap.get("image")
+    assert payload.get("map_bounds") == bitmap.get("bounds")
+
+    view_state = payload.get("map_view_state")
+    assert isinstance(view_state, dict)
+    assert pytest.approx(bitmap["center"]["latitude"], rel=1e-3) == view_state["latitude"]
+    assert pytest.approx(bitmap["center"]["longitude"], rel=1e-3) == view_state["longitude"]
+    assert 5.0 < view_state["zoom"] < 16.5


### PR DESCRIPTION
## Summary
- add a cached helper to load the Jezero crater bitmap with derived bounds and metadata
- surface the bitmap layer, map bounds, and view state through the Mars control telemetry payload and UI
- document texture licensing details and cover the new payload with unit tests

## Testing
- pytest tests/test_mars_control.py

------
https://chatgpt.com/codex/tasks/task_e_68e155a35ad88331a66ccfbe71b30163