### PR TITLE
Adjust pydeck height handling

### DIFF
--- a/app/pages/10_Mars_Control_Center.py
+++ b/app/pages/10_Mars_Control_Center.py
@@ -686,10 +686,9 @@ def _render_orbital_scene(
         map_style=None,
         tooltip=context["tooltip"],
     )
-    chart_kwargs = {"use_container_width": True}
     if height is not None:
-        chart_kwargs["height"] = height
-    target.pydeck_chart(deck, **chart_kwargs)
+        deck.height = height
+    target.pydeck_chart(deck, use_container_width=True)
     if show_caption:
         target.caption(context["caption"])
 


### PR DESCRIPTION
## Summary
- set the 3D orbital deck height directly on the Deck object
- always render the scene using use_container_width without chart-level height overrides

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e17beb62808331b44c998a78fc172d