### PR TITLE
Handle default generator target preset

### DIFF
--- a/app/pages/3_Generator.py
+++ b/app/pages/3_Generator.py
@@ -19,6 +19,7 @@ import altair as alt
 import pandas as pd
 import streamlit as st
 
+from app.modules import load_targets
 from app.modules.candidate_showroom import render_candidate_showroom
 from app.modules.io import (  # si tu IO usa load_process_catalog, cámbialo aquí
     MissingDatasetError,
@@ -118,6 +119,22 @@ _playbook_prefilters, _playbook_prefill_label = view_model.pop_playbook_prefill(
 st.header("Generador asistido por IA")
 
 target = view_model.get_target()
+auto_applied_target_name: str | None = None
+if target is None:
+    try:
+        presets = load_targets()
+    except MissingDatasetError:
+        presets = []
+
+    if presets:
+        target = dict(presets[0])
+        view_model.set_target(target)
+        auto_applied_target_name = str(target.get("name") or "Objetivo predefinido").strip() or "Objetivo predefinido"
+
+if auto_applied_target_name:
+    st.caption(
+        f"Se aplicó automáticamente el objetivo **{auto_applied_target_name}** desde los presets disponibles."
+    )
 
 
 def _collect_external_profiles(candidate: Mapping[str, Any], inventory: pd.DataFrame) -> dict[str, Any]:

--- a/tests/pages/test_generator_page.py
+++ b/tests/pages/test_generator_page.py
@@ -21,6 +21,7 @@ def _generator_page_app(
     *,
     force_control_expander_none: bool = False,
     missing_dataset: bool = False,
+    use_initial_target: bool = True,
 ) -> None:
     import os
     import runpy
@@ -93,6 +94,7 @@ def _generator_page_app(
     import app.modules.ml_models as ml_models
     import app.modules.visualizations as visualizations
     import app.modules.page_data as page_data
+    import app.modules as modules
 
     original_load_theme = ui_blocks.load_theme
     ui_blocks.load_theme = lambda **_: None  # type: ignore[assignment]
@@ -196,6 +198,18 @@ def _generator_page_app(
 
     page_data.build_ranking_table = fake_ranking_table
 
+    default_target = {
+        "name": "Residence Renovations",
+        "scenario": "Residence Renovations",
+        "max_energy_kwh": 2.5,
+        "max_water_l": 1.8,
+        "max_crew_min": 60.0,
+        "crew_time_low": False,
+    }
+
+    original_load_targets = modules.load_targets
+    modules.load_targets = lambda: [default_target]
+
     st.session_state.clear()
 
     class StubService:
@@ -203,15 +217,8 @@ def _generator_page_app(
             return [], pd.DataFrame()
 
     view_model = GeneratorViewModel.from_streamlit(service=StubService())
-    view_model.set_target(
-        {
-            "name": "Residence Renovations",
-            "max_energy_kwh": 2.5,
-            "max_water_l": 1.8,
-            "max_crew_min": 60.0,
-            "crew_time_low": False,
-        }
-    )
+    if use_initial_target:
+        view_model.set_target(default_target)
     candidates_seed = [
         {
             "score": 0.87,
@@ -254,6 +261,7 @@ def _generator_page_app(
         ml_models.get_model_registry = original_model_registry
         visualizations.ConvergenceScene = original_scene
         page_data.build_ranking_table = original_ranking
+        modules.load_targets = original_load_targets
 
 
 @pytest.fixture
@@ -341,6 +349,16 @@ def test_generator_page_renders_without_inventory(
     # Expect at least the generator header to render even with minimal data.
     headers = " ".join(block.body for block in app.header)
     assert "Generador asistido por IA" in headers
+
+
+def test_generator_page_auto_applies_default_target(
+    run_generator_page: Callable[..., object]
+) -> None:
+    app = run_generator_page(None, use_initial_target=False)
+
+    captions = " ".join(block.body for block in app.caption)
+    assert "Se aplicó automáticamente el objetivo" in captions
+    assert "Residence Renovations" in captions
 
 
 def test_generator_page_shows_error_for_missing_dataset(


### PR DESCRIPTION
## Summary
- ensure the generator page loads a default target preset when no prior selection is available and inform the user about the applied objective
- keep the view model target in sync to avoid losing the preset after reruns and adjust the generator page tests to cover the new behavior

## Testing
- `pytest tests/pages/test_generator_page.py`


------
https://chatgpt.com/codex/tasks/task_e_68e178d0db308331afb13378db32756d