### PR TITLE
Fix candidate generator CLI imports

### DIFF
--- a/scripts/generate_candidates.py
+++ b/scripts/generate_candidates.py
@@ -4,11 +4,26 @@ from __future__ import annotations
 
 import argparse
 import json
+import sys
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict
 
 import pandas as pd
+
+
+def _ensure_project_root() -> Path:
+    """Ensure the repository root is available on ``sys.path`` when run as a script."""
+
+    module_path = Path(__file__).resolve()
+    root = module_path.parents[1]
+    root_str = str(root)
+    if root_str not in sys.path:
+        sys.path.insert(0, root_str)
+    return root
+
+
+_ensure_project_root()
 
 from app.modules.generator import PredProps, generate_candidates
 from app.modules.io import load_process_df, load_targets, load_waste_df

--- a/tests/test_generate_candidates_script.py
+++ b/tests/test_generate_candidates_script.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import scripts.generate_candidates as script
+
+
+def test_generate_candidates_script_bootstrap(monkeypatch):
+    """The CLI helper should always ensure the repo root is importable."""
+
+    repo_root = Path(__file__).resolve().parents[1]
+    repo_str = str(repo_root)
+
+    # Simulate an environment where the repository root is missing from sys.path.
+    new_path = [entry for entry in sys.path if entry != repo_str]
+    monkeypatch.setattr(sys, "path", new_path, raising=False)
+    assert repo_str not in sys.path
+
+    script._ensure_project_root()
+
+    assert repo_str in sys.path


### PR DESCRIPTION
## Summary
- ensure the `scripts/generate_candidates.py` CLI adds the repository root to `sys.path` when executed directly
- add a regression test that exercises the bootstrap helper to guarantee the root is restored

## Testing
- pytest tests/test_generate_candidates_script.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e1850d93708331a31340c37501d18e