### PR TITLE
Serve Mars bitmap layers from static URLs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,10 @@ __pycache__/
 # Generated demo audio clips (synthesised at runtime)
 app/static/audio/*.wav
 
+# Mars textures copied to the static directory at runtime
+/app/static/mars/*
+!/app/static/mars/.gitkeep
+
 # Machine learning artifacts
 # By default ignore model outputs but allow committed reference artefacts
 /data/models/

--- a/app/pages/10_Mars_Control_Center.py
+++ b/app/pages/10_Mars_Control_Center.py
@@ -862,30 +862,33 @@ with tabs[0]:
 
         layers: list[pdk.Layer] = []
 
-        def _resolve_bitmap_image(payload: Mapping[str, Any] | None) -> str | None:
+        def _resolve_bitmap_image(payload: Mapping[str, Any] | None) -> Mapping[str, Any] | None:
             if not isinstance(payload, Mapping):
                 return None
             image_candidate = payload.get("image")
             if isinstance(image_candidate, Mapping):
-                if isinstance(image_candidate.get("data"), str):
-                    return image_candidate["data"]
-                if isinstance(image_candidate.get("uri"), str):
-                    return image_candidate["uri"]
-            elif isinstance(image_candidate, str):
-                return image_candidate
+                url_candidate = image_candidate.get("url")
+                if isinstance(url_candidate, str):
+                    return {"url": url_candidate}
+                data_candidate = image_candidate.get("data")
+                if isinstance(data_candidate, str):
+                    return {"data": data_candidate}
+                uri_candidate = image_candidate.get("uri")
+                if isinstance(uri_candidate, str):
+                    return {"uri": uri_candidate}
             if isinstance(payload.get("image_uri"), str):
-                return payload["image_uri"]
+                return {"data": payload["image_uri"]}
             return None
 
         if isinstance(bitmap_payload, Mapping):
-            image_resource = _resolve_bitmap_image(bitmap_payload)
+            image_payload = _resolve_bitmap_image(bitmap_payload)
             bounds = bitmap_payload.get("bounds")
-            if image_resource and bounds:
+            if image_payload and bounds:
                 layers.append(
                     pdk.Layer(
                         "BitmapLayer",
                         id="jezero-bitmap",
-                        image=image_resource,
+                        image=image_payload,
                         bounds=bounds,
                         opacity=0.92,
                         desaturate=0.0,

--- a/datasets/README.md
+++ b/datasets/README.md
@@ -27,6 +27,10 @@ reproducible.
 | `mars/Katie_1_-_DLR_Jezero_hi_v2.jpg` | HiRISE orthomosaic for the Mars 2020 Jezero landing ellipse · NASA/JPL-Caltech/University of Arizona with processing by DLR/FU Berlin | NASA imagery is released into the public domain; DLR requires the credit line above when reusing the mosaic. | High-resolution texture used for the Jezero bitmap layer. Derived from the Mars 2020 mission press kit curated for the hackathon. |
 | `mars/8k_mars.jpg` | Mars Global Color Map (MGS/MOLA/VO) assembled by NASA/JPL-Caltech/USGS | Public domain (NASA) | Global fallback texture when the Jezero-specific mosaic is not available. Downsampled to 8K resolution for browser rendering. |
 
+These assets are mirrored into the Streamlit static directory and exposed under
+`/static/mars/<archivo>` so the dashboard layers can reference a CDN-friendly
+URL while keeping the original provenance metadata bundled with the dataset.
+
 ## Polymer composite supplier data
 
 | Processed file | Source asset | Notes |

--- a/tests/test_mars_control.py
+++ b/tests/test_mars_control.py
@@ -14,6 +14,9 @@ def test_load_jezero_bitmap_payload_structure():
 
     assert set(payload.keys()) >= {"image_uri", "image", "bounds", "center", "metadata"}
     assert payload["image_uri"].startswith("data:image/")
+    image_payload = payload["image"]
+    assert isinstance(image_payload, dict)
+    assert image_payload.get("url", "").endswith(".jpg")
 
     bounds = payload["bounds"]
     assert isinstance(bounds, tuple)
@@ -27,6 +30,9 @@ def test_load_jezero_bitmap_payload_structure():
     assert isinstance(metadata, dict)
     assert "attribution" in metadata
     assert metadata.get("mime_type") in {"image/jpeg", "image/png"}
+    assert metadata.get("asset_url") == image_payload.get("url")
+    assert metadata.get("license")
+    assert metadata.get("provenance")
 
 
 def test_build_map_payload_includes_bitmap_and_bounds():
@@ -37,7 +43,8 @@ def test_build_map_payload_includes_bitmap_and_bounds():
 
     bitmap = payload.get("bitmap_layer")
     assert isinstance(bitmap, dict)
-    assert bitmap.get("image")
+    assert isinstance(bitmap.get("image"), dict)
+    assert "static/mars/" in bitmap.get("image", {}).get("url", "")
     assert payload.get("map_bounds") == bitmap.get("bounds")
 
     view_state = payload.get("map_view_state")
@@ -57,6 +64,8 @@ def test_load_jezero_slope_bitmap_contains_legend():
     assert legend.get("description")
     assert isinstance(legend.get("ticks"), list) and legend["ticks"]
     assert payload.get("image_uri").startswith("data:image/")
+    assert isinstance(payload.get("image"), dict)
+    assert payload["image"].get("url")
 
 
 def test_load_jezero_ortho_bitmap_metadata():


### PR DESCRIPTION
## Summary
- copy the Jezero bitmaps into `app/static/mars/` via the shared static-asset helper and include the served URL + provenance metadata
- update the Mars Control Center bitmap resolution logic to prioritise the static URL payloads for deck.gl layers
- refresh the Mars control tests/documentation and ignore runtime copies of the mirrored textures

## Testing
- pytest tests/test_mars_control.py

------
https://chatgpt.com/codex/tasks/task_e_68e1755c1f0083319e57bae8e0b0cf43