### PR TITLE
Serve Mars radar textures from static URLs

### DIFF
--- a/app/modules/mars_control.py
+++ b/app/modules/mars_control.py
@@ -799,13 +799,16 @@ def _load_bitmap_layer(
     if legend:
         metadata["legend"] = legend
 
-    return {
-        "image_uri": image_uri,
-        "image": {"url": asset_url},
+    payload: dict[str, Any] = {
+        "image": asset_url,
         "bounds": bounds,
         "center": center,
         "metadata": metadata,
     }
+    if image_uri:
+        payload["fallback_image_uri"] = image_uri
+
+    return payload
 
 
 @st.cache_data(show_spinner=False)

--- a/app/pages/10_Mars_Control_Center.py
+++ b/app/pages/10_Mars_Control_Center.py
@@ -1054,22 +1054,25 @@ with tabs[0]:
 
         layers: list[pdk.Layer] = []
 
-        def _resolve_bitmap_image(payload: Mapping[str, Any] | None) -> Mapping[str, Any] | None:
+        def _resolve_bitmap_image(payload: Mapping[str, Any] | None) -> str | None:
             if not isinstance(payload, Mapping):
                 return None
             image_candidate = payload.get("image")
+            if isinstance(image_candidate, str):
+                return image_candidate
             if isinstance(image_candidate, Mapping):
                 url_candidate = image_candidate.get("url")
                 if isinstance(url_candidate, str):
-                    return {"url": url_candidate}
-                data_candidate = image_candidate.get("data")
-                if isinstance(data_candidate, str):
-                    return {"data": data_candidate}
-                uri_candidate = image_candidate.get("uri")
-                if isinstance(uri_candidate, str):
-                    return {"uri": uri_candidate}
-            if isinstance(payload.get("image_uri"), str):
-                return {"data": payload["image_uri"]}
+                    return url_candidate
+                legacy_candidate = image_candidate.get("uri")
+                if isinstance(legacy_candidate, str):
+                    return legacy_candidate
+            fallback_uri = payload.get("fallback_image_uri")
+            if isinstance(fallback_uri, str):
+                return fallback_uri
+            legacy_data_uri = payload.get("image_uri")
+            if isinstance(legacy_data_uri, str):
+                return legacy_data_uri
             return None
 
         if isinstance(bitmap_payload, Mapping):

--- a/tests/test_mars_control.py
+++ b/tests/test_mars_control.py
@@ -12,11 +12,13 @@ from app.modules.mars_control_center import MarsControlCenterService
 def test_load_jezero_bitmap_payload_structure():
     payload = load_jezero_bitmap()
 
-    assert set(payload.keys()) >= {"image_uri", "image", "bounds", "center", "metadata"}
-    assert payload["image_uri"].startswith("data:image/")
-    image_payload = payload["image"]
-    assert isinstance(image_payload, dict)
-    assert image_payload.get("url", "").endswith(".jpg")
+    assert set(payload.keys()) >= {"image", "bounds", "center", "metadata"}
+    image_value = payload["image"]
+    assert isinstance(image_value, str)
+    assert image_value.endswith(".jpg")
+    fallback_value = payload.get("fallback_image_uri")
+    assert isinstance(fallback_value, str)
+    assert fallback_value.startswith("data:image/")
 
     bounds = payload["bounds"]
     assert isinstance(bounds, tuple)
@@ -30,7 +32,7 @@ def test_load_jezero_bitmap_payload_structure():
     assert isinstance(metadata, dict)
     assert "attribution" in metadata
     assert metadata.get("mime_type") in {"image/jpeg", "image/png"}
-    assert metadata.get("asset_url") == image_payload.get("url")
+    assert metadata.get("asset_url") == image_value
     assert metadata.get("license")
     assert metadata.get("provenance")
 
@@ -43,8 +45,8 @@ def test_build_map_payload_includes_bitmap_and_bounds():
 
     bitmap = payload.get("bitmap_layer")
     assert isinstance(bitmap, dict)
-    assert isinstance(bitmap.get("image"), dict)
-    assert "static/mars/" in bitmap.get("image", {}).get("url", "")
+    assert isinstance(bitmap.get("image"), str)
+    assert "static/mars/" in bitmap.get("image", "")
     assert payload.get("map_bounds") == bitmap.get("bounds")
 
     view_state = payload.get("map_view_state")
@@ -63,9 +65,11 @@ def test_load_jezero_slope_bitmap_contains_legend():
     assert isinstance(legend, dict)
     assert legend.get("description")
     assert isinstance(legend.get("ticks"), list) and legend["ticks"]
-    assert payload.get("image_uri").startswith("data:image/")
-    assert isinstance(payload.get("image"), dict)
-    assert payload["image"].get("url")
+    fallback_value = payload.get("fallback_image_uri")
+    assert isinstance(fallback_value, str)
+    assert fallback_value.startswith("data:image/")
+    assert isinstance(payload.get("image"), str)
+    assert payload["image"].endswith(".jpg") or payload["image"].endswith(".png")
 
 
 def test_load_jezero_ortho_bitmap_metadata():


### PR DESCRIPTION
## Summary
- expose Mars bitmap layers using the copied static asset URL while keeping a base64 data URI as a fallback
- update the Mars Control Center radar to pass bitmap URLs directly to pydeck without injecting data payloads
- align mars control tests with the new payload schema to ensure static texture copying and overlay toggles

## Testing
- pytest tests/test_mars_control.py

------
https://chatgpt.com/codex/tasks/task_e_68e17c7d367c8331b2d9cd60463a707c