### PR TITLE
Implement mixing rule material aggregation

### DIFF
--- a/app/modules/generator/service.py
+++ b/app/modules/generator/service.py
@@ -2509,15 +2509,8 @@ def heuristic_props(
     moisture = float(np.dot(base_weights, _vector("moisture_pct", 0.0, 1.0 / 100.0)))
     difficulty = float(np.dot(base_weights, _vector("difficulty_factor", 1.0, 1.0 / 3.0)))
 
-    reference_columns = [
-        column
-        for column in getattr(_ASSEMBLER.material_reference, "property_columns", ())
-        if column in picks.columns
-    ]
-    has_reference = any(picks[column].notna().any() for column in reference_columns)
-
-    if has_reference:
-        aggregated = _ASSEMBLER.aggregate_material_properties(picks, weights)
+    aggregated = _ASSEMBLER.aggregate_material_properties(picks, weights)
+    if aggregated:
         density_ref = aggregated.get("material_density_kg_m3")
         modulus = aggregated.get("material_modulus_gpa")
         strength = aggregated.get("material_tensile_strength_mpa")


### PR DESCRIPTION
## Summary
- add mixing-rule-aware aggregation that combines component properties using series and parallel formulations
- ensure heuristic_props consumes the aggregated reference data when available
- add targeted unit tests covering composite property aggregation and heuristic usage

## Testing
- pytest tests/test_data_sources.py::test_candidate_assembler_applies_mixing_rules_for_components
- pytest tests/test_generator.py::test_heuristic_props_uses_mixed_reference
- pytest tests/test_data_sources.py::test_candidate_assembler_aggregates_extended_metrics
- pytest tests/test_generator.py::test_heuristic_props_prefers_material_reference

------
https://chatgpt.com/codex/tasks/task_e_68e1d8a2ffcc8331bb9dd0ed1feb16f9