### PR TITLE
Fix Playbook dataclass field order to prevent Streamlit crash

### DIFF
--- a/app/modules/scenarios.py
+++ b/app/modules/scenarios.py
@@ -30,8 +30,8 @@ class Playbook:
     product_label: str
     product_end_use: str
     example_recipe: ExampleRecipe
-    metadata: Dict[str, str] = field(default_factory=dict)
     steps: List[Step]
+    metadata: Dict[str, str] = field(default_factory=dict)
     generator_filters: Optional[Dict[str, bool]] = None
 
 


### PR DESCRIPTION
## Summary
- Reorder the `Playbook` dataclass so the non-default `steps` field precedes fields with defaults, keeping generator filters optional and playbook data compatible.

## Testing
- `streamlit run app/pages/4_Results_and_Tradeoffs.py --server.headless true --browser.gatherUsageStats false --server.port 8501`
- `streamlit run app/pages/7_Scenario_Playbooks.py --server.headless true --browser.gatherUsageStats false --server.port 8501`


------
https://chatgpt.com/codex/tasks/task_e_68e2a70ceaf08331959aeec1c3919c83