### PR TITLE
Add physical dataset badge and CI visualisation

### DIFF
--- a/app/modules/ui_blocks.py
+++ b/app/modules/ui_blocks.py
@@ -309,6 +309,37 @@ def pill(
     return markup
 
 
+def render_dataset_badge(
+    *,
+    uses_physical_dataset: bool,
+    tooltip: str | None = None,
+    container: DeltaGenerator | None = None,
+) -> None:
+    """Render a badge signalling whether a physical NASA dataset backed the model."""
+
+    load_theme(show_hud=False)
+
+    tone: PillKind = "ok" if uses_physical_dataset else "warn"
+    label = "Physical dataset used ✅" if uses_physical_dataset else "Heuristic fallback ⚠️"
+
+    default_tooltip = (
+        "Predicción calibrada con datasets físicos Rex-AI/NASA."
+        if uses_physical_dataset
+        else "Sin respaldo directo de dataset físico; se usa heurística Rex-AI."
+    )
+    title = escape((tooltip or default_tooltip).strip())
+
+    markup = (
+        f"<span class='mission-pill mission-pill--{tone}' "
+        f"data-mission-pill='{tone}' data-lab-pill='{tone}' data-kind='{tone}' "
+        f"title='{title}'>"
+        f"{escape(label)}</span>"
+    )
+
+    target = container or st
+    target.markdown(markup, unsafe_allow_html=True)
+
+
 def section(title: str, subtitle: str = "") -> None:
     st.subheader(title)
     if subtitle:

--- a/app/modules/utils.py
+++ b/app/modules/utils.py
@@ -11,6 +11,8 @@ __all__ = [
     "format_number",
     "format_resource_text",
     "format_label_summary",
+    "uses_physical_dataset",
+    "physical_dataset_tooltip",
 ]
 
 
@@ -119,3 +121,31 @@ def format_label_summary(summary: Mapping[str, Mapping[str, float]] | None) -> s
         parts.append(fragment)
 
     return " · ".join(parts)
+
+
+def uses_physical_dataset(source: Any) -> bool:
+    """Return ``True`` when the prediction source maps to a Rex-AI physical model."""
+
+    if isinstance(source, str):
+        return source.lower().startswith("rexai")
+    return False
+
+
+def physical_dataset_tooltip(*, summary: str | None = None, trained_at: Any | None = None) -> str:
+    """Compose a concise tooltip describing NASA datasets backing Rex-AI predictions."""
+
+    base = (
+        "Respaldado por datasets físicos NASA ISRU: granulometría MGS-1, espectros (Fig.4) y "
+        "perfiles térmicos (Fig.5)."
+    )
+    parts = [base]
+
+    if summary:
+        parts.append(f"Cobertura labels: {summary}.")
+
+    if trained_at:
+        trained_label = str(trained_at).strip()
+        if trained_label and trained_label not in {"?", "—"}:
+            parts.append(f"Entrenado {trained_label}.")
+
+    return " ".join(parts)


### PR DESCRIPTION
## Summary
- add a reusable UI badge that flags when Rex-AI predictions come from NASA physical datasets and surface it on generator and results pages
- compute consistent tooltip text and dataset usage status with shared helpers and surface the badge near predictions and in the results header
- replace the generator confidence-interval table with an Altair error-bar chart while keeping the detailed table for reference

## Testing
- `pytest tests/pages/test_generator_page.py::test_generator_page_renders_histograms_with_inventory -q`


------
https://chatgpt.com/codex/tasks/task_e_68e29def2e488331b457d8832059add3