### PR TITLE
Fix Mars tooltip serialization for pydeck

### DIFF
--- a/app/pages/10_Mars_Control_Center.py
+++ b/app/pages/10_Mars_Control_Center.py
@@ -24,7 +24,6 @@ from typing import Any, Mapping, Sequence
 import pandas as pd
 import plotly.graph_objects as go
 import pydeck as pdk
-from pydeck.types import String as DeckString
 import streamlit as st
 
 from app.modules import data_sources as ds
@@ -1982,22 +1981,20 @@ with tabs[4]:
                 min_zoom=7.2,
                 max_zoom=16.5,
             )
+            tooltip_html = (
+                "<div style='font-size:14px;font-weight:600;'>{capsule}</div>"
+                "<div>ETA: {eta_minutes} min</div>"
+                "<div>{status}</div>"
+                "<div>{tooltip}</div>"
+            )
             tooltip = {
-                "html": DeckString(
-                    (
-                        "<div style='font-size:14px;font-weight:600;'>{capsule}</div>"
-                        "<div>ETA: {eta_minutes} min</div>"
-                        "<div>{status}</div>"
-                        "<div>{tooltip}</div>"
-                    ),
-                    quote_type="'",
-                ),
+                "html": tooltip_html,
                 "style": {
-                    "backgroundColor": DeckString("#0b1220", quote_type="'"),
-                    "color": DeckString("#f8fafc", quote_type="'"),
-                    "border": DeckString("1px solid #38bdf8", quote_type="'"),
-                    "borderRadius": DeckString("8px", quote_type="'"),
-                    "padding": DeckString("10px", quote_type="'"),
+                    "backgroundColor": "#0b1220",
+                    "color": "#f8fafc",
+                    "border": "1px solid #38bdf8",
+                    "borderRadius": "8px",
+                    "padding": "10px",
                 },
             }
             deck = pdk.Deck(


### PR DESCRIPTION
## Summary
- replace Mars orbital view tooltip DeckString usage with native strings for JSON serialization
- keep tooltip styling and content identical while ensuring compatibility with pydeck

## Testing
- python - <<'PY'


------
https://chatgpt.com/codex/tasks/task_e_68e16b9817dc8331ab23d296cbd60ade