### PR TITLE
Fix Mars Control Center bootstrap imports

### DIFF
--- a/app/pages/10_Mars_Control_Center.py
+++ b/app/pages/10_Mars_Control_Center.py
@@ -4,9 +4,16 @@ from datetime import datetime
 import hashlib
 import io
 import json
+import sys
 from pathlib import Path
 import html
 import math
+
+if not __package__:
+    repo_root = Path(__file__).resolve().parents[2]
+    repo_root_str = str(repo_root)
+    if repo_root_str not in sys.path:
+        sys.path.insert(0, repo_root_str)
 
 from app.bootstrap import ensure_streamlit_entrypoint
 


### PR DESCRIPTION
## Summary
- ensure the Mars Control Center page updates sys.path like other pages before bootstrapping Streamlit

## Testing
- No tests were run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e16b31fb7883318f01321892e02ab5