### PR TITLE
Fix official match detection and add regression test

### DIFF
--- a/app/modules/generator/service.py
+++ b/app/modules/generator/service.py
@@ -869,11 +869,14 @@ def _inject_official_features(frame: pd.DataFrame) -> pd.DataFrame:
 
     combine_exprs: list[pl.Expr] = []
     drop_official: list[str] = []
+    match_checks: list[pl.Expr] = []
     left_columns = set(inventory_pl.columns)
+    available_columns = set(joined_lazy.collect_schema().names())
     for column in bundle.value_columns:
         official_name = f"{column}_official"
-        if official_name not in joined_lazy.columns:
+        if official_name not in available_columns:
             continue
+        match_checks.append(pl.col(official_name).is_not_null())
         if column in left_columns:
             combine_exprs.append(
                 pl.when(pl.col(official_name).is_not_null())
@@ -887,19 +890,15 @@ def _inject_official_features(frame: pd.DataFrame) -> pd.DataFrame:
 
     if combine_exprs:
         joined_lazy = joined_lazy.with_columns(combine_exprs)
-    if drop_official:
-        joined_lazy = joined_lazy.drop(drop_official)
-
-    match_checks = [
-        pl.col(column).is_not_null() for column in bundle.value_columns if column in joined_lazy.columns
-    ]
     if match_checks:
         joined_lazy = joined_lazy.with_columns(
             pl.when(pl.any_horizontal(match_checks))
             .then(pl.col("_official_match_key"))
-            .otherwise(pl.col("_official_match_key"))
+            .otherwise(pl.lit(""))
             .alias("_official_match_key")
         )
+    if drop_official:
+        joined_lazy = joined_lazy.drop(drop_official)
 
     if bundle.l2l_category_features:
         category_rows = [

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -1512,6 +1512,23 @@ def test_prepare_waste_frame_direct_match_overrides_official_fields():
     assert pytest.approx(row["density_kg_m3"], rel=1e-2) == 100.0
 
 
+def test_prepare_waste_frame_clears_match_key_when_unmatched():
+    waste_df = pd.DataFrame(
+        {
+            "id": ["missing_official"],
+            "category": ["Uncharted Debris"],
+            "material": ["Mystery Polymer"],
+            "kg": [1.0],
+            "volume_l": [0.5],
+            "flags": [""],
+        }
+    )
+
+    prepared = generator.prepare_waste_frame(waste_df)
+
+    assert prepared.loc[0, "_official_match_key"] == ""
+
+
 def test_prepare_waste_frame_includes_reference_columns(reference_dataset_tables):
     expected_columns: set[str] = set()
     for prefix, table in reference_dataset_tables.items():


### PR DESCRIPTION
## Summary
- cache the joined schema when injecting official features and use it for determining available columns
- reset `_official_match_key` when no official values are applied, preventing stale match keys
- add a regression test covering materials without official data to ensure unmatched rows stay unmatched

## Testing
- pytest tests/test_generator.py::test_prepare_waste_frame_clears_match_key_when_unmatched


------
https://chatgpt.com/codex/tasks/task_e_68e17045c1988331991ebb032cf670d8