### PR TITLE
Remove unsupported height parameter from Mars Control Center map

### DIFF
--- a/app/pages/10_Mars_Control_Center.py
+++ b/app/pages/10_Mars_Control_Center.py
@@ -1999,7 +1999,7 @@ with tabs[4]:
                 map_style=None,
                 tooltip=tooltip,
             )
-            st.pydeck_chart(deck, use_container_width=True, height=540)
+            st.pydeck_chart(deck, use_container_width=True)
             st.caption(
                 "La escena sincroniza la órbita de cada cápsula con la simulación: el tamaño refleja el progreso y los eventos críticos se resaltan en ámbar."
             )


### PR DESCRIPTION
## Summary
- remove the unsupported `height` keyword argument from the Mars Control Center `st.pydeck_chart` call so the page can render

## Testing
- streamlit run app/pages/10_Mars_Control_Center.py --server.headless true --global.developmentMode=false

------
https://chatgpt.com/codex/tasks/task_e_68e167febe188331ac33a994c6fe0bc5