### PR TITLE
Refresh in-app and docs copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,254 +1,199 @@
-# Space Trash Hack — Streamlit Demo (2025)
+# Space Trash Hack — Consola Rex-AI (2025)
 
-Demo ligera que muestra la lógica del "cerebro de reciclaje" para Marte:
-1) Inventario de residuos (NASA non-metabolic waste, simplificado)
-2) Diseño de objetivo (TargetSpec)
-3) Generación de recetas (combinaciones + proceso)
-4) Resultados y trade-offs (Pareto, Sankey, métricas)
+Demo interactiva de la plataforma Rex-AI para reciclar residuos orbitales y
+marcianos. La aplicación combina inventarios NASA, catálogos de procesos y un
+ensemble de modelos entrenados para sugerir recetas de reutilización, explicar
+sus métricas y generar entregables operativos.
 
-## Ejecución
+## Índice rápido
 
-La entrada recomendada para lanzar la demo es:
+1. [Flujo interactivo de la app](#flujo-interactivo-de-la-app)
+2. [Puesta en marcha](#puesta-en-marcha)
+3. [Estructura del proyecto](#estructura-del-proyecto)
+4. [Datos y entrenamiento de IA](#datos-y-entrenamiento-de-ia)
+5. [Feedback operativo y reentrenamiento](#feedback-operativo-y-reentrenamiento)
+6. [Benchmarks y validaciones](#benchmarks-y-validaciones)
+7. [Distribución de artefactos de modelo](#distribución-de-artefactos-de-modelo)
+8. [Scripts útiles](#scripts-útiles)
+
+---
+
+## Flujo interactivo de la app
+
+La consola guía a la tripulación a través de once pasos; cada pantalla mezcla
+explicaciones para perfiles técnicos y operativos.
+
+| Paso | Descripción | Página |
+| --- | --- | --- |
+| 1. **Home** | Resumen del inventario, salud del modelo y alertas críticas. | `app/Home.py` |
+| 2. **Definir objetivo** | Configurá rigidez, estanqueidad y límites de recursos según el escenario (Residence Renovations, Cosmic Celebrations o Daring Discoveries). | `app/pages/2_Target_Designer.py` |
+| 3. **Generador asistido** | Ejecutá la IA para proponer recetas, ajustá filtros y visualizá riesgo vs. recursos en tiempo real. | `app/pages/3_Generator.py` |
+| 4. **Resultados y trade-offs** | Analizá la receta seleccionada con bandas de incertidumbre, comparativa heurística y trazabilidad NASA. | `app/pages/4_Results_and_Tradeoffs.py` |
+| 5. **Compare & Explain** | Contrasta varias opciones, genera narrativa técnica y registra la decisión final. | `app/pages/5_Compare_and_Explain.py` |
+| 6. **Pareto & Export** | Aplicá límites finales, identificá el frente Pareto y descargá planes JSON/CSV listos para operaciones. | `app/pages/6_Pareto_and_Export.py` |
+| 7. **Scenario Playbooks** | Playbooks curados con filtros recomendados, métricas clave y checklist editable. | `app/pages/7_Scenario_Playbooks.py` |
+| 8. **Feedback & Impact** | Capturá métricas reales, feedback cualitativo y prepará datos para reentrenamiento. | `app/pages/8_Feedback_and_Impact.py` |
+| 9. **Spectral Mix Designer** | Calculá mezclas FTIR usando curvas de referencia NASA/UCF. | `app/pages/8_Spectral_Mix_Designer.py` |
+| 10. **Capacity Simulator** | Proyectá producción por sol considerando turnos, downtime y límites diarios. | `app/pages/9_Capacity_Simulator.py` |
+| 11. **Mars Control Center** | Consolida vuelos, inventario, decisiones IA y telemetría. | `app/pages/10_Mars_Control_Center.py` |
+| 12. **Mission Planner** | Construí lotes, rutas logísticas y políticas de sustitución para la próxima misión. | `app/pages/11_Mission_Planner.py` |
+
+Cada página comparte estilo y componentes reutilizables desde
+`app/modules/ui_blocks.py`, de modo que la narrativa se mantenga consistente.
+
+---
+
+## Puesta en marcha
 
 ```bash
 streamlit run app/Home.py
 ```
 
-No se requieren variables de entorno adicionales para el arranque interactivo.
-Sin embargo, podés personalizar dónde se buscan los artefactos de datos y
-modelos exportando las siguientes variables antes de ejecutar cualquier
-entrypoint:
+No se requieren variables de entorno para la demo, pero podés personalizar
+rutas y artefactos con:
 
-- `REXAI_DATA_ROOT`: raíz alternativa que reemplaza a `data/` como punto de
-  partida para datasets curados, logs y archivos "gold". Se admite tanto rutas
-  absolutas como relativas o con `~`; siempre se normalizan a un path absoluto.
-- `REXAI_MODELS_DIR`: ubicación explícita para los bundles de modelos. Si no se
-  define, por defecto se usa `<DATA_ROOT>/models`, aprovechando el valor
-  resultante de `REXAI_DATA_ROOT` cuando está presente.
+- `REXAI_DATA_ROOT`: reemplaza el directorio `data/` como raíz de datasets,
+  logs y artefactos. Acepta rutas absolutas, relativas o con `~`.
+- `REXAI_MODELS_DIR`: apunta explícitamente al directorio de modelos; por
+  defecto usa `<DATA_ROOT>/models`.
 
-> ⚙️ **Bootstrap obligatorio:** antes de cualquier `import app.*`, cada entrypoint
-> de Streamlit (incluyendo los módulos dentro de `app/pages/`) debe llamar a
-> `ensure_streamlit_entrypoint(__file__)`:
->
-> ```python
-> from app.bootstrap import ensure_streamlit_entrypoint
->
-> PROJECT_ROOT = ensure_streamlit_entrypoint(__file__)
-> ```
->
-> Esto fuerza la inclusión de la raíz del repositorio en `sys.path` cuando se
-> ejecutan archivos sueltos con `streamlit run` o `python app/...`, devuelve el
-> directorio que contiene `app/__init__.py` y evita los `ModuleNotFoundError`
-> al importar `app.*`.
->
-> 🧪 **Scripts y tests**: para utilidades CLI o fixtures de Pytest, usa
-> `ensure_project_root(__file__)` en vez de manipular `sys.path` a mano:
->
-> ```python
-> from app.bootstrap import ensure_project_root
->
-> PROJECT_ROOT = ensure_project_root(__file__)
-> ```
->
-> Así mantenemos un único helper oficial para exponer el paquete `app` sin
-> reintroducir hacks circulares.
+### Bootstrap de entrypoints
 
-El script `app/Home.py` centraliza la vista de *Mission Overview* y actúa como
-único entrypoint interactivo, manteniendo alineada la pantalla principal con el
-paso "Overview" de la navegación multipaso.
+Cada módulo de Streamlit debe invocar `ensure_streamlit_entrypoint(__file__)`
+para inyectar la raíz del repositorio en `sys.path` y evitar errores al ejecutar
+`streamlit run` directamente.
 
-## Módulos principales
+```python
+from app.bootstrap import ensure_streamlit_entrypoint
+PROJECT_ROOT = ensure_streamlit_entrypoint(__file__)
+```
 
-La refactorización de 2025 separó responsabilidades clave para mantener el
-código testeable y comprensible:
+Para scripts y tests CLI utilizá `ensure_project_root(__file__)` como helper.
 
-| Módulo | Responsabilidades |
-| --- | --- |
-| `app/modules/data_sources.py` | Resuelve rutas dentro de `datasets/`, normaliza taxonomías NASA y expone el bundle cacheado de features oficiales. |
-| `app/modules/generator.py` | Mezcla residuos, selecciona procesos y construye candidatos junto con sus features listos para inferencia. |
-| `app/modules/logging_utils.py` | Construye payloads JSON serializables y mantiene escritores Parquet rotados para los logs de inferencia. |
+### Requisitos
 
-Los tests unitarios apuntan a estos límites para garantizar que cada módulo
-permanezca enfocado en su dominio (ingesta, generación y logging). El módulo
-`generator` simplemente importa `official_features_bundle()` desde
-`data_sources` y re-exporta `append_inference_log()` desde `logging_utils`, de
-modo que las pruebas pueden interceptar la ingesta o el logging sin tocar la
-arquitectura de ensamblado de candidatos.
-
-### Semillas reproducibles del generador
-
-El ensamblador de recetas ahora acepta una semilla explícita para repetir una
-sesión completa de generación. Podés fijarla de tres maneras equivalentes:
-
-- Cargar la app Streamlit y completar el campo **"Semilla (opcional)"** antes
-  de presionar "Generar recomendaciones".
-- Ejecutar el CLI `python scripts/generate_candidates.py --seed 1234` para
-  persistir los candidatos deterministas en `data/candidates.json`.
-- Definir la variable de entorno `REXAI_GENERATOR_SEED=1234` antes de invocar
-  cualquier entrypoint. El parámetro explícito siempre tiene prioridad sobre la
-  variable de entorno.
-
-La semilla inicializa tanto el RNG global como los RNG por tarea, de modo que
-los candidatos producidos (scores, combinaciones de residuos y desempates del
-optimizador) se mantengan iguales entre ejecuciones.
-
-> Nota: los helpers legacy `app/modules/branding.py`, `app/modules/charts.py`
-> y `app/modules/embeddings.py` fueron eliminados. La app se apoya en
-> `app/modules/ui_blocks.py` para el layout y en los modelos entrenados para
-> producir incrustaciones latentes reales.
-
-## Requisitos
 - Python 3.10+
 - `pip install -r requirements.txt`
 
-### Fase 0 — Verificaciones antes de entrenar
+---
 
-1. **Validar ingestas y revisar errores**. Ejecuta las utilidades de `app.modules.data_pipeline`
-   (o los tests asociados) para verificar que los CSV/Parquet crudos cumplen los modelos de
-   datos. Cada incidencia se registra en `data/logs/ingestion.errors.jsonl`; inspecciona ese
-   archivo antes de continuar para corregir filas inválidas o faltantes.
-2. **Generar artefactos mínimos**. Ejecutá
-   `python scripts/build_gold_dataset.py --output-dir data/gold` para refrescar el
-   dataset curado y, luego, `python -m app.modules.model_training --gold data/gold --append-logs "data/logs/feedback_*.parquet"`
-   para producir el pipeline base y los metadatos indispensables en `data/models/`
-   (por ejemplo `data/models/rexai_regressor.joblib` y `data/models/metadata.json`). El
-   plan detallado de entrenamiento y variantes está descrito en
-   [README_ML_GAMEPLAN.md](README_ML_GAMEPLAN.md).
-3. **Confirmar el modo activo**. Si `data/models/rexai_regressor.joblib` no existe cuando se
-   levanta la aplicación, `ModelRegistry` lanza un bootstrap automático que entrena un RandomForest
-   sintético ligero y lo guarda en `data/models/`. Esto evita tener que versionar binarios para
-   ejecutar la demo por primera vez. Mientras el bootstrap corre (o si fallara), la app recurre a
-   las reglas `heuristic_props` para estimar rigidez, estanqueidad, energía, agua y minutos de crew.
-   En cuanto el modelo y sus metadatos (`metadata.json`, clasificadores y `trained_on = "gold_v1"`)
-   están presentes en `data/models/`, `ModelRegistry.ready` arranca en `True` y las predicciones
-   pasan a provenir del ensemble entrenado (RandomForest + ensambles opcionales) con intervalos de
-   confianza y explicabilidad verificables vía `python -m scripts.verify_model_ready`.
+## Estructura del proyecto
 
-## Entrenar y generar artefactos de IA
+- `app/modules/data_sources.py`: resuelve rutas dentro de `datasets/`, normaliza
+  taxonomías NASA y expone bundles cacheados.
+- `app/modules/generator`: orquesta el generador de recetas (mezcla residuos,
+  selecciona procesos y calcula features para inferencia).
+- `app/modules/logging_utils.py`: serializa payloads y escribe logs Parquet.
+- `app/modules/ml_models.py`: carga modelos entrenados, maneja el bootstrap
+  sintético y expone `ModelRegistry` cacheado.
+- `app/modules/navigation.py`: define el flujo multipaso utilizado por todas las
+  páginas.
+- `app/modules/ui_blocks.py`: layout y componentes visuales compartidos.
 
-El pipeline de entrenamiento consume datasets físicos/químicos alineados con
-los documentos de NASA y UCF:
+Tests unitarios se enfocan en estos límites para asegurar separación clara entre
+ingesta, generación y logging.
 
-- `datasets/raw/nasa_waste_inventory.csv`: taxonomía de residuos no-metabólicos
-  (pouches, espumas, EVA/CTB, textiles, nitrilo, etc.).
-- `datasets/raw/mgs1_composition.csv` / `mgs1_oxides.csv` / `mgs1_properties.csv`:
-  composición mineralógica y propiedades de MGS-1 (regolito de referencia).
-- `datasets/raw/nasa_trash_to_gas.csv`: rendimiento de procesos Trash-to-Gas y
-  Trash-to-Supply-Gas para Gateway/Mars.
-- `datasets/raw/logistics_to_living.csv`: eficiencia de reuso de CTB (Logistics-2-Living).
+### Semillas reproducibles
 
-`app/modules/model_training.py` construye combinaciones realistas mezclando esos
-datasets con el catálogo de procesos y genera:
+El generador acepta una semilla explícita para repetir sesiones completas:
 
-- Dataset procesado en `datasets/processed/rexai_training_dataset.parquet`.
-- Corridas sintéticas utilizadas para depurar el pipeline en
-  `datasets/processed/ml/synthetic_runs.parquet`.
-- Dataset procesado en `data/processed/rexai_training_dataset.parquet`.
-- Pipeline RandomForest multi-salida (`data/models/rexai_regressor.joblib`) con
-  estimación de incertidumbre (desvío entre árboles + residuales de validación).
-- Ensemble de modelos de "wow effect":
-  - `data/models/rexai_xgboost.joblib` (boosting por target).
-  - `data/models/rexai_tabtransformer.pt` (transformer tabular ligero, opcional si PyTorch está disponible).
-- Autoencoder tabular opcional (`data/models/rexai_autoencoder.pt`, requiere PyTorch). Las
-  incrustaciones latentes expuestas en la app provienen exclusivamente de este
-  autoencoder entrenado; ya no existe ningún helper heurístico para fabricarlas
-  manualmente.
-- Metadatos en `data/models/metadata.json` (features, targets, fecha, métricas,
-  importancias de features, residuales, paths de artefactos).
+- Campo **“Semilla (opcional)”** en la app Streamlit.
+- CLI `python scripts/generate_candidates.py --seed 1234`.
+- Variable `REXAI_GENERATOR_SEED=1234` antes de ejecutar cualquier entrypoint.
 
-Para regenerar todos los artefactos (mezclando datasets simulados con el
-corpus dorado y feedback humano cuando está disponible):
+La semilla sincroniza RNG global y por tarea para que scores, combinaciones y
+desempates del optimizador sean reproducibles.
 
-```bash
-python -m app.modules.model_training --gold data/gold --append-logs "data/logs/feedback_*.parquet"
-```
+---
 
-### Reentrenar desde feedback humano
+## Datos y entrenamiento de IA
 
-Cada sesión de la tripulación registrada en el panel "Feedback & Impact"
-genera archivos `data/logs/feedback_*.parquet` con las correcciones aplicadas
-al proceso (rigidez, estanqueidad, penalizaciones de energía/agua/crew). El
-comando dedicado `retrain_from_feedback` consume esos logs, convierte las
-señales en targets supervisados y re-ejecuta el pipeline principal con
-`--append-logs` ya configurado:
+### Inventario de datasets
 
-```bash
-python -m app.modules.retrain_from_feedback
-```
+- `datasets/raw/nasa_waste_inventory.csv`: residuos no-metabólicos.
+- `datasets/raw/mgs1_composition.csv`, `mgs1_oxides.csv`, `mgs1_properties.csv`:
+  propiedades del regolito MGS-1.
+- `datasets/raw/nasa_trash_to_gas.csv`: procesos Trash-to-Gas / Trash-to-Supply.
+- `datasets/raw/logistics_to_living.csv`: eficiencia logística → habitabilidad.
 
-Opcionalmente podés especificar rutas alternativas:
+### Pipeline base
 
-```bash
-python -m app.modules.retrain_from_feedback \
-  --gold data/gold \
-  --features data/gold/features.parquet \
-  --logs "data/logs/custom_feedback_*.parquet"
-```
+1. **Validación de ingestas** — Ejecutá `python -m app.modules.data_pipeline`
+   (o los tests asociados) para validar CSV/Parquet crudos. Los errores se
+   registran en `data/logs/ingestion.errors.jsonl`.
+2. **Construcción de dataset gold** — `python scripts/build_gold_dataset.py --output-dir data/gold`.
+3. **Entrenamiento principal** — `python -m app.modules.model_training --gold data/gold --append-logs "data/logs/feedback_*.parquet"`.
+4. **Modelos resultantes** — se guardan en `data/models/` (`rexai_regressor.joblib`,
+   clasificadores auxiliares, ensembles opcionales) y metadata en `metadata.json`.
 
-Al finalizar, `data/models/metadata.json` y `metadata_gold.json` se actualizan
-con la nueva fecha (`trained_at`) y el label de procedencia (`trained_on`, por
-ejemplo `hil_v1` o `hybrid_v2`). La pantalla principal de la app refleja la
-última fecha de reentrenamiento y la mezcla utilizada.
+Si no hay modelos presentes, `ModelRegistry` entrena automáticamente un modelo
+sintético liviano (`trained_on = "synthetic_v0_bootstrap"`) para evitar fallos en
+la primera ejecución. Cuando se detectan artefactos reales (`metadata.json` con
+`trained_on` válido) la app usa el ensemble entrenado y expone bandas de
+incertidumbre, importancias de features y embeddings latentes.
 
-Como la instancia de `ModelRegistry` queda cacheada vía `st.cache_resource`,
-tras copiar artefactos nuevos sin reiniciar la app recordá invalidar esa caché.
-Podés exponer un botón admin en Streamlit que llame a
-`app.modules.ml_models.get_model_registry().clear()` o ejecutar manualmente:
+### Artefactos generados
+
+- `datasets/processed/rexai_training_dataset.parquet`
+- `data/processed/rexai_training_dataset.parquet`
+- `data/models/rexai_regressor.joblib`, `data/models/metadata.json`
+- Ensambles opcionales: `rexai_xgboost.joblib`, `rexai_tabtransformer.pt`
+- Autoencoder tabular opcional (`data/models/rexai_autoencoder.pt`)
+
+---
+
+## Feedback operativo y reentrenamiento
+
+Cada sesión registrada en **Feedback & Impact** genera `data/logs/feedback_*.parquet`
+con correcciones de rigidez, estanqueidad, energía, agua y crew. El comando
+`python -m app.modules.retrain_from_feedback` convierte esas señales en targets
+supervisados y reentrena el pipeline con `--append-logs` configurado.
+
+Tras copiar nuevos artefactos recordá invalidar el cache de `ModelRegistry`:
 
 ```bash
 python -c "from app.modules.ml_models import get_model_registry; get_model_registry.clear()"
 ```
 
-Luego de limpiar la caché, refrescá la página para que la UI vuelva a cargar la
-metadata y los pipelines recién entrenados.
+Los módulos de impacto escriben automáticamente sus directorios (`LOGS_DIR.mkdir`)
+por lo que no es necesario versionar `data/logs/`.
 
-> Nota: la optimización bayesiana con Ax/BoTorch es opcional. El entorno Streamlit
-> detecta automáticamente si `ax-platform` y `botorch` están instalados; en caso
-> contrario utiliza el optimizador heurístico integrado. Para habilitarla basta con
-> `pip install ax-platform botorch` antes de ejecutar la app.
+---
 
-### Logs generados en runtime
+## Benchmarks y validaciones
 
-Los módulos que escriben métricas o telemetría crean sus rutas dinámicamente en
-runtime. Por ejemplo, `app/modules/impact.py` y `app/modules/logging_utils.py`
-invocan `LOGS_DIR.mkdir(parents=True, exist_ok=True)` antes de guardar archivos
-Parquet/JSON. Gracias a esto no es necesario versionar `data/logs/`; la carpeta
-se materializa automáticamente cuando se ejecutan los tests o la app y se
-elimina limpiando los artefactos generados. Para verificar este flujo, ejecutá:
+El script `python scripts/run_benchmarks.py --format csv --with-ablation`
+genera comparativas entre heurísticas y el modelo Rex-AI. Produce:
+
+- `data/benchmarks/scenario_predictions.csv`
+- `data/benchmarks/scenario_metrics.csv`
+- Archivos de ablation (`ablation_predictions.csv`, `ablation_metrics.csv`)
+
+Resumen de referencia (`data/benchmarks/scenario_metrics.csv`): MAE global
+16 129, RMSE 34 056 y CI95 promedio 32 498 con `gold_v1`.
+
+Para validar readiness antes de publicar ejecutá:
 
 ```bash
-pytest tests/test_impact_logging.py
+python -m scripts.verify_model_ready
 ```
 
-La prueba crea un directorio temporal, persiste entradas de impacto y feedback
-utilizando los módulos anteriores y confirma que los Parquet aparecen sin
-requerir un placeholder en Git.
+El script asegura que `ModelRegistry.ready` sea `True` y que la metadata contenga
+métricas, residuales y rutas consistentes.
 
-Los binarios (`.joblib`, `.pt`, `.parquet`) permanecen ignorados por Git para
-mantener el repo liviano. Cuando existen localmente, la app reemplaza las
-predicciones heurísticas por las del modelo Rex-AI (RandomForest + XGBoost +
-TabTransformer), expone bandas de confianza 95%, importancias promedio y el
-vector latente entrenado sobre mezclas MGS-1 + residuos NASA. El bootstrap
-automático genera un modelo sintético con la etiqueta `trained_on = "synthetic_v0_bootstrap"`,
-que podés reemplazar en cualquier momento por artefactos reales empaquetados con
-`python -m scripts.package_model_bundle --output dist/rexai_model_bundle_gold_v1.zip` para
-distribuir un bundle reproducible en el que `ModelRegistry.ready` queda en `True` desde el arranque.
+---
 
-## Distribución de artefactos ML
+## Distribución de artefactos de modelo
 
-Los modelos entrenados se empaquetan automáticamente con:
+### Empaquetar y compartir
 
 ```bash
 python -m scripts.package_model_bundle --output dist/rexai_model_bundle_gold_v1.zip
+sha256sum dist/rexai_model_bundle_gold_v1.zip
 ```
 
-El script genera un ZIP reproducible con todos los binarios
-(`data/models/rexai_regressor.joblib`, clasificadores y ensambles opcionales) y
-ambas versiones de metadata (`metadata.json` y `metadata_gold.json`). Ese
-bundle debe subirse como Release Asset (o artifact de CI) bajo el nombre
-`rexai_model_bundle_gold_v1.zip`.
-
-Para reutilizarlo en otro entorno:
+El ZIP incluye todos los binarios (`joblib`, `pt`, `metadata.json`) y es ideal
+para releases o artefactos de CI. Para reutilizarlo:
 
 ```bash
 wget https://github.com/<org>/<repo>/releases/latest/download/rexai_model_bundle_gold_v1.zip
@@ -256,179 +201,43 @@ unzip rexai_model_bundle_gold_v1.zip -d /tmp/rexai-models
 rsync -av /tmp/rexai-models/data/models/ data/models/
 ```
 
-Reemplazá `<org>/<repo>` por la organización y el nombre reales del repositorio.
+O simplemente `unzip dist/rexai_model_bundle_gold_v1.zip -d .` dentro del repo.
+Luego corré `python -m scripts.verify_model_ready` para confirmar que la app
+arrancará en modo IA.
 
-Colocar los archivos dentro de `data/models/` **antes** de ejecutar
-`streamlit run app/Home.py` garantiza que la app arranque directamente en modo
-IA (`ready=True`) sin depender del bootstrap sintético. El comando anterior deja
-los archivos `.joblib` y `metadata.json` en el lugar correcto; si ya tenés el
-ZIP generado localmente podés simplemente descomprimirlo dentro del repositorio:
+### Descarga automática (secrets)
 
-```bash
-unzip dist/rexai_model_bundle_gold_v1.zip -d .
-```
-
-Esto recreará la estructura `data/models/` con los artefactos actualizados.
-Antes de lanzar Streamlit ejecutá `python -m scripts.verify_model_ready` para
-confirmar que `ModelRegistry.ready` devuelve `True` y que la app usará el
-ensemble entrenado desde el inicio.
-
-### Actualizar el bundle publicado
-
-1. **Entrenar**: `python -m app.modules.model_training --gold data/gold --append-logs "data/logs/feedback_*.parquet"`
-   genera los `.joblib` y `metadata*.json` bajo `data/models/`.
-2. **Verificar**: ejecutá `python -m scripts.verify_model_ready` y conservá el
-   JSON resultante como bitácora del reentrenamiento.
-3. **Empaquetar**: `python -m scripts.package_model_bundle --output dist/rexai_model_bundle_<tag>.zip`
-   produce el ZIP reproducible con todos los artefactos.
-4. **Publicar**: subí el ZIP como release asset (o al almacenamiento acordado) y
-   registrá la URL final en `MODEL_BUNDLE_URL` junto con el hash en
-   `MODEL_BUNDLE_SHA256` dentro de los secrets del despliegue. Actualizá la
-   referencia cada vez que cambie `<tag>` para que la descarga automática apunte
-   al bundle nuevo.
-
-### Descarga automática desde secrets
-
-Para despliegues donde no queremos subir los binarios al repositorio, la app
-puede descargar el ZIP desde un release público/privado antes de levantar el
-registro de modelos. Configurá los siguientes valores como variables de entorno
-o en `st.secrets`:
+En despliegues remotos podés definir:
 
 ```toml
-# .streamlit/secrets.toml
 MODEL_BUNDLE_URL = "https://github.com/<org>/<repo>/releases/download/v1.0.0/rexai_model_bundle_gold_v1.zip"
-MODEL_BUNDLE_SHA256 = "<hash calculado con sha256sum>"
+MODEL_BUNDLE_SHA256 = "<hash sha256>"
 ```
 
-Con esas claves presentes, `ModelRegistry` descarga el bundle a un directorio
-temporal, valida opcionalmente el hash y lo extrae automáticamente sobre
-`data/models/` antes de cargar `joblib`. Si los artefactos ya existen en el
-directorio destino, la descarga se omite.
-
-Flujo recomendado para publicar nuevos modelos:
-
-1. Ejecutá `python -m scripts.package_model_bundle --output dist/<bundle>.zip`.
-2. Calculá el hash con `sha256sum dist/<bundle>.zip` (o `shasum -a 256`).
-3. Cargá el ZIP como Release Asset en GitHub y copiá la URL de descarga directa
-   (`https://github.com/<org>/<repo>/releases/download/...`).
-4. Actualizá `MODEL_BUNDLE_URL` y `MODEL_BUNDLE_SHA256` en el entorno/secrets
-   del despliegue (Streamlit Cloud, Hugging Face, etc.).
-
-Así cada reinicio de la app asegura que `data/models/` contenga la versión
-publicada sin ejecutar el bootstrap sintético.
+Con esas claves `ModelRegistry` descargará, verificará y expandirá el bundle antes
+de cargar los modelos.
 
 ### Mantener el bundle actualizado
 
-1. Reentrena con los datasets más recientes:
+1. Reentrená con los datasets más recientes.
+2. Ejecutá `python -m scripts.verify_model_ready` y guardá el JSON de evidencia.
+3. Empaquetá con `python -m scripts.package_model_bundle --output dist/rexai_model_bundle_<tag>.zip`.
+4. Publicá el ZIP y actualizá `MODEL_BUNDLE_URL`/`MODEL_BUNDLE_SHA256`.
 
-   ```bash
-   python -m app.modules.model_training --gold data/gold --append-logs "data/logs/feedback_*.parquet"
-   ```
+---
 
-   El pipeline actualizará `data/models/rexai_regressor.joblib`, clasificadores
-   auxiliares, y escribirá `data/models/metadata.json` con un `trained_on`
-   legible por `ModelRegistry.trained_label()` (por ejemplo `hybrid_v1`).
+## Scripts útiles
 
-2. Empaqueta los artefactos con `python -m scripts.package_model_bundle --output dist/rexai_model_bundle_hybrid_v1.zip`,
-   verifica con `python -m scripts.verify_model_ready` y publica el ZIP
-   resultante.
+- `python scripts/build_gold_dataset.py`: refresca el dataset curado.
+- `python -m app.modules.model_training`: entrenamiento principal.
+- `python -m scripts.generate_candidates --seed N`: genera candidatos determinísticos.
+- `python scripts/run_benchmarks.py --with-ablation`: benchmarks completos.
+- `python -m scripts.verify_model_ready`: chequeo de consistencia de modelos.
+- `python -m scripts.package_model_bundle`: empaquetar artefactos entrenados.
+- `python -m app.modules.retrain_from_feedback`: reentrenar incorporando feedback humano.
 
-3. Documenta la fecha y el label (`trained_on`) en el release/changelog para que
-   los despliegues confirmen qué dataset alimentó el entrenamiento.
+---
 
-## Verificación automática de readiness
-
-Antes de publicar un release ejecutar:
-
-```bash
-python -m scripts.verify_model_ready
-```
-
-El chequeo carga `ModelRegistry`, valida que `ready == True`, que todas las
-métricas/residuales estén presentes en `metadata.json` y reporta las rutas de
-artefactos generados. Si falta algún binario o metadata crítica, el script sale
-con error para evitar releases inconsistentes.
-
-## Benchmarks heurísticos vs IA
-
-Para auditar la deriva entre las reglas `heuristic_props` y el modelo Rex-AI
-podés ejecutar:
-
-```bash
-python scripts/run_benchmarks.py --format csv --with-ablation
-```
-
-El comando espera que `data/models/rexai_regressor.joblib` esté disponible y
-genera tablas comparativas en `data/benchmarks/`. Además de los archivos
-`scenario_predictions.csv`/`scenario_metrics.csv`, la flag `--with-ablation`
-añade `ablation_predictions.csv` y `ablation_metrics.csv`, que documentan el
-impacto de desactivar grupos de features (composición MGS-1, banderas NASA e
-índices logísticos) durante la inferencia.
-
-Los errores se calculan tratando las heurísticas como baseline. El resumen por
-escenario (promediado sobre las cinco métricas) incorpora también el ancho
-medio de los intervalos de confianza al 95% (`ci95_width_mean`):
-
-| Escenario | MAE medio | RMSE | CI95 (ancho medio) |
-|-----------|----------:|-----:|-------------------:|
-| CTB Reconfig | 16 016 | 33 654 | 33 210 |
-| Espuma + MGS-1 + Sinter | 16 090 | 34 298 | 31 687 |
-| Multicapa + Laminar | 16 281 | 34 214 | 32 596 |
-| Global (los 3 escenarios) | 16 129 | 34 056 | 32 498 |
-
-Los valores anteriores provienen de `data/benchmarks/scenario_metrics.csv` y se
-actualizan automáticamente al rerunear el script.【F:data/benchmarks/scenario_metrics.csv†L18-L25】
-
-### Observaciones
-
-* **Gap frente a las heurísticas**: el ensemble entrenado sobre `gold_v1` reduce
-  el error medio global a 16 129 (RMSE 34 056), casi dos órdenes de magnitud por
-  debajo del bootstrap sintético previo y alineado con las escalas de cada
-  target.【F:data/benchmarks/scenario_metrics.csv†L18-L25】
-* **Consumo de crew**: sigue siendo el más sensible; el MAE por escenario ronda
-  4 177 minutos, lo que equivale a una guardia extendida pero ya no a desvíos del
-  orden de cientos de miles.【F:data/benchmarks/scenario_metrics.csv†L18-L22】
-* **Energía y agua**: los errores promedio se estabilizan en ~76 032 kWh y
-  435 litros agregados, consistentes con la variabilidad del dataset dorado.
-  Las bandas de confianza capturan estos márgenes (≈146 058 kWh y 937 L).【F:data/benchmarks/scenario_metrics.csv†L21-L24】
-* **Rigidez/estanqueidad**: las discrepancias siguen acotadas (≤0.54), lo que
-  facilita auditar calibraciones mecánicas sin perder precisión perceptiva.【F:data/benchmarks/scenario_predictions.csv†L2-L23】
-* **CI95**: las bandas medias caen a ~32 498 unidades globales, con escenarios
-  entre 31 687 y 33 210 gracias al reentrenamiento con el corpus dorado.【F:data/benchmarks/scenario_metrics.csv†L18-L25】
-
-Consulta [BENCHMARK.md](BENCHMARK.md) para el resumen detallado, la metodología
-y cómo interpretar los tres escenarios y los resultados de ablation. Con los
-artefactos `gold_v1` cargados, el ensemble alcanza un MAE global de 16 129, RMSE
-34 056 y bandas CI95 promedio de 32 498, demostrando una mejora drástica frente
-al bootstrap heurístico original.【F:data/benchmarks/scenario_metrics.csv†L18-L25】
-Los barridos con `--with-ablation` confirman ajustes pendientes: quitar las
-banderas NASA o los índices logísticos apenas modifica el MAE y puede ensanchar
-las bandas de confianza, por lo que conviene priorizar calibraciones finas en
-lugar de apagar features completos.【F:data/benchmarks/ablation_metrics.csv†L71-L73】
-
-Después de incorporar feedback humano, ejecuta el benchmark nuevamente apuntando
-a un directorio distinto (`--output-dir data/benchmarks/post_feedback`) y
-genera un comparativo con:
-
-```bash
-python scripts/plot_benchmark_deltas.py \
-  --before data/benchmarks/pre_feedback/scenario_metrics.csv \
-  --after data/benchmarks/post_feedback/scenario_metrics.csv
-```
-
-El HTML resultante (`data/benchmarks/feedback_deltas.html`) grafica cuánto se
-redujeron (o empeoraron) MAE, RMSE y el ancho del CI95 frente al baseline
-anterior, evidenciando el impacto directo del feedback en las métricas de la IA.
-
-## Ejecutar la app
-
-Con los artefactos generados, lanzar la demo con:
-
-```bash
-streamlit run app/Home.py
-```
-
-La UI detecta `ModelRegistry.ready` y, si los modelos están presentes, muestra
-predicciones, bandas de confianza, importancia de features y comparaciones con
-los ensambles opcionales. Ante ausencia de modelos utiliza los fallbacks
-heurísticos originales.
+Para detalles adicionales consultá la documentación en `docs/` (onboarding,
+setup de entorno, diseño de UX y guía de datos). Cada archivo fue actualizado
+para que perfiles técnicos y no técnicos encuentren el contexto necesario.

--- a/app/modules/navigation.py
+++ b/app/modules/navigation.py
@@ -19,50 +19,60 @@ class MissionStep:
 
 
 MISSION_STEPS: tuple[MissionStep, ...] = (
-    MissionStep("home", "Home", "Home", "Panel principal de la misión"),
-    MissionStep("target", "Definir objetivo", "2_Target_Designer", "Configura las metas de la misión"),
-    MissionStep("generator", "Generador asistido", "3_Generator", "Explora candidatos sugeridos por IA"),
+    MissionStep("home", "Home", "Home", "Panorama general: inventario, salud del modelo y alertas críticas."),
+    MissionStep(
+        "target",
+        "Definir objetivo",
+        "2_Target_Designer",
+        "Configura metas de producto y límites operativos antes de generar recetas.",
+    ),
+    MissionStep(
+        "generator",
+        "Generador asistido",
+        "3_Generator",
+        "Orquesta candidatos creados con IA y reglas de seguridad para la misión en curso.",
+    ),
     MissionStep(
         "results",
         "Resultados y trade-offs",
         "4_Results_and_Tradeoffs",
-        "Evalúa resultados y métricas clave",
+        "Desglosa cada receta: rendimiento, incertidumbre y cumplimiento de restricciones.",
     ),
     MissionStep(
         "compare",
         "Compare & Explain",
         "5_Compare_and_Explain",
-        "Compara alternativas y explica decisiones",
+        "Contrasta alternativas, interpreta las métricas y documenta la decisión.",
     ),
     MissionStep(
         "export",
         "Pareto & Export",
         "6_Pareto_and_Export",
-        "Prepara entregables y exporta datos",
+        "Examina el frente Pareto y descarga entregables listos para operaciones.",
     ),
     MissionStep(
         "playbooks",
         "Scenario Playbooks",
         "7_Scenario_Playbooks",
-        "Crea playbooks con filtros predefinidos",
+        "Aplica procedimientos preconfigurados y atajos de filtrado por escenario.",
     ),
     MissionStep(
         "feedback",
         "Feedback & Impact",
         "8_Feedback_and_Impact",
-        "Recoge feedback y mide impacto",
+        "Registra resultados reales, cuantifica impactos y prepara reentrenamientos.",
     ),
     MissionStep(
         "capacity",
         "Capacity Simulator",
         "9_Capacity_Simulator",
-        "Simula capacidad y recursos disponibles",
+        "Proyecta producción diaria, cuellos de botella y consumo de recursos.",
     ),
     MissionStep(
         "mission_planner",
         "Mission Planner",
         "11_Mission_Planner",
-        "Planifica lotes, rutas y políticas para la próxima misión",
+        "Arma lotes, rutas logísticas y políticas de sustitución para la siguiente misión.",
     ),
 )
 

--- a/app/pages/10_Mars_Control_Center.py
+++ b/app/pages/10_Mars_Control_Center.py
@@ -386,13 +386,12 @@ def _render_metric(label: str, score: float, help_text: str | None = None) -> No
             st.caption(help_text)
 
 
-st.title("Centro de control marciano")
+st.title("🛰️ Centro de control marciano")
 st.markdown(
     """
-    Orquesta la operación completa de la misión: vuelos de logística, inventario
-    orbital, decisiones asistidas por IA y planificación de procesos. Cada
-    sección consume los servicios de telemetría recién desplegados para mantener
-    la vista táctica de los equipos de operaciones.
+    Consolida vuelos, inventario, decisiones automáticas y planificación diaria
+    en una sola consola. Cada pestaña se alimenta de telemetría en tiempo real
+    para que operaciones priorice acciones críticas y documente resultados.
     """
 )
 

--- a/app/pages/11_Mission_Planner.py
+++ b/app/pages/11_Mission_Planner.py
@@ -44,7 +44,8 @@ inventory_by_id = inventory.set_index("id") if has_id_column else pd.DataFrame()
 with layout_stack():
     st.title("🛰️ Mission Planner")
     st.caption(
-        "Seleccioná lotes de materiales, ajustá objetivos operativos y generá rutas logísticas optimizadas."
+        "Seleccioná materiales, fijá objetivos operativos y obtené rutas logísticas"
+        " optimizadas con señales de política y sustitución."
     )
 
     selector_cols = st.columns((2, 2, 1.4, 1.4))
@@ -96,7 +97,10 @@ with layout_stack():
             selected = selected.head(len(selected_ids))
     if selected.empty and not inventory.empty:
         selected = inventory.head(3).copy()
-        st.info("No se seleccionaron materiales, se utilizarán los primeros del inventario de referencia.")
+        st.info(
+            "No se seleccionaron materiales. Usaremos las primeras entradas del"
+            " inventario de referencia como punto de partida."
+        )
 
     lot_size = st.slider(
         "Tamaño de lote (nº materiales)",
@@ -163,17 +167,19 @@ sankey = mission_planner.build_sankey(assignments)
 with layout_stack():
     st.subheader("Asignación de procesos sugeridos")
     if assignments_df.empty:
-        st.warning("No se encontraron procesos compatibles con las restricciones seleccionadas.")
+        st.warning("No se encontraron procesos compatibles. Ajustá límites o materiales y probá de nuevo.")
     else:
         st.dataframe(assignments_df, use_container_width=True, hide_index=True)
 
     st.subheader("Logística prevista")
+    st.caption("Visualizá cómo viajan los materiales desde el inventario hacia los procesos priorizados.")
     if sankey is None:
         st.caption("Añadí materiales para visualizar la ruta logística consolidada.")
     else:
         st.plotly_chart(sankey, use_container_width=True)
 
     st.subheader("Optimización del lote")
+    st.caption("Compará combinaciones según energía consumida y rigidez alcanzada para decidir el lote final.")
     if pareto_df.empty:
         st.caption("Ajustá el tamaño del lote u objetivos para explorar combinaciones óptimas.")
     else:
@@ -189,7 +195,7 @@ with layout_stack():
 
     st.subheader("Alertas de política y sustitución")
     if not alerts:
-        st.caption("Sin alertas relevantes para los materiales seleccionados.")
+        st.caption("Sin alertas relevantes para los materiales seleccionados en esta iteración.")
     else:
         for alert in alerts:
             st.warning(alert)

--- a/app/pages/2_Target_Designer.py
+++ b/app/pages/2_Target_Designer.py
@@ -35,13 +35,14 @@ render_breadcrumbs(current_step)
 st.title("2) Definir objetivo (TargetSpec)")
 
 st.info(
-    "En esta misión podés elegir entre tres escenarios: **Residence Renovations** "
-    "(rehabilitar hábitats existentes), **Cosmic Celebrations** (montajes rápidos para"
-    " eventos especiales) y **Daring Discoveries** (expediciones de laboratorio)."
-    " Configurá la rigidez y la estanqueidad para alinear la ingeniería del producto "
-    "con cada reto, y fijá límites de agua, energía y minutos de tripulación para "
-    "asegurarte de que la receta resultante respete los recursos disponibles en la "
-    "estación."
+    "Seleccioná el escenario que describe tu misión y usá los deslizadores para "
+    "balancear desempeño y logística antes de pasar al generador:\n"
+    "- **Residence Renovations** prioriza refuerzos estructurales y sellado estable "
+    "  para módulos habitables.\n"
+    "- **Cosmic Celebrations** busca montajes rápidos con bajo consumo de crew y "
+    "  recursos.\n"
+    "- **Daring Discoveries** habilita prototipos de laboratorio donde la precisión "
+    "  del sellado y la energía disponible son críticas."
 )
 
 presets = load_targets()
@@ -75,9 +76,18 @@ if scenario not in scenario_options:
     scenario = default_scenario
 
 scenario_descriptions = {
-    "Residence Renovations": "rehabilitar y ampliar espacios existentes a largo plazo",
-    "Cosmic Celebrations": "crear montajes efímeros y visuales para eventos orbitales",
-    "Daring Discoveries": "apoyar misiones científicas con prototipos ajustados",
+    "Residence Renovations": (
+        "rehabilitar y ampliar espacios habitables con énfasis en estabilidad"
+        " estructural"
+    ),
+    "Cosmic Celebrations": (
+        "montar instalaciones efímeras donde manda la agilidad y el consumo"
+        " acotado de recursos"
+    ),
+    "Daring Discoveries": (
+        "respaldar expediciones científicas con prototipos precisos y soporte"
+        " instrumental"
+    ),
 }
 
 scenario = st.selectbox(
@@ -199,12 +209,19 @@ st.table(limits_table)
 crew_focus_text = "priorizar procesos rápidos" if crew_time_low else "permitir procesos con más supervisión"
 scenario_text = scenario_descriptions.get(scenario, scenario.lower())
 st.markdown(
-    "**Resumen narrativo:** Configuraste el objetivo para "
-    f"**{scenario}**, enfocado en {scenario_text}. La receta deberá respetar una "
-    f"rigidez de {rigidity:.2f} (protege la estructura), una estanqueidad de {tightness:.2f} "
-    "(evita fugas críticas) y usar hasta "
-    f"{max_water:.2f} L de agua y {max_energy:.2f} kWh de energía. También indicaste "
-    f"{crew_focus_text}, con un máximo de {max_crew:.0f} minutos humanos disponibles."
+    "\n".join(
+        [
+            "**Resumen de misión**",
+            f"- Escenario elegido: **{scenario}** ({scenario_text}).",
+            f"- Rigidez objetivo: `{rigidity:.2f}` (controla la resistencia del producto).",
+            f"- Estanqueidad objetivo: `{tightness:.2f}` (evita fugas y pérdida de presión).",
+            f"- Recursos máximos: `{max_water:.2f}` L de agua y `{max_energy:.2f}` kWh disponibles.",
+            f"- Tiempo humano asignado: `{max_crew:.0f}` minutos para operadores ({crew_focus_text}).",
+        ]
+    )
 )
 
-st.success("Objetivo listo. Abrí la página **3) Generador** para obtener recetas.")
+st.success(
+    "Objetivo listo. Pasá al paso **3 · Generador asistido** para crear recetas"
+    " compatibles con estas restricciones."
+)

--- a/app/pages/3_Generator.py
+++ b/app/pages/3_Generator.py
@@ -822,7 +822,9 @@ def render_candidate_card(
         if st.button(f"✅ Seleccionar Opción {idx}", key=f"pick_{idx}"):
             view_model.set_selected(candidate, badge)
             st.success(
-                "Opción seleccionada. Abrí **4) Resultados**, **5) Comparar & Explicar** o **6) Pareto & Export**."
+                "Opción seleccionada. Avanzá a **4 · Resultados**, **5 · Compare & Explain** "
+                "o **6 · Pareto & Export** para revisar métricas, justificar la decisión y "
+                "descargar entregables."
             )
 
 playbook_filters_applied = False
@@ -832,7 +834,7 @@ if _playbook_prefilters is not None and isinstance(target, dict):
     )
 
 # ----------------------------- Encabezado -----------------------------
-st.header("Generador IA")
+st.header("🧪 Generador asistido por IA")
 header_badges = _collect_target_badges(target)
 if header_badges:
     badge_columns = st.columns(len(header_badges))
@@ -840,29 +842,39 @@ if header_badges:
         with column:
             pill(label, kind=kind)
 st.caption(
-    "Cargá tu objetivo y generá lotes optimizados comparando recursos y riesgos"
-    " con una vista transparente de métricas y penalizaciones."
+    "Construí propuestas que cumplan el objetivo definido, comparando consumo"
+    " de recursos, riesgo operativo y señales de laboratorio en una sola vista."
 )
 
 st.info(
     "**Flujo recomendado**\n"
-    "1. Configurar objetivo → definí el escenario y los límites críticos.\n"
-    "2. Ajustar filtros → refiná residuos, procesos y penalizaciones según tu estrategia.\n"
-    "3. Generar → ejecutá la IA para evaluar propuestas y priorizar las más sólidas.\n"
-    "4. Revisar resultados → compará riesgos, recursos y sellado antes de decidir."
+    "1. Configurá el objetivo → elegí el escenario y los límites técnicos clave.\n"
+    "2. Ajustá filtros → concentrá la búsqueda en residuos, procesos y penalizaciones"
+    " relevantes.\n"
+    "3. Generá candidatos → ejecutá la IA y revisá cómo cada receta equilibra"
+    " rigidez, estanqueidad y recursos.\n"
+    "4. Analizá resultados → usá las páginas siguientes para validar riesgos,"
+    " explicar la decisión y preparar entregables."
 )
 
 if playbook_filters_applied:
     if _playbook_prefill_label:
         st.success(
-            f"Filtros recomendados para **{_playbook_prefill_label}** activados. Revisá el showroom para verlos en acción."
+            f"Filtros recomendados para **{_playbook_prefill_label}** activados."
+            " Explorá el showroom para ver cómo afectan al ranking."
         )
     else:
-        st.success("Filtros recomendados activados. Revisá el showroom para verlos en acción.")
+        st.success(
+            "Filtros recomendados activados. Revisá el showroom para entender la"
+            " priorización propuesta."
+        )
 
 # ----------------------------- Pre-condición: target -----------------------------
 if not target:
-    st.warning("Configura primero el objetivo en **2 · Target Designer** para habilitar el generador.")
+    st.warning(
+        "Definí primero las metas de rigidez, estanqueidad y recursos en **2 · Target"
+        " Designer** para habilitar el generador."
+    )
     st.stop()
 
 # ----------------------------- Datos base -----------------------------

--- a/app/pages/4_Results_and_Tradeoffs.py
+++ b/app/pages/4_Results_and_Tradeoffs.py
@@ -215,7 +215,9 @@ header_chips.append({"label": "Restricciones OK" if feasible else "Revisar restr
 
 st.title(f"📊 {process_id} · {process_name}")
 st.caption(
-    "Predicciones Rex-AI con trazabilidad NASA y contraste frente a la heurística de referencia."
+    "Mirá cómo la receta seleccionada responde según Rex-AI, con trazabilidad"
+    " NASA, comparación con la heurística y alertas si alguna restricción se"
+    " estira demasiado."
 )
 
 if header_chips:
@@ -227,9 +229,15 @@ if constraint_entries:
     render_constraint_chips(constraint_entries)
 
 if feasible:
-    st.success("La receta cumple las metas de rigidez y propiedades definidas.")
+    st.success(
+        "La receta respeta rigidez, estanqueidad y límites de recursos definidos en"
+        " el objetivo. Continuá con la comparación o exportá el plan."
+    )
 else:
-    st.error("La receta no cumple todas las restricciones. Ajustá materiales o límites.")
+    st.error(
+        "La receta supera al menos una restricción. Ajustá materiales, procesos o"
+        " límites y regenerá candidatos."
+    )
 
 error_rows: list[dict[str, object]] = []
 for entry in constraint_entries:
@@ -263,6 +271,11 @@ for entry in constraint_entries:
 
 if error_rows:
     st.subheader("Bandas de incertidumbre ±σ")
+    st.caption(
+        "Mostramos el valor estimado junto con la desviación estándar del ensemble."
+        " Las barras resaltan dónde conviene reforzar mediciones o ampliar el"
+        " dataset."
+    )
     error_df = pd.DataFrame(error_rows)
     base = alt.Chart(error_df)
     error_bars = base.mark_errorbar(color="#94a3b8").encode(
@@ -320,6 +333,11 @@ if isinstance(candidates_all, list) and candidates_all:
 
 if pareto_rows:
     st.subheader("Frente Pareto de candidatos generados")
+    st.caption(
+        "Cada punto representa una receta explorada; el color celeste indica las"
+        " que forman parte del frente Pareto (mejor score y menor penalización"
+        " sin dominancia)."
+    )
     pareto_df = pd.DataFrame(pareto_rows)
     scatter = alt.Chart(pareto_df).mark_circle().encode(
         x=alt.X("score:Q", title="Score"),

--- a/app/pages/5_Compare_and_Explain.py
+++ b/app/pages/5_Compare_and_Explain.py
@@ -205,7 +205,10 @@ render_breadcrumbs(current_step)
 cands  = st.session_state.get("candidates", [])
 target = st.session_state.get("target", None)
 if not cands or not target:
-    st.warning("Generá opciones en **3) Generador** primero.")
+    st.warning(
+        "Aún no hay candidatos para comparar. Volvé a **3 · Generador asistido** y"
+        " creá al menos una receta."
+    )
     st.stop()
 
 try:
@@ -217,12 +220,13 @@ except MissingDatasetError as error:
 st.title("🧪 Comparar y decidir")
 st.markdown(
     """
-**Objetivo de la etapa:** comparar los candidatos generados para validar si cumplen límites operativos y seleccionar a los finalistas.
+**Qué hacemos acá:** contrastamos todas las opciones sugeridas por Rex-AI para
+entender qué tan bien equilibran desempeño técnico y consumo de recursos.
 
-**Cómo encaja en el flujo:**
-1. **Seleccioná candidatos** en la etapa anterior (Generador).
-2. **Analizá métricas clave** acá para entender recursos, desempeño y restricciones.
-3. **Decidí la receta** que pasa a prototipado o iterá si necesitás nuevos candidatos.
+**Cómo avanzar:**
+1. **Traé los candidatos** generados en el paso anterior.
+2. **Revisá la tabla comparativa** para chequear límites operativos y datos de referencia NASA.
+3. **Seleccioná la mejor receta** o volvé al generador si necesitás iterar.
 """
 )
 
@@ -266,7 +270,8 @@ for idx, candidate in enumerate(cands, start=1):
 # ======== tabla comparativa base ========
 st.subheader("📊 Tabla comparativa de candidatos")
 st.caption(
-    "Visualizá el score junto a recursos y propiedades clave para verificar si cada opción respeta los límites de la misión."
+    "La tabla reúne score, proceso, mezcla y recursos consumidos. Usala como"
+    " checklist rápido antes de pasar al duelo detallado."
 )
 st.dataframe(df_base.set_index("Opción"), use_container_width=True)
 
@@ -305,21 +310,22 @@ if reference_rows:
 kpi_cols = st.columns(4)
 with kpi_cols[0]:
     st.metric("Opciones generadas", len(cands))
-    st.caption("Más opciones permiten contrastar mejor, pero revisá que todas cumplan los límites.")
+    st.caption("Cuantas más alternativas tengas, mejor podés justificar la selección final.")
 with kpi_cols[1]:
     st.metric("Mejor Score", f"{df_base['Score'].max():.2f}")
-    st.caption("Un score alto indica equilibrio entre criterios; compará con las restricciones.")
+    st.caption("Valores altos implican buen balance entre rigidez, estanqueidad y penalizaciones.")
 with kpi_cols[2]:
     st.metric("Consumo mínimo de agua", f"{df_base['Agua (L)'].min():.2f} L")
-    st.caption("Valores bajos son favorables porque liberan recursos hídricos.")
+    st.caption("Conservar agua simplifica logística y permite más ciclos de limpieza o cultivo.")
 with kpi_cols[3]:
     st.metric("Energía mínima", f"{df_base['Energía (kWh)'].min():.2f} kWh")
-    st.caption("Menor energía consumida es positiva para misiones con baterías acotadas.")
+    st.caption("Menor demanda eléctrica es clave para operar con paneles y baterías limitadas.")
 
 # ======== Panel comparativo interactivo ========
 st.markdown("## 🧭 Comparación lado a lado")
 st.caption(
-    "Paso a paso: 1) Arrastrá para ordenar según prioridad. 2) El panel muestra los dos primeros. 3) Revisá el mapa de colores para identificar fortalezas y riesgos."
+    "Ordená manualmente la prioridad y compará las dos mejores opciones lado a"
+    " lado para detectar ventajas y riesgos en segundos."
 )
 
 candidate_labels = [

--- a/app/pages/6_Pareto_and_Export.py
+++ b/app/pages/6_Pareto_and_Export.py
@@ -66,7 +66,10 @@ target = st.session_state.get("target")
 selected_state = st.session_state.get("selected")
 
 if not candidates or not target:
-    st.warning("Generá candidatos en **3 · Generador** y definí un objetivo en **2 · Target Designer**.")
+    st.warning(
+        "Necesitás al menos una receta seleccionada y un objetivo definido. Volvé"
+        " a **2 · Target Designer** y **3 · Generador asistido** antes de exportar."
+    )
     st.stop()
 
 selected_candidate = selected_state["data"] if isinstance(selected_state, dict) else None
@@ -83,8 +86,8 @@ export_df = build_candidate_export_table(candidates, inventory_df)
 with layout_stack():
     st.title("📤 Pareto & Export")
     st.caption(
-        "Explorá la frontera de Pareto con límites reales y exportá el plan priorizado "
-        "para compartirlo con la tripulación."
+        "Filtrá por límites operativos, identificá las opciones que siguen en el"
+        " frente Pareto y descargá los paquetes listos para operaciones."
     )
 
 kpi_df = build_export_kpi_table(export_df)
@@ -104,6 +107,10 @@ if not kpi_df.empty:
 limits_container = st.container()
 with limits_container:
     st.subheader("Límites activos")
+    st.caption(
+        "Ajustá manualmente los topes de energía, agua y crew para reflejar la"
+        " planificación final antes de exportar."
+    )
     defaults = {
         "energy": _safe_float(target.get("max_energy_kwh"), fallback=_safe_float(export_df["Energía (kWh)"].max())),
         "water": _safe_float(target.get("max_water_l"), fallback=_safe_float(export_df["Agua (L)"].max())),
@@ -193,6 +200,10 @@ else:
     filtered_df["Seleccionado"] = False
 
 st.subheader("Opciones dentro de límites")
+st.caption(
+    "Filtramos automáticamente las recetas que cumplen los límites actuales."
+    " Las marcadas en celeste siguen perteneciendo al frente Pareto."
+)
 st.dataframe(
     filtered_df,
     use_container_width=True,
@@ -202,6 +213,7 @@ st.dataframe(
 materials_df = build_material_summary_table(candidates)
 if not materials_df.empty:
     st.subheader("Top residuos aportados")
+    st.caption("Qué materiales sostienen la receta prioritaria y cuánto contribuye cada uno.")
     st.dataframe(materials_df, use_container_width=True, hide_index=True)
 
 if selected_candidate and isinstance(selected_badge, dict):
@@ -211,9 +223,11 @@ if selected_candidate and isinstance(selected_badge, dict):
     st.markdown(
         f"**Opción {option_text}** — {selected_candidate.get('process_name', 'Proceso')}"
     )
-    st.caption(f"Seguridad: {selected_badge.get('level', '—')} · {selected_badge.get('detail', '')}")
+    st.caption(
+        f"Seguridad: {selected_badge.get('level', '—')} · {selected_badge.get('detail', '')}"
+    )
 else:
-    st.info("Seleccioná un plan para habilitar la exportación.")
+    st.info("Elegí un plan prioritario para activar las descargas y el resumen de seguridad.")
 
 st.markdown("---")
 
@@ -252,4 +266,4 @@ if selected_candidate:
             state="idle",
         )
 else:
-    st.caption("Los botones de exportación se activan al elegir un plan prioritario.")
+    st.caption("Los botones de exportación se habilitan cuando seleccionás un plan en la tabla de arriba.")

--- a/app/pages/7_Scenario_Playbooks.py
+++ b/app/pages/7_Scenario_Playbooks.py
@@ -65,12 +65,18 @@ selected_candidate = state_sel.get("data") if isinstance(state_sel, dict) else N
 props = selected_candidate.get("props") if isinstance(selected_candidate, dict) else None
 
 if not target:
-    st.info("Definí un objetivo en **2 · Target Designer** para habilitar los playbooks.")
+    st.info(
+        "Necesitás un objetivo activo para recomendar procedimientos. Configuralo"
+        " en **2 · Target Designer** y volvé a esta pantalla."
+    )
     st.stop()
 
 with layout_stack():
     st.title("📚 Scenario Playbooks")
-    st.caption("Procedimientos listos para ejecutar según el escenario operativo seleccionado.")
+    st.caption(
+        "Accedé a guías paso a paso calibradas para cada escenario. Cada playbook"
+        " incluye filtros sugeridos, métricas y checklist editable."
+    )
 
 scenarios = list(PLAYBOOKS.keys())
 if not scenarios:
@@ -127,6 +133,7 @@ if st.button("Abrir generador con estos filtros"):
     st.switch_page("pages/3_Generator.py")
 
 st.subheader("Recursos del candidato activo")
+st.caption("Mirá el consumo estimado de la opción elegida antes de lanzar el playbook.")
 metric_columns = st.columns(4)
 metrics = [
     ("Masa final (kg)", getattr(props, "mass_final_kg", None)),
@@ -143,6 +150,7 @@ if not props:
     st.caption("Seleccioná un candidato en **3 · Generador** para ver métricas reales.")
 
 st.subheader("Pasos del playbook")
+st.caption("Cada paso combina tareas operativas y notas técnicas para guiar a la tripulación.")
 steps_df = pd.DataFrame(
     {
         "Paso": list(range(1, len(playbook.steps) + 1)),
@@ -153,6 +161,7 @@ steps_df = pd.DataFrame(
 st.dataframe(steps_df, use_container_width=True, hide_index=True)
 
 st.subheader("Checklist editable")
+st.caption("Personalizá la lista de control y compartila con el equipo en segundos.")
 default_lines = [
     "- Verificar disponibilidad de materiales",
     "- Preparar equipo de proceso",

--- a/app/pages/8_Feedback_and_Impact.py
+++ b/app/pages/8_Feedback_and_Impact.py
@@ -87,7 +87,10 @@ feedback_summary_df = build_feedback_summary_table(expanded_feedback_df)
 
 with layout_stack():
     st.title("📝 Feedback & Impact")
-    st.caption("Registra corridas reales, consolida el feedback y cuantificá el impacto en la misión.")
+    st.caption(
+        "Documentá resultados reales, conectalos con el objetivo activo y usá los"
+        " registros para reentrenar Rex-AI sin perder trazabilidad."
+    )
 
 metric_cols = st.columns(4)
 metric_cols[0].metric("Corridas registradas", impact_summary.get("runs", 0))
@@ -97,18 +100,24 @@ metric_cols[3].metric("Crew total (min)", _format_metric(impact_summary.get("cre
 
 if not feedback_summary_df.empty:
     st.subheader("Impacto del feedback")
+    st.caption("Indicadores calculados a partir de feedback estructurado: medias, desvíos y alertas relevantes.")
     st.dataframe(feedback_summary_df, use_container_width=True, hide_index=True)
 else:
     st.caption("Aún no se registró feedback cuantitativo.")
 
 st.subheader("Corridas registradas")
+st.caption("Historial de lotes ejecutados con métricas reales y notas asociadas.")
 if expanded_impact_df.empty:
-    st.info("Todavía no hay registros de impacto. Usá el formulario para agregar la primera corrida.")
+    st.info(
+        "Todavía no hay registros de impacto. Cargá tu primera corrida con masa,"
+        " energía, agua y crew medidos para iniciar el historial."
+    )
 else:
     impact_preview = expanded_impact_df.sort_values("ts_iso", ascending=False).head(20)
     st.dataframe(impact_preview, use_container_width=True, hide_index=True)
 
 st.subheader("Feedback recientes")
+st.caption("Respuestas individuales de la tripulación con su percepción del proceso.")
 if expanded_feedback_df.empty:
     st.caption("Sin feedback registrado por el momento.")
 else:
@@ -119,6 +128,7 @@ st.markdown("---")
 
 with st.form("impact_form"):
     st.subheader("Registrar impacto de una corrida")
+    st.caption("Ingresá métricas medidas en campo para alimentar el análisis de impacto y readiness del modelo.")
     scenario = st.selectbox(
         "Escenario",
         [target.get("scenario", "-")] if isinstance(target, dict) else ["-"],
@@ -156,11 +166,12 @@ with st.form("impact_form"):
             extra={"notes": impact_notes},
         )
         append_impact(entry)
-        st.success("Impacto registrado.")
+        st.success("Impacto registrado. Los datos quedan listos para dashboards y reentrenamiento.")
         st.rerun()
 
 with st.form("feedback_form"):
     st.subheader("Registrar feedback operativo")
+    st.caption("Capturá percepciones cualitativas y cuantitativas de la tripulación tras ejecutar la receta.")
     astronaut = st.text_input("Operador o equipo", value="")
     overall = st.slider("Satisfacción general", 0, 10, 8)
     rigidity_ok = st.checkbox("Rigidez dentro de lo esperado", value=True)
@@ -186,5 +197,5 @@ with st.form("feedback_form"):
             },
         )
         append_feedback(entry)
-        st.success("Feedback registrado.")
+        st.success("Feedback registrado. Se actualizará el resumen y quedará disponible para el próximo reentrenamiento.")
         st.rerun()

--- a/app/pages/8_Spectral_Mix_Designer.py
+++ b/app/pages/8_Spectral_Mix_Designer.py
@@ -24,7 +24,10 @@ initialise_frontend()
 render_brand_header()
 
 st.title("🌈 Mezclador espectral FTIR")
-st.caption("Subí una firma objetivo y Rex-AI propondrá una mezcla viable usando el stock disponible.")
+st.caption(
+    "Subí una firma objetivo y Rex-AI propondrá una mezcla viable aprovechando"
+    " el stock disponible y las curvas de referencia NASA/UCF."
+)
 
 try:
     bundle = ds.load_material_reference_bundle()
@@ -33,7 +36,7 @@ except Exception as error:  # pragma: no cover - fallback for missing datasets
     st.stop()
 
 if not bundle.spectral_curves:
-    st.info("El bundle de referencia no incluye curvas FTIR para mezclar todavía.")
+    st.info("El bundle de referencia todavía no incluye curvas FTIR para mezclar.")
     st.stop()
 
 spectral_keys = sorted(bundle.spectral_curves.keys())
@@ -109,9 +112,9 @@ with layout_block("layout-stack"):
         else:
             st.info("El CSV no contiene filas con datos numéricos.")
     elif uploaded_file is None:
-        st.info("Cargá un CSV para obtener la mezcla propuesta.")
+        st.info("Cargá un CSV con la firma objetivo para calcular la mezcla.")
     elif not selected_materials:
-        st.info("Seleccioná al menos un material base.")
+        st.info("Seleccioná al menos un material base antes de lanzar el solver.")
 
 if not result_payload:
     st.stop()
@@ -122,6 +125,7 @@ target_curve = result_payload.get("target_curve")
 error_metrics = result_payload.get("error", {})
 
 st.subheader("Comparativa espectral")
+st.caption("Superponemos la firma objetivo, la mezcla sugerida y la línea base para auditar el ajuste.")
 if isinstance(synthetic_curve, pd.DataFrame) and isinstance(target_curve, pd.DataFrame):
     target_df = target_curve.rename(columns={"intensity": "value"})
     target_df["serie"] = "Objetivo"
@@ -145,6 +149,7 @@ else:
 
 if not coefficients.empty:
     st.subheader("Receta recomendada")
+    st.caption("Fracciones normalizadas por material seleccionadas para reproducir la firma de destino.")
     stock_limits = {}
     if not stock_df.empty and stock_df["kg"].sum() > 0:
         total_stock = float(stock_df["kg"].sum())
@@ -161,6 +166,7 @@ if not coefficients.empty:
 
 if error_metrics:
     st.subheader("Errores de ajuste")
+    st.caption("Metadatos cuantitativos de la mezcla propuesta: RMSE, error relativo por banda y residuos.")
     metrics_df = pd.DataFrame(
         {
             "Métrica": ["MAE", "RMSE", "Error máximo"],

--- a/app/pages/9_Capacity_Simulator.py
+++ b/app/pages/9_Capacity_Simulator.py
@@ -41,7 +41,10 @@ props = selected_candidate.get("props") if isinstance(selected_candidate, dict) 
 
 with layout_stack():
     st.title("🧮 Capacity Simulator")
-    st.caption("Evalúa la producción diaria frente a límites de recursos y downtime estimado.")
+    st.caption(
+        "Modelá cómo se comporta la línea de producción a lo largo de varios soles"
+        " considerando turnos, eficiencia y restricciones de recursos."
+    )
 
 col_left, col_right = st.columns(2)
 with col_left:
@@ -135,7 +138,11 @@ if simulate_clicked:
     metric_summary[3].metric("Crew total (min)", f"{total_row['Crew (min)']:.0f}")
 
     st.subheader("Producción por sol")
+    st.caption("Resultados ajustados por downtime y límites diarios. La fila final resume el total acumulado.")
     result_table = pd.concat([per_day_df, pd.DataFrame([total_row])], ignore_index=True)
     st.dataframe(result_table, use_container_width=True, hide_index=True)
 else:
-    st.caption("Configurá los parámetros y presioná **Simular** para ver la proyección por sol.")
+    st.caption(
+        "Configurá los parámetros y presioná **Simular** para proyectar masa,"
+        " energía, agua y crew consumidos por jornada marciana."
+    )

--- a/docs/data-viz.md
+++ b/docs/data-viz.md
@@ -1,97 +1,61 @@
 # Rex-AI Data Visualization Theme
 
-La experiencia visual de Rex-AI está inspirada en tableros automotrices de gama
-alta: superficies satinadas, tipografías técnicas y acentos eléctricos que
-refuerzan precisión y dinamismo. Este documento resume las guías de uso,
-paletas y configuraciones disponibles para Altair y Plotly.
+Guía para utilizar los temas registrados de Altair y Plotly en la consola
+Rex-AI. Describe cómo activar la paleta, qué tokens están disponibles y buenas
+prácticas para mantener consistencia visual.
 
 ## Activación
 
-* La app registra los temas automáticamente llamando a
-  `initialise_frontend()` (expuesta por `app.modules.ui_blocks`) inmediatamente
-  después de `st.set_page_config()`.
-* El modo por defecto es `dark`. Puede forzarse otra variante definiendo la
-  variable de entorno `REXAI_THEME_MODE=light` o `REXAI_THEME_MODE=dark`.
-* Ambos motores (Altair y Plotly) comparten tokens cromáticos a través del
-  módulo `app.modules.visual_theme`. Para acceder a ellos:  
-  ```python
-  from app.modules.visual_theme import get_palette
+```python
+from app.modules.ui_blocks import initialise_frontend
+from app.modules.visual_theme import apply_global_visual_theme
 
-  palette = get_palette()  # respeta el modo activo
-  st.write(palette.categorical)
-  ```
+initialise_frontend()
+apply_global_visual_theme()
+```
 
-## Tipografía y layout
+- El modo por defecto es oscuro; podés forzarlo con
+  `REXAI_THEME_MODE=light|dark`.
+- `get_palette()` expone los colores actuales para integraciones personalizadas.
 
-| Elemento               | Configuración                                            |
-|------------------------|----------------------------------------------------------|
-| Títulos / headings     | `Rajdhani`, semibold, espaciado 0.02em                    |
-| Cuerpos / labels       | `Inter`, 12–14px según el motor                           |
-| Fondos                 | Panel satinado (ver paleta) con grid en baja opacidad     |
-| Bordes y gridlines     | Gris azulado translúcido (`grid` en la paleta)            |
-| Hover / focus          | Fondos oscuros con borde en `accent`                      |
-| Selecciones destacadas | Gradiente eléctrico (ver sección siguiente)               |
+## Tokens principales
 
-## Paletas
+| Token | Uso |
+| --- | --- |
+| `background` | Fondo global del dashboard. |
+| `surface` | Paneles y tarjetas. |
+| `panel` | Contenedores secundarios / overlays. |
+| `text`, `muted` | Texto principal y secundario. |
+| `accent`, `accent_soft` | Curvas activas, marcas destacadas. |
+| `grid` | Líneas de referencia y ejes. |
+| `categorical` | Lista de colores para series múltiples. |
 
-### Modo claro
+Los valores cambian automáticamente entre modo claro y oscuro. Usá el helper
+para obtenerlos:
 
-| Token              | Valor                                            | Uso principal                                  |
-|--------------------|--------------------------------------------------|------------------------------------------------|
-| `background`       | `#F8FAFC`                                        | Fondo de aplicación / dashboards               |
-| `surface`          | `#FFFFFF`                                        | Paneles, tarjetas y áreas de gráfica           |
-| `panel`            | `#E2E8F0`                                        | Bordes suaves y barras de herramientas         |
-| `text`             | `#0F172A`                                        | Texto principal                                |
-| `muted`            | `#475569`                                        | Etiquetas secundarias                          |
-| `accent`           | `#1D4ED8`                                        | Líneas, marcadores activos                     |
-| `accent_soft`      | `#60A5FA`                                        | Rellenos suaves                                |
-| `grid`             | `rgba(30,64,175,0.14)`                            | Gridlines y ejes                               |
-| `categorical`      | `#0F76FF`, `#1DD3F8`, `#F59E0B`, `#14B8A6`, `#7C3AED`, `#F97316` | Series múltiples | 
+```python
+from app.modules.visual_theme import get_palette
+palette = get_palette()
+alt.themes.set_theme("rexai_dark")
+```
 
-### Modo oscuro
+## Gradiente eléctrico
 
-| Token              | Valor                                            | Uso principal                                  |
-|--------------------|--------------------------------------------------|------------------------------------------------|
-| `background`       | `#070B12`                                        | Fondo global                                   |
-| `surface`          | `#0E141F`                                        | Paneles y tarjetas                             |
-| `panel`            | `#192132`                                        | Delineados sutiles                             |
-| `text`             | `#F8FAFC`                                        | Texto principal                                |
-| `muted`            | `#94A3B8`                                        | Texto secundario                               |
-| `accent`           | `#38BDF8`                                        | Curvas y puntos activos                        |
-| `accent_soft`      | `#7DD3FC`                                        | Rellenos suaves                                |
-| `grid`             | `rgba(148,163,184,0.22)`                          | Gridlines y ejes                               |
-| `categorical`      | `#7DD3FC`, `#34D399`, `#FBBF24`, `#F472B6`, `#A855F7`, `#F97316` | Series múltiples | 
-
-### Gradiente eléctrico (highlight)
-
-El resalte para selecciones y transiciones se basa en un gradiente de energía
-eléctrica aplicado en ambos motores como escala secuencial:
-
-* `#7CF4FF`
-* `#2AA8FF`
-* `#4C4CFF`
-
-Altair lo usa para `range["diverging"]`, `range["heatmap"]` y `range["ramp"]`,
-mientras que Plotly lo asigna a `coloraxis` y a los `colorscale` por defecto en
-`scatter`, `bar` y `heatmap`. Aplicarlo manualmente es tan simple como usar el
-rango `"ramp"` o el template `"rexai_dark"/"rexai_light"` ya registrado.
+El gradiente `palette.electric_gradient` (`#7CF4FF → #2AA8FF → #4C4CFF`) se usa
+para highlights, heatmaps y selección de filas. En Plotly está disponible como
+`colorscale="rexai_electric"`.
 
 ## Buenas prácticas
 
-1. **Evitar hardcodear colores**: el tema ya define escalas por defecto para
-   Altair y Plotly. Solo sobrescribir cuando haya semántica crítica.
-2. **Contraste**: sobre fondos personalizados, respetar las combinaciones
-   `text` + `muted` para mantener accesibilidad WCAG AA.
-3. **Highlight de selección**: para resaltar filas/barra activa, usar los
-   colores del gradiente (`palette.electric_gradient`) en orden o aplicarlos a
-   `marker.line.color` en Plotly.
-4. **Impresión / exportación**: para fondos blancos usar `REXAI_THEME_MODE=light`
-   en la línea de comandos antes de ejecutar `streamlit run`.
+1. Evitá hardcodear colores; apoyate en el template `rexai_dark`/`rexai_light`.
+2. Reutilizá `palette.categorical` para asegurar contraste adecuado.
+3. Para exportar a PDF o slides con fondo claro activá `REXAI_THEME_MODE=light`
+ante de ejecutar `streamlit run`.
+4. Documentá cualquier escala adicional en este archivo para mantener el catálogo
+   al día.
 
-## Referencias rápidas
+## Referencias
 
-* Altair: tema registrado como `rexai_dark` y `rexai_light`.
-* Plotly: template registrado como `rexai_dark` y `rexai_light`; el template
-  activo queda en `pio.templates.default`.
-* CSS global: se inyecta automáticamente mediante `apply_global_visual_theme`,
-  reutilizando `app/static/styles/base.css`.
+- Altair registra los temas como `rexai_dark` y `rexai_light`.
+- Plotly establece `pio.templates.default = "rexai_dark"` (o light según modo).
+- El CSS global se inyecta mediante `apply_global_visual_theme()`.

--- a/docs/data_inventory.md
+++ b/docs/data_inventory.md
@@ -1,66 +1,65 @@
-# Inventario de datos Rex-AI (Sprint 0)
+# Inventario de datos Rex-AI
 
-Este documento mapea los datos existentes en el repositorio a los *features*, *targets* y señales auxiliares del pipeline predictivo. Sirve como punto de partida para el script `build_gold_dataset.py` y para coordinar nuevas ingestas.
+Mapa completo de datasets, artefactos intermedios y etiquetas utilizadas por el
+pipeline de Rex-AI. Sirve como referencia para `scripts/build_gold_dataset.py`
+y para coordinar nuevas ingestas.
 
 ## Directorios clave
 
-| Ruta | Contenido | Uso en pipeline |
+| Ruta | Contenido | Uso principal |
 | --- | --- | --- |
-| `datasets/raw/` | Archivos CSV provenientes de NASA, UCF y catálogos internos. | Fuente primaria para enriquecer features físicos (composición, oxidos) y perfiles de residuo. |
-| `datasets/processed/` | Espacio reservado para datasets intermedios (`rexai_training_dataset.parquet`). | Entrada legacy del modelo actual; servirá como referencia para validaciones de consistencia. |
-| `data/gold/` | Directorio destino para `features.parquet` y `labels.parquet`. | Dataset "gold" armonizado que alimentará el entrenamiento/re-entrenamiento. |
-| `datasets/processed/` | Espacio reservado para datasets intermedios (`rexai_training_dataset.parquet`, `ml/synthetic_runs.parquet`). | Entrada legacy del modelo actual; servirá como referencia para validaciones de consistencia y análisis de corridas sintéticas. |
-| `data/processed/` | Artefactos intermedios generados por el pipeline (`rexai_training_dataset.parquet`, `ml/synthetic_runs.parquet`). | Fuente principal para validar que el reentrenamiento produzca datasets consistentes. |
-| `datasets/gold/` | Directorio destino para `features.parquet` y `labels.parquet`. | Dataset "gold" armonizado que alimentará el entrenamiento/re-entrenamiento. |
-| `data/` | Configuración operativa (catálogo de procesos, logs, presets de objetivos) y modelos empaquetados. | Cruce de parámetros de proceso, restricciones operacionales y mediciones previas. |
-| `data/models/` | Modelos actuales (`rexai_regressor.joblib`, `metadata.json`, clasificadores). | Sirven para validar compatibilidad de features/targets y para bootstrap mientras se migra al nuevo pipeline. |
+| `datasets/raw/` | CSV originales de NASA, UCF y catálogos internos. | Fuente de features físicos y logísticos. |
+| `datasets/processed/` | Resultados intermedios (`rexai_training_dataset.parquet`, `ml/synthetic_runs.parquet`). | Control de consistencia y análisis sintético. |
+| `data/gold/` | `features.parquet`, `labels.parquet` armonizados. | Dataset “gold” para entrenamiento y reentrenamiento. |
+| `data/processed/` | Copias procesadas consumidas por la app (`rexai_training_dataset.parquet`). | Punto de validación para nuevas corridas. |
+| `data/models/` | Artefactos entrenados (`rexai_regressor.joblib`, `metadata.json`, ensambles). | Base para `ModelRegistry`. |
+| `data/` | Catálogo de procesos, presets, logs y configuraciones de UI. | Parametrización operativa y trazabilidad. |
 
 ## Fuentes crudas (`datasets/raw/`)
 
-| Archivo | Columnas principales | Tipo | Cómo se usa |
-| --- | --- | --- | --- |
-| `mgs1_properties.csv` | `simulant`, `property`, `value`, `units`, `notes` | Long table | Referencia de propiedades físicas del regolito (densidad, distribución de grano). Se pivoteará para features como `regolith_density` o controles de mezclado. |
-| `mgs1_composition.csv` | `simulant`, `mineral`, `wt_percent` | Long table | Define fracciones minerales base. Se agregará por mineral para features agregados (`plagioclase_pct`, etc.) o se integrará a un índice de compatibilidad. |
-| `mgs1_oxides.csv` | `simulant`, `oxide`, `wt_percent` | Long table | Fuente directa para features `oxide_*` (p.ej. `oxide_sio2`, `oxide_feot`, `oxide_mgo`, `oxide_cao`, `oxide_so3`, `oxide_h2o`). |
-| `nasa_waste_inventory.csv` | `id`, `category`, `item`, `key_materials`, `mass_kg`, `volume_m3`, `moisture_pct`, `pct_mass`, `pct_volume`, `commercial_equivalent`, `difficulty_factor`, `flags`, `notes` | Catálogo tabular | Base para features de mezcla de residuos: `mass_input_kg`, `difficulty_index`, fracciones por familia (`foam_frac`, `eva_frac`, `textile_frac`, etc.) y *flags* (`closed_cell`, `ctb`, `eva`, `multilayer`). |
-| `nasa_trash_to_gas.csv` | `mission`, `category`, `kg_per_cm_day`, `gas_mix_*`, `o2_ch4_yield_kg`, `water_makeup_kg`, `isp_*`, `delta_v_ms` | Indicadores por misión | Se utilizará para construir índices `gas_recovery_index` y `trash_to_gas_score` vinculados a cada mezcla candidata. |
-| `logistics_to_living.csv` | `scenario`, `crew_days`, `crew_count`, `goods_kg`, `packaging_kg`, `ctb_count`, `reuse_plan`, `outfitting_replaced_kg`, `residual_waste_kg` | Escenarios logísticos | Alimenta el índice `logistics_reuse_index` y metas de reducción de residuo. |
+| Archivo | Columnas destacadas | Uso |
+| --- | --- | --- |
+| `nasa_waste_inventory.csv` | `id`, `category`, `mass_kg`, `volume_m3`, `moisture_pct`, `difficulty_factor`, `flags` | Base de residuos NASA; se expanden features de masa, volumen, humedad, dificultad y familias (`foam`, `eva`, `multilayer`). |
+| `mgs1_properties.csv` | `simulant`, `property`, `value`, `units` | Propiedades físicas del regolito MGS-1 (densidad, granulometría). |
+| `mgs1_composition.csv` | `mineral`, `wt_percent` | Fracciones minerales; se agregan a índices de compatibilidad. |
+| `mgs1_oxides.csv` | `oxide`, `wt_percent` | Alimenta features `oxide_*` para análisis químico. |
+| `nasa_trash_to_gas.csv` | `mission`, `kg_per_cm_day`, `gas_mix_*`, `water_makeup_kg` | Construye `gas_recovery_index` y puntajes Trash-to-Gas. |
+| `logistics_to_living.csv` | `scenario`, `crew_days`, `goods_kg`, `outfitting_replaced_kg` | Deriva índices de reutilización logística. |
 
 ## Configuración operativa (`data/`)
 
-| Archivo | Columnas / Campos | Cómo contribuye |
+| Archivo | Campos | Rol |
 | --- | --- | --- |
-| `process_catalog.csv` | `process_id`, `name`, `location`, `energy_kwh_per_kg`, `water_l_per_kg`, `crew_min_per_batch`, `notes` | Define parámetros base por proceso (P01–P04). Se usa para poblar targets esperados (`energy_kwh`, `water_l`, `crew_min`) y como *features* de contexto (`process_id`, `location`). |
-| `waste_inventory_sample.csv` | Similar a `nasa_waste_inventory` pero resumido | Dataset de prueba para UI/benchmark. Útil para validar mapeos de flags a features. |
-| `impact_log.csv` | `ts_iso`, `scenario`, `target_name`, `materials`, `weights`, `process_id`, ... | Historial de ejecuciones de la app. Campos `materials`/`weights` permiten reconstruir recetas generadas manualmente (servirán como `weak labels`). |
-| `feedback_log.csv` | `ts_iso`, `astronaut`, `scenario`, `target_name`, `option_idx`, `rigidity_ok`, `ease_ok`, `issues`, `notes`, `extra` | Feedback cualitativo de usuarios. Se convertirá en etiquetas *weak* (`label_source=weak`) con mapeos booleanos a `rigidez`/`estanqueidad`. |
-| `targets_presets.json` | Lista de presets: `name`, `rigidity`, `tightness`, `max_water_l`, `max_energy_kwh`, `max_crew_min` | Sirve para inicializar pesos multiobjetivo y normalizar *score* de usuario. |
-| `benchmarks/*.csv` | Métricas y predicciones históricas | Para comparar baseline heurístico vs IA; no entran directo al dataset gold pero ayudan en validación. |
-| `models/metadata.json` | Descripción del bundle actual (features, targets, métricas) | Referencia para garantizar compatibilidad de columnas en el nuevo esquema. |
+| `process_catalog.csv` | Energía/agua/crew por proceso, notas y ubicación. | Parametriza targets esperados y features de contexto. |
+| `targets_presets.json` | `name`, `rigidity`, `tightness`, `max_water_l`, `max_energy_kwh`, `max_crew_min`, `scenario` | Presets para el Target Designer y normalización de scores. |
+| `waste_inventory_sample.csv` | Subconjunto de inventario NASA. | Dataset de demo y validación rápida. |
+| `data/logs/feedback_*.parquet` | Correcciones de usuarios (rigidez, estanqueidad, penalizaciones). | Fuente de labels débiles para reentrenamiento. |
+| `data/logs/impact_*.parquet` | Métricas reales de corridas. | Registro operativo y auditoría. |
+| `benchmarks/*.csv` | MAE/RMSE históricos, predicciones y ablations. | Seguimiento de drift y validación. |
 
-## Mapeo preliminar de features y targets
+## Mapeo de features y targets
 
-| Tipo | Columna objetivo | Fuente | Transformación |
+| Tipo | Destino | Fuente | Transformación |
 | --- | --- | --- | --- |
-| Feature numérico | `regolith_pct` | Control de receta (UI / generador) | Porcentaje de MGS-1 mezclado (derivado de inputs de usuario). |
-| Feature categórico | `process_id` | `process_catalog.csv` / receta | Codificar como categoría (one-hot). |
-| Feature numérico | `mass_input_kg`, `total_mass_kg` | `nasa_waste_inventory.csv` + cantidades de receta | Suma ponderada de masas de cada residuo. |
-| Feature numérico | `density_kg_m3` | `mgs1_properties.csv` + mezcla | Usar `density_bulk` ajustado por humedad. |
-| Feature numérico | `moisture_frac` | `nasa_waste_inventory.csv` (`moisture_pct`) | Normalizar a 0–1 según composición de la receta. |
-| Feature numérico | `difficulty_index` | `nasa_waste_inventory.csv` (`difficulty_factor`) | Promedio ponderado por masa. |
-| Feature numérico | `problematic_mass_frac`, `problematic_item_frac` | Flags de `nasa_waste_inventory.csv` | Clasificar flags críticos (`hazard`, `sharp`, etc.) y agregarlos como fracciones. |
-| Feature numérico | `foam_frac`, `eva_frac`, `textile_frac`, `multilayer_frac`, `glove_frac`, `polyethylene_frac`, `carbon_fiber_frac`, `hydrogen_rich_frac`, `packaging_frac` | Flags + `key_materials` | Etiquetado binario/ponderado según presencia de cada familia en la receta. |
-| Feature numérico | `gas_recovery_index`, `trash_to_gas_score` | `nasa_trash_to_gas.csv` | Mapear misión/escenario al índice correspondiente. |
-| Feature numérico | `logistics_reuse_index` | `logistics_to_living.csv` | Normalizar `outfitting_replaced_kg` / `packaging_kg`. |
-| Feature numérico | `oxide_sio2`, `oxide_feot`, `oxide_mgo`, `oxide_cao`, `oxide_so3`, `oxide_h2o` | `mgs1_oxides.csv` | Usar directamente las fracciones de óxidos del regolito. |
-| Target continuo | `rigidez`, `estanqueidad` | Etiquetas reales/simuladas (`feedback` o ensayos) | Escala 0–1. Inicialmente se poblará con heurísticas calibradas. |
-| Target continuo | `energy_kwh`, `water_l`, `crew_min` | `process_catalog.csv` + mediciones reales | Ajustar según masa del batch y telemetría del proceso. |
-| Flag | `tightness_pass`, `process_risk` | Clasificadores auxiliares / feedback | Derivados de `estanqueidad` y análisis de proceso. |
-| Meta | `score_objective` | Configuración de usuario | Función multiobjetivo (no se persiste como label, pero se registra para ranking). |
+| Feature numérico | `mass_input_kg`, `total_mass_kg` | `nasa_waste_inventory` + receta | Suma ponderada por masa. |
+| Feature numérico | `moisture_frac` | `moisture_pct` | Normalización 0–1 ajustada por peso. |
+| Feature numérico | `difficulty_index` | `difficulty_factor` | Promedio ponderado por masa. |
+| Feature numérico | `foam_frac`, `eva_frac`, `multilayer_frac`, etc. | Flags de inventario | Conteo ponderado / one-hot de familias. |
+| Feature numérico | `gas_recovery_index`, `trash_to_gas_score` | `nasa_trash_to_gas.csv` | Mapear misión → índice. |
+| Feature numérico | `logistics_reuse_index` | `logistics_to_living.csv` | `outfitting_replaced_kg / packaging_kg`. |
+| Feature numérico | `oxide_*` | `mgs1_oxides.csv` | Uso directo de fracciones. |
+| Feature numérico | `regolith_pct` | UI/generador | Porcentaje de MGS-1 agregado a la receta. |
+| Feature categórico | `process_id` | `process_catalog.csv` | One-hot / embeddings tabulares. |
+| Targets continuos | `rigidez`, `estanqueidad`, `energy_kwh`, `water_l`, `crew_min` | Heurísticas calibradas + feedback operativo | Escala 0–1 para rigidez/estanqueidad; valores físicos para recursos. |
+| Flags auxiliares | `tightness_pass`, `process_risk` | Clasificadores y feedback | Se derivan en el pipeline para explicar decisiones. |
 
-## Próximas acciones sobre los datos
+## Próximas acciones
 
-1. Normalizar IDs de residuo (`id` vs `material`) para que cada receta tenga `recipe_id` único y trazable.
-2. Definir diccionario de flags → features (ej.: `ctb` → `eva_frac`, `multilayer`; `closed_cell` → `foam_frac`).
-3. Documentar en `datasets/schema.yaml` el orden y tipo de columnas esperadas para `features.parquet` y `labels.parquet`.
-4. Inventariar cualquier fuente externa adicional (simulador térmico, experimentos físicos) antes de poblar `feedback/`.
+1. Normalizar IDs de residuo (`id`, `material`) para generar `recipe_id` único y
+aumentar la trazabilidad.
+2. Publicar `datasets/schema.yaml` con tipos esperados para `features.parquet`
+y `labels.parquet`.
+3. Inventariar nuevas fuentes (simulador térmico, ensayos físicos) antes de
+alimentar `feedback/`.
+4. Documentar mapeos `flag → feature` en un diccionario central para evitar
+interpretaciones divergentes.

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -1,27 +1,42 @@
 # Sistema visual base
 
-La UI ahora depende de una única hoja de estilos ligera (`app/static/styles/base.css`) que aporta la paleta NASA-inspired y los grids responsivos compartidos por todas las páginas. El objetivo es mantener contraste alto sin HUDs ni toggles interactivos.
+La app utiliza una única hoja de estilos (`app/static/styles/base.css`) para
+aplicar la paleta inspirada en NASA, tipografía y grillas responsivas. El diseño
+prioriza contraste alto y componentes reutilizables para que cada página se
+perciba como parte de la misma consola.
 
-## Variables clave
+## Variables de diseño
 
-| Variable | Valor | Uso |
+| Variable | Valor | Descripción |
 | --- | --- | --- |
-| `--color-background` | `#09192f` | Fondo general de la aplicación.
-| `--color-surface` | `#112a45` | Paneles base y superficies neutras.
-| `--color-surface-raised` | `#1c3554` | Tarjetas elevadas con sombra ligera.
-| `--color-text` | `#f5f7fb` | Tipografía principal.
-| `--color-accent` | `#63b3ff` | Links, estados activos y CTA.
-| `--space-lg` | `1.5rem` | Espaciado vertical estándar entre bloques.
-| `--shadow-soft` | `0 6px 18px rgba(3, 13, 31, 0.35)` | Profundidad suave para paneles.
+| `--mission-color-background` | `#09192f` | Fondo global. |
+| `--mission-color-panel` | `#101724` | Paneles secundarios y tarjetas. |
+| `--mission-color-surface` | `#112a45` | Superficies principales. |
+| `--mission-color-text` | `#f8fafc` | Texto primario. |
+| `--mission-color-accent` | `#5aa9ff` | CTA, estados activos, iconografía. |
+| `--mission-space-sm/md/lg` | `0.75rem` / `1rem` / `1.5rem` | Gaps estándar entre componentes. |
+| `--mission-radius-md` | `0.5rem` | Bordes redondeados para paneles. |
+| `--mission-shadow-soft` | `0 6px 18px rgba(3, 13, 31, 0.35)` | Sombra base para profundidad. |
 
-> Si necesitás otro tono o espaciado, añadilo en `:root` siguiendo el prefijo `--color-` o `--space-` para mantener consistencia.
+Extender el sistema sumando variables con el prefijo `--mission-` garantiza
+consistencia entre páginas y facilita documentar cambios en `docs/ui-components.md`.
 
-## Patrones disponibles
+## Patrones reutilizables
 
-- `.layout-grid` + modificadores (`--dual`, `--flow`) resuelven columnas fluidas.
-- `.layout-stack` y `.depth-stack` generan pilas verticales con gap consistente.
-- `.rex-surface` y `.rex-glass` proveen superficies con bordes redondeados y sombras suaves.
-- `.chipline`, `.badge-group` y `.hr-micro` mantienen micro-componentes alineados con la paleta.
-- `.rexai-minimal-button` estiliza botones CTA sin depender de microinteracciones JS.
+- `.layout-grid` (`--dual`, `--flow`) → columnas fluidas y responsivas.
+- `.layout-stack`, `.depth-stack` → pilas verticales con espaciado consistente.
+- `.side-panel`, `.pane` → contenedores con borde, sombra y padding definidos.
+- `.chipline`, `.badge-group` → etiquetas compactas para estado o filtros.
+- `.rexai-minimal-button` → CTA sin microinteracciones complejas.
 
-Todos los componentes se renderizan correctamente en móviles (<768px) gracias a los media queries incluidos; evitá sobreescribirlos salvo que sea imprescindible.
+Todos los patrones incluyen media queries para pantallas < 768 px. Evitá
+sobreescribirlos salvo que documentes el cambio.
+
+## Ajustes recomendados
+
+1. Actualizá colores desde la raíz (`:root`) y reflejá las modificaciones en
+   `docs/ui-components.md`.
+2. Para nuevos componentes, apoyate en `layout_stack` y `layout_block` desde
+   `app/modules/ui_blocks.py` para heredar estilos automáticamente.
+3. Validá contraste con herramientas WCAG al introducir combinaciones de color
+   personalizadas.

--- a/docs/experiments_logbook.md
+++ b/docs/experiments_logbook.md
@@ -1,10 +1,22 @@
 # Registro de experimentos físicos / simulador
 
-El flujo operativo para experimentos permanece en pausa hasta que el equipo de
-operaciones confirme su implementación. Toda la propuesta detallada se movió a
+Seguimiento breve del estado de los experimentos físicos y del simulador. La
+propuesta detallada vive en
 [`docs/proposals/experiments_feedback_flow.md`](proposals/experiments_feedback_flow.md)
-para evaluar y ajustar fuera del plan activo.
+mientras operaciones confirma su implementación.
 
-Mientras tanto, enfocarse en los procesos documentados en `feedback/README.md`
-y en el pipeline descrito en `docs/feedback_loop.md`, que continúan vigentes
-para incorporar mediciones validadas en la app.
+## Estado actual
+
+- El circuito activo continúa siendo el de `docs/feedback_loop.md` (feedback
+  registrado vía app o Parquet manuales).
+- Cualquier ensayo físico debe documentarse en el esquema `datasets/feedback_schema.yaml`.
+- Las corridas con simulador quedan en pausa hasta contar con hardware y turnos
+dedicados.
+
+## Próximos pasos sugeridos
+
+1. Revisar la propuesta externa y acordar un piloto con operaciones.
+2. Definir formato final de `experiments_logbook.parquet` para integrarlo al
+   pipeline gold.
+3. Integrar notificaciones en el Mission Planner para señalar cuando haya
+   experimentos pendientes de ingestión.

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -1,53 +1,57 @@
 # Onboarding operativo Rex-AI
 
-El home y la demo guiada se reconstruyeron para priorizar claridad operativa en
-los laboratorios. Los componentes viven en `app.modules.ui_blocks` y los flows
-usan microcopys breves pensados para tripulaciones mixtas (ingeniería + crew
-ops). Esta guía resume qué preparar antes de un recorrido y cómo adaptar la
-experiencia.
+Esta guía acompaña a facilitadores y tripulaciones mixtas (ingeniería + crew
+ops) que recorren la demo de Rex-AI. El objetivo es explicar qué preparar antes
+de la sesión, cómo guiar cada paso y qué hacer si necesitás ajustar la
+experiencia sobre la marcha.
 
-## 1. Brief operativo
-- **Componente**: combinación de `layout_stack`, `chipline` y `minimal_button`.
-- **Narrativa**: enfocá el mensaje en la misión del turno (ej. "Validar receta
-  EVA sin PFAS"). Evitá metáforas y usa verbos de acción.
-- **Assets**: las imágenes o GIFs deben ir en `app/static/media`. Mantener peso
-  < 3 MB para garantizar carga rápida en Streamlit Cloud.
+## 1. Antes de la sesión
 
-## 2. Checklist escalonado
-- **Layout**: `layout_stack` + `layout_block("layout-grid--dual")`.
-- **Contenido**: tres pasos máximos. El primero siempre "Inventario", el
-  segundo "Target" y el tercero "Generador" o "Feedback" según la demo.
-- **Estado**: usá `pill` (`ok`, `warn`, `risk`) para señalar el estado de cada
-  paso sin necesidad de texto largo.
+1. **Prepará los datasets de ejemplo** en `data/` (`waste_inventory_sample.csv`
+   y `processes_sample.csv`) para evitar esperas al cargar el generador.
+2. **Chequeá el inventario** ejecutando `pytest tests/pages` o el módulo
+   `app.modules.data_pipeline`. Verificá que existan las columnas `kg`,
+   `_source_volume_l` y `moisture_pct` para habilitar métricas automáticas.
+3. **Define el storytelling**: elegí un escenario (p. ej. Residence Renovations)
+   y decidí qué mensaje enfatizarás (seguridad, consumo de recursos, logística).
+4. **Actualizá assets** livianos (imágenes o GIFs < 3 MB) dentro de
+   `app/static/media` si necesitás un brief visual personalizado.
 
-## 3. Guía automatizada
-- **Activación**: `minimal_button` con `key="guided_demo"` que setea
-  `st.session_state["demo_active"]`.
-- **Progresión**: usa `st_autorefresh` o callbacks livianos para avanzar cada
-  6-8 segundos y mantené las transiciones limpias.
-- **Copy de pasos**: declaralo en un JSON (`data/onboarding_steps.json`) con
-  `title`, `body` y `icon`. Así podemos traducir rápido o ajustar mensajes.
+## 2. Estructura del recorrido
 
-## 4. Laboratorio Target
-- **Componente clave**: sliders configurados con
-  `compute_target_limits(presets)`. Garantiza que el CSV de inventario tenga las
-  columnas `_source_volume_l` y `kg` para calcular baselines NASA.
-- **Tip**: guardá presets de prueba en `data/targets_presets.json` con valores
-  que cuenten una historia (ej. "Contenedores herméticos" con poca agua y alta
-  estanqueidad).
+| Paso | Objetivo | Componentes clave |
+| --- | --- | --- |
+| **Brief inicial** | Alinear a la tripulación con la misión del turno. | `layout_stack`, `chipline`, `minimal_button` |
+| **Checklist escalonado** | Recordar los pasos críticos (Inventario → Target → Generador/Feedback). | `layout_block("layout-grid--dual")`, `pill` |
+| **Guía automatizada** | Mostrar la demo sin intervención manual. | `minimal_button` (`key="guided_demo"`), callbacks livianos |
+| **Laboratorio Target** | Ajustar rigidez, estanqueidad y límites operativos. | `compute_target_limits`, sliders |
+| **Generador / Export** | Visualizar riesgo, recursos y entregar un artefacto tangible. | `layout_stack`, `action_button` |
 
-## 5. Recomendaciones de demostración
-1. **Preparar datos**: deja cargados `waste_inventory_sample.csv` y
-   `processes_sample.csv` para evitar esperas.
-2. **Storytelling**: comienza con la pill de seguridad para alinear prioridades
-   y luego mostrá el generador.
-3. **Hand-off**: al terminar, exportá un CSV desde el generador para entregar un
-   artefacto tangible.
+### Tips narrativos
 
-## 6. Troubleshooting rápido
-- Si un chip no se pinta con el tono esperado, revisá que `tone` tenga uno de
-  los valores soportados (`positive`, `warning`, `danger`, `info`, `accent`).
-- Si los sliders muestran límites raros, corré `pytest tests/pages` para validar
-  que `compute_target_limits` siga leyendo el inventario.
-- Para ajustar densidades o sombras, edita `app/static/styles/base.css` y
-  sincronizá la documentación en `docs/ui-components.md`.
+- Usá verbos directos (“Validar receta EVA sin PFAS”) y evitá metáforas.
+- Mostrá primero la pill de seguridad para fijar prioridades y luego la vista de
+  candidatos.
+- Al cerrar, exportá un CSV/JSON para entregar evidencia tangible de la sesión.
+
+## 3. Personalización rápida
+
+- **Mensajes guiados**: definilos en `data/onboarding_steps.json` con `title`,
+  `body` e `icon`. Esto permite traducir o ajustar copy sin tocar código.
+- **Presets de Target**: guardá escenarios de práctica en
+  `data/targets_presets.json` (por ejemplo, “Contenedores herméticos” con poca
+  agua y alta estanqueidad).
+- **Tema visual**: cualquier ajuste a sombras o densidades se hace en
+  `app/static/styles/base.css`; reflejá el cambio en `docs/ui-components.md`.
+
+## 4. Troubleshooting inmediato
+
+| Síntoma | Revisión recomendada |
+| --- | --- |
+| Chips sin color esperado | Confirmá que `tone` sea `positive`, `warning`, `danger`, `info` o `accent`. |
+| Sliders con límites extraños | Ejecutá `pytest tests/pages` para validar `compute_target_limits`. |
+| Guía automatizada no avanza | Revisá que `st.session_state["demo_active"]` se actualice y que los callbacks usen tiempos de 6–8 s. |
+| Mixers sin datos | Verificá que los CSV de inventario/curvas tengan columnas numéricas y ejecutá nuevamente la carga. |
+
+Con estas prácticas el onboarding mantiene un tono claro para perfiles técnicos
+y no técnicos, minimizando sorpresas durante demostraciones en laboratorio.

--- a/docs/ui-components.md
+++ b/docs/ui-components.md
@@ -1,31 +1,27 @@
 # Biblioteca de componentes UI
 
-La capa visual de Rex-AI se consolidó en `app.modules.ui_blocks`. El objetivo es
-ofrecer bloques accesibles, fáciles de combinar y con un perfil visual
-consistente para las demostraciones de laboratorio. El módulo inyecta un tema
-ligero inspirado en paneles NASA y expone utilidades para construir layouts,
-controles y estados informativos sin depender del antiguo paquete `luxe`.
+`app/modules/ui_blocks.py` centraliza el layout y los microcomponentes de Rex-AI.
+La meta es armar pantallas consistentes sin escribir HTML crudo y mantener un
+tono directo para la tripulación.
 
-> **Nota de copy**: mantené un tono directo y técnico. Los títulos deben ser
-> cortos y los mensajes orientados a acciones concretas de la tripulación.
-
-## Inicializar tema base
+## Inicializar tema y layout
 
 ```python
-from app.modules.ui_blocks import load_theme, layout_stack
+from app.modules.ui_blocks import configure_page, initialise_frontend, layout_stack
 
-load_theme()  # inyecta CSS base NASA e iconografía compartida
+configure_page(page_title="Rex-AI", page_icon="🛰️")
+initialise_frontend()
 
 with layout_stack() as stack:
     stack.subheader("Panel de control Rex-AI")
     stack.write("Agrupá métricas clave dentro del contexto del laboratorio.")
 ```
 
-- `layout_stack` y `layout_block` permiten orquestar columnas y agrupaciones
-  sin escribir HTML manual.
-- El tema global mantiene contraste AA sin depender de toggles en pantalla.
+- `configure_page` aplica título, favicon y opciones de Streamlit.
+- `initialise_frontend` inyecta la hoja de estilos base y el tema compartido.
+- `layout_stack`/`layout_block` construyen grillas responsivas sin escribir CSS.
 
-## Layouts operativos
+## Patrones operativos
 
 ```python
 from app.modules.ui_blocks import layout_stack, layout_block, micro_divider
@@ -33,42 +29,31 @@ from app.modules.ui_blocks import layout_stack, layout_block, micro_divider
 with layout_stack() as stack:
     stack.markdown("### Checklist del turno")
     with layout_block("layout-grid layout-grid--dual", parent=stack):
-        col1, col2 = st.columns(2)
-        col1.success("Inventario NASA validado")
-        col2.info("Crew brief listo")
+        col_left, col_right = st.columns(2)
+        col_left.success("Inventario NASA validado")
+        col_right.info("Crew brief listo")
     micro_divider(parent=stack)
     stack.caption("Actualizá el estado antes de iniciar la corrida IA.")
 ```
 
-Los helpers utilizan clases definidas en `app/static/styles/base.css`. Evitá
-escribir HTML crudo salvo que necesites un layout puntual; siempre que sea
-posible extendé estas utilidades.
-
-## Chips y pills para estados de laboratorio
+## Pills y chips
 
 ```python
-from app.modules.ui_blocks import chipline, pill
+from app.modules.ui_blocks import pill, chipline
 
-pill("🛡️ Seguridad · OK", kind="ok")
-
-chipline(
-    [
-        {"label": "PFAS controlados", "icon": "🧪", "tone": "positive"},
-        {"label": "Microplásticos mitigados", "icon": "🧴", "tone": "positive"},
-        {"label": "Crew listo", "icon": "👩‍🚀"},
-    ]
-)
+pill("🛡️ Seguridad OK", kind="ok")
+chipline([
+    {"label": "PFAS controlados", "icon": "🧪", "tone": "positive"},
+    {"label": "Microplásticos mitigados", "icon": "🧴", "tone": "positive"},
+    {"label": "Crew listo", "icon": "👩‍🚀"},
+])
 ```
 
-- `pill` admite `kind="ok" | "warn" | "risk"` para reflejar el semáforo
-  operativo.
-- `chipline` acepta strings o diccionarios con `label`, `icon` y `tone`. Usala
-  para resumir medidas de mitigación, badges de inventario o flags EVA.
+- `pill(kind="ok" | "warn" | "risk")` resume el estado operativo.
+- `chipline` acepta strings o diccionarios con `label`, `icon`, `tone`.
+- Pasá `render=False` para obtener el HTML y reutilizarlo en otros contenedores.
 
-Si necesitás el HTML para incrustarlo en otro componente, pasá `render=False` y
-recibirás el markup listo para reutilizar.
-
-## Botones de acción compartidos
+## Botones de acción
 
 ```python
 from app.modules.ui_blocks import minimal_button
@@ -82,42 +67,39 @@ if minimal_button(
     lanzar_pipeline()
 ```
 
-- `minimal_button` cubre el 90% de los CTAs operativos; ajustá `state` (`idle`,
-  `loading`, `success`, `error`) según la respuesta del backend.
-- `futuristic_button` conserva una variante destacada con layout propio;
-  los efectos visuales ahora son discretos para no distraer durante las demos.
+`minimal_button` soporta estados `idle`, `loading`, `success`, `error` y evita
+microinteracciones intrusivas. `action_button` añade soporte para descargas y
+marcos más robustos.
 
-## Marcadores de objetivo
+## Sliders del Target Designer
 
-Los sliders de la página **Target Designer** se alimentan con
-`app.modules.target_limits.compute_target_limits`. El helper analiza los presets
-de `data/targets_presets.json` y el inventario NASA para calcular límites,
-pasos y mensajes de ayuda.
+`compute_target_limits` calcula límites y tooltips a partir de presets e
+inventario NASA.
 
 ```python
 from app.modules.target_limits import compute_target_limits
-
 presets = load_targets()
-slider_limits = compute_target_limits(presets)
-st.slider(
+limits = compute_target_limits(presets)
+water_slider = st.slider(
     "Agua máxima (L)",
-    slider_limits["max_water_l"]["min"],
-    slider_limits["max_water_l"]["max"],
-    slider_limits["max_water_l"]["min"],
-    slider_limits["max_water_l"]["step"],
-    help=slider_limits["max_water_l"]["help"],
+    limits["max_water_l"]["min"],
+    limits["max_water_l"]["max"],
+    limits["max_water_l"]["default"],
+    limits["max_water_l"]["step"],
+    help=limits["max_water_l"]["help"],
 )
 ```
 
-> **Tip**: mantené el CSV de inventario actualizado; el helper toma el P90 de
-> volumen y masa para alinear los límites con los baseline NASA.
+## Extender la biblioteca
 
-## Extender el sistema
+1. Creá nuevos helpers en `ui_blocks.py` con parámetros explícitos y soporte para
+   `render=False` (útil en tests).
+2. Definí clases en `app/static/styles/base.css` siguiendo el prefijo `rex-` o
+   `layout-` para mantener consistencia.
+3. Documentá cambios relevantes en este archivo y en `docs/design-system.md`.
 
-- Si necesitás un nuevo bloque, creadlo en `ui_blocks.py` siguiendo la misma
-  filosofía: estilos inyectados, API declarativa y soporte para `render=False`
-  en caso de tests o composición.
-- Para variantes visuales definí clases en `app/static/styles/base.css` y
-  referencialas mediante `use_token` o funciones auxiliares.
-- Documentá los cambios en esta página para que el equipo de laboratorio tenga
-  una referencia única del sistema operativo UI.
+### Copy y tono
+
+- Títulos cortos (máx. 4 palabras) y verbos de acción.
+- Mensajes directos, sin metáforas ni jerga innecesaria.
+- Siempre indicá qué debe hacer la tripulación a continuación.

--- a/docs/ux-copy-minimal.md
+++ b/docs/ux-copy-minimal.md
@@ -1,35 +1,28 @@
 # Guía de copy minimalista
 
-## Principios de tono
-- Escribí en forma directa y concreta. Cada frase debe indicar la acción o el dato clave sin rodeos.
-- Evitá superlativos y exageraciones. Preferí cifras o hechos verificables.
-- Usá verbos de acción en títulos y botones ("Configurá", "Exportá", "Revisá").
-- Optá por títulos cortos (máx. 4 palabras). Si necesitás contexto adicional, agregalo en un subtítulo o caption.
-- No uses metáforas ni analogías espaciales; describí lo que ocurre en la interfaz.
-- Mantené la voz en segunda persona singular (vos) para ser consistente con el resto del producto.
+## Principios
 
-## Plantillas sugeridas
-- **Título de sección:** `Verbo + objeto directo` (ej.: `Analizá residuos`, `Generá lote`).
-- **Subtítulo o lead:** `Contexto breve + resultado` (ej.: `Analizamos el inventario NASA y señalamos masas críticas`).
-- **Botón principal:** `Verbo de acción en infinitivo o imperativo` (ej.: `Generar lote`, `Exportar reporte`).
-- **Mensajes de estado:** `Verbo + estado actual` (ej.: `Procesando lote`, `Resultados listos`).
-- **Avisos informativos:** `Acción recomendada + condición` (ej.: `Cargá el inventario antes de generar recetas`).
+- Usa verbos de acción y titulares concisos (máx. 4 palabras).
+- Explicá qué debe hacer la tripulación inmediatamente después de leer el
+  mensaje.
+- Evitá metáforas; preferí datos verificables o indicaciones concretas.
+- Mantené la voz en segunda persona (vos) para coherencia con el resto de la app.
 
-## Ejemplos antes / después
-### Home (`app/Home.py`)
-- La vista inicial consolida el panel principal directamente en Home para
-  mantener la consistencia del flujo sin depender de un paso intermedio.
-- **Antes:** "Rex-AI orquesta el reciclaje orbital y marciano".
-- **Después:** "Rex-AI coordina el reciclaje orbital y marciano" (sustituye la metáfora por un verbo directo).
+## Plantillas
 
-- **Antes:** "Radiografiamos el inventario NASA, destacamos masas críticas...".
-- **Después:** "Analizamos el inventario NASA, destacamos masas críticas..." (elimina la metáfora médica y mantiene la acción).
+- **Título de sección**: `Verbo + objeto directo` (ej. `Analizá residuos`).
+- **Lead / subtítulo**: `Contexto + resultado` (ej. `Balanceamos recursos y riesgo`).
+- **Botón principal**: `Verbo imperativo` (ej. `Generar lote`).
+- **Mensaje de estado**: `Verbo + estado` (ej. `Procesando lote`).
+- **Aviso**: `Acción recomendada + condición` (ej. `Cargá inventario para generar`).
 
-### Generador (`app/pages/3_Generator.py`)
-- **Antes:** "¿Qué hace el generador (en criollo)?".
-- **Después:** "¿Cómo funciona el generador?" (pregunta directa, sin modismos).
+## Ejemplos
 
-- **Antes:** "Pistas visuales sobre cómo evoluciona el frente Pareto...".
-- **Después:** "Visualizá cómo evoluciona el frente Pareto..." (usa un verbo de acción y elimina lenguaje figurado).
+| Antes | Después |
+| --- | --- |
+| “¿Qué hace el generador (en criollo)?” | “¿Cómo funciona el generador?” |
+| “Radiografiamos el inventario NASA…” | “Analizamos el inventario NASA…” |
+| “Filtros recomendados activados. Revisá el showroom para verlos en acción.” | “Filtros recomendados activados. Revisá el showroom para entender la priorización.” |
 
-Seguí estas pautas al redactar nuevos componentes o revisar copy existente para conservar una narrativa minimalista y consistente.
+Usá estas guías al redactar nuevos componentes o revisar copy existente para
+mantener una narrativa clara y consistente.

--- a/docs/ux-inventory.md
+++ b/docs/ux-inventory.md
@@ -1,32 +1,45 @@
 # UX Inventory Builder
 
-## Home inventory workspace
-The inventory builder now lives on the Home flow and combines Streamlit layout primitives with an AG Grid-based editor to provide a hybrid workspace optimised for astronaut operations.
+Descripción del workspace de inventario integrado en la Home de Rex-AI. Combina
+layouts de Streamlit con AG Grid para que astronautas y analistas editen datos
+en vivo sin perder contexto.
 
-## Hybrid grid experience
-- **Tesla-style validation colours**: mass and volume columns display a teal-to-red gradient that highlights invalid or negative values instantly.
-- **Row grouping**: inventory items are grouped by `category` via the AG Grid group panel, enabling quick collapsing/expansion by type.
-- **Flag chips**: flags render as pill-shaped chips both in-grid and in the lateral detail view for fast scanning of multi-flag items.
-- **Side-by-side layout**: the editable grid occupies the left pane, while the right pane surfaces contextual previews, chip summaries and batch actions.
+## Experiencia híbrida
 
-## Sidebar analytics
-- The "Análisis instantáneo" sidebar exposes live metrics (mass, volume, problematics) with deltas to communicate trends.
-- A lightweight recommendation engine surfaces the most frequent problematic flags to prioritise segregation.
-- Quick filters appear as toggleable chips styled after MUI pills; selections persist thanks to `st.session_state`.
+- **Validación por color**: columnas de masa/volumen usan un gradiente
+  teal→rojo para destacar valores anómalos.
+- **Agrupación por categoría**: el panel de AG Grid agrupa por `category` para
+  expandir/colapsar familias rápidamente.
+- **Flag chips**: las banderas se representan con pills en la grilla y en la
+  vista lateral para facilitar escaneo.
+- **Layout dual**: la grilla editable queda a la izquierda; la derecha muestra
+  resumen contextual, chips y acciones masivas.
 
-## Batch editing flow
-1. Select one or more rows using the AG Grid checkboxes.
-2. Review the contextual preview and flag chips that appear on the right pane.
-3. Use the batch edit form to adjust mass (with tooltip guidance) and append shared flags in one action.
-4. Submit to apply updates to all selected rows; a toast confirms completion.
+## Sidebar analítica
 
-## Persistence & state management
-- The underlying dataframe, quick-filter selections and AG Grid view state (column order, sorting, grouping) are saved in `st.session_state`.
-- When the user toggles filters or edits the grid, the state is merged back into `inventory_data`, ensuring the same configuration after reruns or saves.
-- Saving the inventory writes the cleaned dataframe while preserving the in-session grid configuration for continuity.
+- Métricas en vivo (masa, volumen, elementos problemáticos) con variaciones.
+- Recomendaciones rápidas: flags problemáticos frecuentes para priorizar
+  segregación.
+- Filtros rápidos como chips persistentes (`st.session_state`).
 
-## Guardrails & validation cues
-- Negative numeric inputs are automatically clamped to zero during batch updates to prevent invalid states.
-- Problematic items receive a red border accent in the grid and appear prominently in the sidebar metrics.
-- Hover tooltips on editable columns leverage AG Grid defaults to remind users about shared flag semantics.
+## Edición por lotes
 
+1. Seleccioná filas con los checkboxes de AG Grid.
+2. Revisá la vista contextual y los chips en el panel derecho.
+3. Ajustá valores en el formulario de batch edit (incluye tooltips de ayuda).
+4. Confirmá para aplicar cambios; aparece un toast de éxito.
+
+## Persistencia de estado
+
+- Dataframe, filtros y configuración de AG Grid (orden, sorting, grouping)
+  viven en `st.session_state`.
+- Al editar o filtrar, el estado se fusiona de vuelta en `inventory_data` para
+  mantener la configuración tras reruns o guardados.
+- El guardado del inventario escribe el dataframe limpio y preserva la
+  configuración de la grilla.
+
+## Guardrails
+
+- Inputs numéricos negativos se clampan a 0 durante ediciones masivas.
+- Items problemáticos resaltan con borde rojo y aparecen en la sidebar.
+- Tooltips de AG Grid recuerdan la semántica de cada flag editable.

--- a/docs/visual-qa-playbook.md
+++ b/docs/visual-qa-playbook.md
@@ -1,22 +1,24 @@
 # Playbook de QA Visual
 
-Este playbook documenta la validación visual de las vistas **3 · Generador** y **4 · Resultados** tras la actualización del grid maestro, wrappers semánticos y animaciones.
+Checklist para validar las vistas **3 · Generador** y **4 · Resultados** después
+de cambios en grillas, wrappers y componentes.
 
-| Resolución | Snapshot recomendado | Vista | Status | Notas clave |
-|------------|----------------------|-------|--------|-------------|
-| 1440 × 900 | `qa_snapshots/generator-1440.png` | Generador | ✅ Validado | Layout dual estable, panel IA y controles con `layout-grid--dual`; estilo base provisto por `styles/base.css`. |
-| 1280 × 832 | `qa_snapshots/generator-1280.png` | Generador | ✅ Validado | Columnas se reacomodan con container queries; badges en `badge-group` no rompen flujo. |
-| 1024 × 768 | `qa_snapshots/generator-1024.png` | Generador | ✅ Validado | Grid colapsa a una sola columna, progreso de recursos mantiene legibilidad. |
-| 1440 × 900 | `qa_snapshots/resultados-1440.png` | Resultados | ✅ Validado | Hero aplica gradiente estático del tema base; métricas iniciales renderizadas en `layout-grid--dual`. |
-| 1280 × 832 | `qa_snapshots/resultados-1280.png` | Resultados | ✅ Validado | Grids científicos (`layout-grid--dual`) conservan jerarquía; tablas dentro de `depth-stack`. |
-| 1024 × 768 | `qa_snapshots/resultados-1024.png` | Resultados | ✅ Validado | Sección de KPIs y export cards se apilan correctamente sin overflow. |
+| Resolución | Snapshot | Vista | Estado | Observaciones |
+| --- | --- | --- | --- | --- |
+| 1440 × 900 | `qa_snapshots/generator-1440.png` | Generador | ✅ | Layout dual estable, panel IA y controles mantienen `layout-grid--dual`. |
+| 1280 × 832 | `qa_snapshots/generator-1280.png` | Generador | ✅ | Columnas se adaptan con container queries; badges alineados en `badge-group`. |
+| 1024 × 768 | `qa_snapshots/generator-1024.png` | Generador | ✅ | Grid colapsa a una columna, progreso de recursos sigue legible. |
+| 1440 × 900 | `qa_snapshots/resultados-1440.png` | Resultados | ✅ | Hero aplica gradiente base; métricas iniciales en `layout-grid--dual`. |
+| 1280 × 832 | `qa_snapshots/resultados-1280.png` | Resultados | ✅ | Grids científicos conservan jerarquía; tablas en `depth-stack`. |
+| 1024 × 768 | `qa_snapshots/resultados-1024.png` | Resultados | ✅ | KPIs y cartas de exportación se apilan sin overflow. |
 
-## Checklist general
+## Checklist
 
-- [x] El grid maestro responde a las media queries de `app/static/styles/base.css` (breakpoints ultrawide → portrait).
-- [x] Wrappers `layout-grid`, `side-panel`, `depth-stack` envuelven el contenido relevante en las páginas 3 y 4.
-- [x] Se mantienen sombras suaves (`layer-shadow`) sin efectos HUD ni animaciones.
-- [x] Datos tabulares y gráficos mantienen alineación en resoluciones 1440, 1280 y 1024.
-- [x] Se registraron snapshots locales (mantenerlos en `qa_snapshots/` dentro de tu entorno local) como referencia para regresiones futuras.
+- [x] El grid maestro responde a los breakpoints definidos en `app/static/styles/base.css`.
+- [x] Wrappers `layout-grid`, `side-panel`, `depth-stack` encapsulan el contenido principal.
+- [x] Sombras suaves activas (`layer-shadow`) sin HUDs adicionales.
+- [x] Datos tabulares y visualizaciones mantienen alineación en 1440, 1280 y 1024 px.
+- [x] Snapshots locales guardados en `docs/qa_snapshots/` (no versionado) para regresiones.
 
-> **Nota:** Para regenerar los snapshots ejecutar `streamlit run app/Home.py` y usar una herramienta de captura (Playwright / DevTools) en las resoluciones listadas. Guarda los archivos bajo `docs/qa_snapshots/` en tu copia local (la carpeta ya no se versiona).
+> Para regenerar snapshots: ejecutá `streamlit run app/Home.py` y capturá las
+> vistas con Playwright o DevTools usando las resoluciones listadas.


### PR DESCRIPTION
## Summary
- rewrite mission step descriptions and refresh copy across generator, results and auxiliary pages
- expand Spanish guidance in documentation with clearer onboarding, data and feedback instructions
- update README with reorganised overview, setup, ML pipeline and distribution sections

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e189321c048331a5ad4386cb34a8b3