### PR TITLE
Document Mars Orbit Hub and add mars_control tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,49 @@ El script `app/Home.py` centraliza la vista de *Mission Overview* y actúa como
 único entrypoint interactivo, manteniendo alineada la pantalla principal con el
 paso "Overview" de la navegación multipaso.
 
+### Mars Orbit Hub — Centro de control
+
+El nuevo *Mars Orbit Hub* vive dentro del multipage de Streamlit. Podés abrirlo
+de dos maneras equivalentes:
+
+```bash
+# Abre el multipage completo y navegá hasta "10 · Mars Control Center"
+streamlit run app/Home.py
+
+# O bien ejecutá sólo el hub táctico
+streamlit run app/pages/10_Mars_Control_Center.py
+```
+
+La experiencia está organizada en cinco tabs sincronizados con los servicios de
+`app.modules.mars_control` y `app.modules.mars_control_center`:
+
+1. **🛰️ Flight Radar / Mapa**. Fusiona la telemetría de vuelos del YAML
+   `data/mars_logistics.yaml` con la geometría GeoJSON de
+   `app/static/geodata/jezero.geojson` para renderizar rutas, zonas operativas y
+   cápsulas activas.
+   El botón *Avanzar simulación* y el *auto tick* de 20 s alimentan la cola de
+   eventos sintetizados por `apply_simulation_tick()`.
+2. **📦 Inventario vivo**. Expone las agregaciones de
+   `aggregate_inventory_by_category()` con destino, pureza estimada, energía y
+   agua requeridos. Es la vista recomendada para auditar el backlog por
+   categoría y material.
+3. **🤖 Decisiones IA**. Consume el bundle generado por
+   `GeneratorService.analyze_manifest()` para mostrar puntuaciones medias,
+   compatibilidades y el resumen compacto de acciones (ganancia promedio, cuota
+   sugerida, top recomendaciones) que entrega `summarise_policy_actions()`.
+4. **🗺️ Planner**. Vincula los ítems críticos del manifiesto con procesos
+   sugeridos mediante `MarsControlCenterService.build_planner_schedule()`,
+   priorizando masa declarada y razones de asignación.
+5. **🎛️ Modo Demo**. Activa el guion sintético del control room. Permite
+   habilitar un loop automático, reiniciar el script, inyectar manifiestos demo
+   y reproducir los clips de audio WAV empaquetados en `app/static/audio/`.
+
+> ℹ️ **Modo demo**: cuando el loop automático está activo, `generate_demo_event`
+> emite un evento cada `n` segundos (configurable). El botón "Inyectar
+> manifiesto demo" ejecuta `run_policy_analysis()` sobre los presets de
+> `mars_control.demo_manifest_catalogue()`, refrescando en vivo el radar y las
+> decisiones IA.
+
 ## Módulos principales
 
 La refactorización de 2025 separó responsabilidades clave para mantener el

--- a/datasets/README.md
+++ b/datasets/README.md
@@ -338,3 +338,18 @@ feature columns (`oxide_<oxide_name>`) written by the generator.
   `water_release` fields set the default `regolith_pct` used throughout
   candidate generation, while the remaining property columns (e.g.
   `density_bulk`) stay available for future feature engineering.
+
+## Mars logistics baseline & geodata
+
+The Mars Control Center relies on two lightweight artefacts to simulate flight
+operations and map overlays:
+
+| File | Description | Refresh strategy |
+| ---- | ----------- | ---------------- |
+| `data/mars_logistics.yaml` | Curated baseline of capsules, scheduled flights, industrial processes and Rex-AI orders used by `app.modules.mars_control.load_logistics_baseline`. | Edit the YAML directly when new capsules/routes are introduced. The helper accepts ISO-8601 timestamps (`Z` suffix) and falls back to `_DEFAULT_DATASET` when optional sections are omitted. |
+| `app/static/geodata/jezero.geojson` | GeoJSON footprint covering the Jezero operational envelope, landing zones and resource areas displayed on the pydeck map. | Update polygon coordinates or feature properties in place. The loader caches the geometry and emits a Streamlit warning if the file is not valid GeoJSON. |
+
+Both artefacts are versioned because they seed the demo experience. When
+iterating on them locally you can force a reload by calling
+`mars_control.load_logistics_baseline(refresh=True)` or
+`mars_control.load_jezero_geodata(refresh=True)` inside a Python shell.

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -2585,11 +2585,33 @@ def test_analyze_manifest_exports_policy_artifacts(tmp_path):
 
     recommendations = pd.read_csv(policy_path)
     assert not recommendations.empty
+    expected_columns = {
+        "item_index",
+        "item_name",
+        "current_material_key",
+        "current_score",
+        "recommended_material_key",
+        "recommended_score",
+        "recommended_quota",
+        "action",
+        "justification",
+        "evidence_json",
+    }
+    assert expected_columns.issubset(set(recommendations.columns))
+    for payload in recommendations["evidence_json"].dropna():
+        parsed = json.loads(payload)
+        assert set(parsed).issuperset({"sources", "evidence"})
 
     compatibility = pd.read_parquet(compat_path)
     assert "sources_json" in compatibility.columns
+    for payload in compatibility["sources_json"].dropna():
+        json.loads(payload)
 
     passport = json.loads(passport_path.read_text("utf-8"))
     assert passport["total_items"] == 1
     assert isinstance(passport["compatibility_sources"], list)
     assert passport["compatibility_sources"]
+    assert passport["recommendations"]
+    for entry in passport["recommendations"]:
+        assert "evidence_json" in entry
+        json.loads(entry["evidence_json"])

--- a/tests/test_mars_control.py
+++ b/tests/test_mars_control.py
@@ -1,0 +1,255 @@
+import json
+from datetime import datetime, timezone
+
+import pandas as pd
+import pytest
+import yaml
+
+from app.modules import mars_control
+
+
+@pytest.fixture(autouse=True)
+def reset_caches(monkeypatch):
+    # Ensure every test starts from a clean baseline cache.
+    monkeypatch.setattr(mars_control, "_BASELINE_CACHE", None, raising=False)
+    monkeypatch.setattr(mars_control, "_JEZERO_GEODATA_CACHE", None, raising=False)
+
+
+def test_load_logistics_baseline_parses_yaml(tmp_path, monkeypatch):
+    dataset = {
+        "flights": [
+            {
+                "flight_id": "MC-999",
+                "capsule_id": "ares",
+                "origin": "Hub",
+                "destination": "Base",
+                "departure": "2043-04-12T06:30:00Z",
+                "arrival": "2043-04-12T18:05:00Z",
+                "status": "en_route",
+                "payload_mass_kg": 1234.5,
+                "manifest_ref": "manifest-test",
+            }
+        ],
+        "capsules": [
+            {
+                "capsule_id": "ares",
+                "name": "Ares",
+                "capacity_kg": 1500,
+                "status": "active",
+                "location": "Orbit",
+                "notes": "Ready",
+            }
+        ],
+        "processes": [
+            {
+                "process_id": "refinery",
+                "name": "Refinery",
+                "throughput_kg_per_day": 50,
+                "energy_kwh_per_kg": 1.2,
+                "crew_hours_per_day": 5,
+            }
+        ],
+        "orders": [
+            {
+                "order_id": "ia-1",
+                "issued_at": "2043-04-12T05:00:00Z",
+                "priority": "high",
+                "directive": "Priorizar",
+                "target": "manifest-test",
+                "context": "Testing",
+            }
+        ],
+        "event_templates": {"inbound": [{"title": "Arribo", "description": "Desc", "delta_mass_kg": 42}]},
+    }
+    dataset_path = tmp_path / "mars_logistics.yaml"
+    dataset_path.write_text(yaml.safe_dump(dataset), encoding="utf-8")
+
+    monkeypatch.setattr(mars_control, "DATA_ROOT", tmp_path, raising=False)
+
+    data = mars_control.load_logistics_baseline(refresh=True)
+
+    assert len(data.flights) == 1
+    flight = data.flights[0]
+    assert flight.flight_id == "MC-999"
+    assert flight.capsule_id == "ares"
+    assert flight.payload_mass_kg == pytest.approx(1234.5)
+    assert isinstance(flight.departure, datetime)
+    assert flight.departure.tzinfo == timezone.utc
+
+    assert len(data.capsules) == 1
+    capsule = data.capsules[0]
+    assert capsule.capacity_kg == pytest.approx(1500.0)
+    assert capsule.notes == "Ready"
+
+    assert len(data.processes) == 1
+    process = data.processes[0]
+    assert process.energy_kwh_per_kg == pytest.approx(1.2)
+
+    assert len(data.ai_orders) == 1
+    order = data.ai_orders[0]
+    assert order.priority == "high"
+    assert order.target == "manifest-test"
+
+    assert "inbound" in data.event_templates
+    assert data.event_templates["inbound"][0]["title"] == "Arribo"
+
+
+def test_aggregate_inventory_by_category_returns_flows():
+    inventory = pd.DataFrame(
+        [
+            {
+                "category": "Foam Packaging",
+                "material_family": "PVDF",
+                "flags": "foam;pvdf",
+                "key_materials": "PVDF 85%; binder",
+                "mass_kg": 120.0,
+                "volume_l": 320.0,
+                "moisture_pct": 5,
+                "difficulty_factor": 1.5,
+            },
+            {
+                "category": "Metal Struts",
+                "material_family": "Alloy",
+                "flags": "structural",
+                "key_materials": "Ti-6Al-4V",
+                "mass_kg": 80.0,
+                "volume_l": 150.0,
+                "moisture_pct": 1,
+                "difficulty_factor": 2.2,
+                "_problematic": True,
+            },
+        ]
+    )
+
+    payload = mars_control.aggregate_inventory_by_category(inventory)
+
+    normalized = payload["normalized"]
+    categories = payload["categories"]
+    flows = payload["flows"]
+
+    assert not normalized.empty
+    assert set(["purity_index", "cross_contamination_risk", "recycle_mass_kg"]).issubset(normalized.columns)
+
+    assert categories.shape[0] == 2
+    assert categories["total_mass_kg"].sum() == pytest.approx(200.0)
+    assert {"Foam Packaging", "Metal Struts"} == set(categories["category"])
+
+    assert not flows.empty
+    assert flows.groupby("destination_key")["mass_kg"].sum().sum() == pytest.approx(200.0)
+    assert set(payload["material_groups"]).issuperset({"espumas", "metales"})
+    assert set(payload["destinations"]).issuperset({"recycle", "reuse", "stock"})
+
+
+def test_apply_simulation_tick_generates_events(monkeypatch):
+    logistics = mars_control.MarsLogisticsData(
+        flights=[],
+        capsules=[],
+        processes=[],
+        ai_orders=[],
+        event_templates={
+            "inbound": [
+                {
+                    "title": "Arribo parcial",
+                    "description": "Carga recibida",
+                    "delta_mass_kg": 100,
+                    "capsule_id": "ares",
+                }
+            ],
+            "orders": [
+                {
+                    "title": "Orden IA",
+                    "description": "Revisar",
+                    "reference": "ia-1",
+                }
+            ],
+        },
+    )
+
+    monkeypatch.setattr(mars_control, "load_logistics_baseline", lambda: logistics)
+    monkeypatch.setattr(
+        mars_control,
+        "compute_mission_summary",
+        lambda inventory=None, logistics=None: {"mass_kg": 320.0},
+    )
+
+    session: dict[str, object] = {}
+
+    first_tick = mars_control.apply_simulation_tick(session=session)
+    assert len(first_tick) == 2
+    assert first_tick[0].tick == 1
+    assert first_tick[0].category == "inbound"
+    assert first_tick[0].metadata["mass_delta"] == pytest.approx(100.0)
+
+    cached_tick = mars_control.apply_simulation_tick(session=session)
+    assert len(cached_tick) == 2
+    assert {event.tick for event in cached_tick} == {2}
+
+    injected = mars_control.apply_simulation_tick(
+        {"inject_event": {"category": "manual", "title": "Test", "details": "Injected"}},
+        session=session,
+    )
+    assert len(injected) == 3
+    assert any(event.category == "manual" for event in injected)
+
+    history = mars_control.iterate_events(since_tick=1, session=session)
+    assert all(event.tick >= 2 for event in history)
+
+
+def test_score_manifest_batch_builds_policy_summary():
+    policy_df = pd.DataFrame(
+        [
+            {
+                "item_name": "PVDF Foam",
+                "current_score": 0.4,
+                "recommended_score": 0.72,
+                "recommended_quota": 0.6,
+                "action": "substitute",
+                "justification": "Compatibilidad validada",
+            },
+            {
+                "item_name": "Metal Strut",
+                "current_score": 0.55,
+                "recommended_score": 0.7,
+                "recommended_quota": 0.4,
+                "action": "reprioritize",
+                "justification": "Reducir penalización",
+            },
+        ]
+    )
+
+    manifest_df = pd.DataFrame(
+        [
+            {"item": "PVDF Foam", "mass_kg": 10.0, "material_utility_score": 0.4},
+            {"item": "Metal Strut", "mass_kg": 15.0, "material_utility_score": 0.55},
+        ]
+    )
+
+    class FakeService:
+        def analyze_manifest(self, manifest):  # pragma: no cover - simple stub
+            return {
+                "manifest": manifest_df,
+                "scored_manifest": manifest_df,
+                "policy_recommendations": policy_df,
+                "material_passport": {
+                    "total_items": 2,
+                    "total_mass_kg": 25.0,
+                    "mean_material_utility_score": 0.475,
+                },
+            }
+
+    results = mars_control.score_manifest_batch(FakeService(), [manifest_df])
+    assert len(results) == 1
+    summary = results[0]["summary"]
+    policy_summary = summary["policy_summary"]
+
+    assert summary["total_mass_kg"] == pytest.approx(25.0)
+    assert summary["item_count"] == 2
+    assert policy_summary["total_actions"] == 2
+    assert policy_summary["mean_score_gain"] == pytest.approx(0.235, rel=1e-6)
+    assert {"substitute", "reprioritize"} == set(policy_summary["actions_by_type"])
+    assert len(policy_summary["top_actions"]) >= 1
+
+    serialized = json.dumps(results[0]["material_passport"])
+    round_trip = json.loads(serialized)
+    assert round_trip["total_items"] == 2
+    assert round_trip["total_mass_kg"] == pytest.approx(25.0)


### PR DESCRIPTION
## Summary
- document how to launch the Mars Orbit Hub and describe the new tabs and demo flow in the main README
- extend the datasets README with the logistics YAML and Jezero GeoJSON artefacts that feed the control center
- add unit coverage for mars_control helpers and tighten generator policy artefact assertions

## Testing
- pytest tests/test_mars_control.py tests/test_generator.py

------
https://chatgpt.com/codex/tasks/task_e_68e149dd7ba88331ac49ee81b0be8241