### PR TITLE
Add PyYAML dependency and guard Mars control import

### DIFF
--- a/app/modules/mars_control.py
+++ b/app/modules/mars_control.py
@@ -53,7 +53,15 @@ import wave
 
 import pandas as pd
 import streamlit as st
-import yaml
+
+try:
+    import yaml
+except ImportError as exc:  # pragma: no cover - import guard
+    st.error(
+        "PyYAML es necesario para cargar los datos logísticos de Marte. "
+        "Instala la dependencia con `pip install pyyaml` y vuelve a intentarlo."
+    )
+    raise
 
 from app.modules import mission_overview
 from app.modules.generator import GeneratorService

--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -50,6 +50,7 @@ pydantic==2.9.2
 pydantic_core==2.23.4
 pydeck==0.9.1
 Pygments==2.19.2
+PyYAML==6.0.2
 pyright==1.1.404
 pytest==8.4.1
 python-dateutil==2.9.0.post0

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,4 @@ skl2onnx==1.17.0
 # Fijamos rich compatible con Streamlit 1.38 para evitar conflictos en Cloud
 rich>=10.14.0,<14
 responses==0.25.3
+pyyaml>=5.4,<7


### PR DESCRIPTION
## Summary
- add PyYAML to the base requirements and lock files so it is installed everywhere
- guard the Mars Control module import with a friendly Streamlit error when the dependency is missing

## Testing
- `streamlit run app/pages/10_Mars_Control_Center.py --server.headless true --server.port 8501`
- `streamlit run app/pages/3_Generator.py --server.headless true --server.port 8502`


------
https://chatgpt.com/codex/tasks/task_e_68e1824d82388331847ca45de3c14cd3