### PR TITLE
Add reusable NASA dataset badge across mission views

### DIFF
--- a/app/modules/mission_overview.py
+++ b/app/modules/mission_overview.py
@@ -359,6 +359,7 @@ def render_overview_dashboard(
         configure_page,
         initialise_frontend,
         render_brand_header,
+        render_nasa_badge,
     )
 
     configure_page(page_title="Mission Overview", page_icon="🛰️")
@@ -367,8 +368,17 @@ def render_overview_dashboard(
     current_step = set_active_step("home")
     render_brand_header()
 
+    try:
+        inventory_df = _resolve_inventory_loader(inventory_loader)
+    except MissingDatasetError as error:
+        render_nasa_badge(missing_datasets=("waste_inventory",))
+        st.error(format_missing_dataset_message(error))
+        st.stop()
+        return
+
     render_breadcrumbs(current_step)
     render_stepper(current_step)
+    render_nasa_badge()
 
     st.title("Panorama general de la misión")
     st.markdown(
@@ -392,13 +402,6 @@ def render_overview_dashboard(
           usalos para priorizar inspecciones.
         """
     )
-
-    try:
-        inventory_df = _resolve_inventory_loader(inventory_loader)
-    except MissingDatasetError as error:
-        st.error(format_missing_dataset_message(error))
-        st.stop()
-        return
 
     mission_metrics = compute_mission_summary(inventory_df)
     render_mission_objective(mission_metrics)

--- a/app/pages/3_Generator.py
+++ b/app/pages/3_Generator.py
@@ -50,6 +50,7 @@ from app.modules.ui_blocks import (
     micro_divider,
     pill,
     render_brand_header,
+    render_nasa_badge,
     render_dataset_badge,
 )
 from app.modules.visualizations import ConvergenceScene
@@ -986,8 +987,12 @@ try:
     waste_df = load_waste_df()
     proc_df = load_process_df()
 except MissingDatasetError as error:
+    render_nasa_badge(missing_datasets=("waste_inventory",))
     st.error(format_missing_dataset_message(error))
     st.stop()
+else:
+    render_nasa_badge()
+
 polymer_density_distribution = numeric_series(
     waste_df, "pc_density_density_g_per_cm3"
 )

--- a/app/pages/7_Scenario_Playbooks.py
+++ b/app/pages/7_Scenario_Playbooks.py
@@ -25,6 +25,7 @@ from app.modules.ui_blocks import (
     initialise_frontend,
     layout_stack,
     render_brand_header,
+    render_nasa_badge,
 )
 
 configure_page(page_title="Scenario Playbooks", page_icon="📚")
@@ -35,6 +36,8 @@ current_step = set_active_step("playbooks")
 render_brand_header()
 
 render_breadcrumbs(current_step)
+
+render_nasa_badge()
 
 FEATURED_PLAYBOOKS: tuple[str, ...] = ("Residence Renovations", "Daring Discoveries")
 GENERATOR_FILTER_PRESETS: dict[str, dict[str, bool]] = {


### PR DESCRIPTION
## Summary
- add a `render_nasa_badge` helper that enumerates canonical NASA datasets and flags heuristic fallbacks
- surface the badge near the top of Home, Generator, Results, Playbooks, and Mars Control Center
- warn when regolith or waste inventory sources are missing so the pages explain heuristic behaviour

## Testing
- pytest tests/ui/test_home_dashboard.py

------
https://chatgpt.com/codex/tasks/task_e_68e2a1e5b7208331b13570ee6bf7abff