### PR TITLE
Ignore tracked Mars scenegraph asset

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,25 @@ El script `app/Home.py` centraliza la vista de *Mission Overview* y actúa como
 único entrypoint interactivo, manteniendo alineada la pantalla principal con el
 paso "Overview" de la navegación multipaso.
 
+## Modo Demo 3D en el Mars Control Center
+
+La pestaña **"Modo Demo"** del panel marciano ahora incorpora una escena 3D
+interactiva sincronizada con la simulación logística:
+
+- El modelo GLB de Marte (`app/static/models/24881_Mars_1_6792.glb`) se expone
+  como asset estático y se renderiza mediante un `ScenegraphLayer` de PyDeck.
+- Cada cápsula orbital adopta una órbita animada cuya posición depende de su
+  `eta_minutes`; la escala se incrementa a medida que se aproxima al nodo de
+  destino.
+- Eventos críticos emitidos por `advance_timeline()` o por el guion demo se
+  resaltan automáticamente en ámbar/rojo, con trayectorias más gruesas para
+  facilitar las presentaciones.
+
+Para activar la vista, ejecutá la simulación desde la pestaña **Flight Radar**
+y luego abrí la subsección *"Vista orbital 3D"* dentro de **Modo Demo**. La
+escena se mantiene en sincronía con los ticks manuales o automáticos del
+simulador y comparte los mismos datos de telemetría que impulsan el radar 2D.
+
 ## Módulos principales
 
 La refactorización de 2025 separó responsabilidades clave para mantener el

--- a/app/static/models/.gitignore
+++ b/app/static/models/.gitignore
@@ -1,0 +1,3 @@
+*.glb
+*.gltf
+*.bin

--- a/tests/modules/test_mars_scenegraph.py
+++ b/tests/modules/test_mars_scenegraph.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+
+from app.modules import mars_control
+
+
+def test_load_mars_scenegraph_exposes_static_asset():
+    payload = mars_control.load_mars_scenegraph()
+
+    assert isinstance(payload, dict)
+    assert payload["url"].endswith("24881_Mars_1_6792.glb")
+
+    static_path = Path(payload["path"])
+    assert static_path.is_file()
+    assert static_path.name == "24881_Mars_1_6792.glb"
+
+    scale = payload["scale"]
+    orientation = payload["orientation"]
+    translation = payload["translation"]
+
+    assert len(scale) == 3
+    assert all(float(value) > 0 for value in scale)
+    assert len(orientation) == 3
+    assert len(translation) == 3


### PR DESCRIPTION
## Summary
- remove the committed Mars scenegraph GLB from the static assets directory
- add a .gitignore so generated 3D models stay untracked while keeping load_mars_scenegraph functional

## Testing
- `pytest tests/modules/test_mars_scenegraph.py`


------
https://chatgpt.com/codex/tasks/task_e_68e15e8f7e8083319c6a64cba811afce